### PR TITLE
feat: context graphs, record_context(), and comprehensive documentation updates

### DIFF
--- a/.cursor/rules/amfs-memory.mdc
+++ b/.cursor/rules/amfs-memory.mdc
@@ -33,13 +33,25 @@ You have access to AMFS (Agent Memory File System) through MCP tools. AMFS is sh
   ```
   amfs_write("<repo>/<module>", "pattern-<name>", "<pattern description>", pattern_refs=["related-key"])
   ```
-- **When finding a bug or risk**: Record it so other agents are warned.
+- **When finding a bug or risk**: Record it so other agents are warned. Use `memory_type="belief"` for hypotheses.
   ```
-  amfs_write("<repo>/<module>", "risk-<name>", "<what could go wrong>", confidence=0.8)
+  amfs_write("<repo>/<module>", "risk-<name>", "<what could go wrong>", confidence=0.8, memory_type="belief")
   ```
 - **When making a non-obvious decision**: Record the reasoning for future agents.
   ```
   amfs_write("<repo>/<module>", "decision-<topic>", "<decision and rationale>")
+  ```
+- **When logging actions taken**: Record what you did so future agents can retrace steps. Experiences decay slower.
+  ```
+  amfs_write("<repo>/<module>", "action-<desc>", "<what you did>", memory_type="experience")
+  ```
+- **When consulting external tools or APIs**: Record the context so decision traces are complete.
+  ```
+  amfs_record_context("<label>", "<summary of what was found>", source="<tool name>")
+  ```
+- **When reviewing how a memory changed**: Check the version history of an entry.
+  ```
+  amfs_history("<entity_path>", "<key>")
   ```
 
 ## When to COMMIT OUTCOMES

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,11 +5,14 @@ You have access to AMFS (Agent Memory File System) through MCP tools. AMFS is sh
 ## Available MCP Tools
 
 - `amfs_read(entity_path, key)` — read a specific memory entry
-- `amfs_write(entity_path, key, value, confidence?, pattern_refs?)` — write knowledge with automatic provenance
+- `amfs_write(entity_path, key, value, confidence?, pattern_refs?, memory_type?)` — write knowledge with automatic provenance. `memory_type` can be `"fact"` (default), `"belief"` (decays faster), or `"experience"` (decays slower)
 - `amfs_search(query?, entity_path?, min_confidence?, agent_id?, sort_by?, limit?)` — search across all entries
 - `amfs_list(entity_path?)` — list entries for an entity
 - `amfs_stats()` — memory overview
 - `amfs_commit_outcome(outcome_ref, outcome_type)` — record outcomes, auto-links to read log
+- `amfs_record_context(label, summary, source?)` — capture external tool/API context in the causal chain (appears in `amfs_explain` output)
+- `amfs_history(entity_path, key, since?, until?)` — retrieve version history of an entry, optionally filtered by time range
+- `amfs_explain(outcome_ref?)` — inspect the full decision trace: AMFS reads + external contexts
 
 ## Workflow
 
@@ -32,9 +35,27 @@ amfs_write("<repo>/<module>", "pattern-<name>", "<description>", pattern_refs=["
 ```
 
 ### When finding bugs or risks
-Warn other agents:
+Warn other agents (use `memory_type="belief"` for hypotheses that need validation):
 ```
-amfs_write("<repo>/<module>", "risk-<name>", "<what could go wrong>", confidence=0.8)
+amfs_write("<repo>/<module>", "risk-<name>", "<what could go wrong>", confidence=0.8, memory_type="belief")
+```
+
+### When logging actions taken
+Record what you did so future agents can retrace steps (experiences decay slower):
+```
+amfs_write("<repo>/<module>", "action-<desc>", "<what you did>", memory_type="experience")
+```
+
+### When consulting external tools or APIs
+Record external context so the decision trace is complete:
+```
+amfs_record_context("pagerduty-incidents", "3 SEV-1 in last 24h", source="PagerDuty API")
+```
+
+### When reviewing history
+Check how a memory evolved over time:
+```
+amfs_history("<entity_path>", "<key>")
 ```
 
 ### When something significant happens

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ A filesystem-modeled protocol and SDK that gives multi-agent AI systems a standa
 **Key concepts:**
 
 - **MemoryEntry** — A versioned key-value pair with provenance (who wrote it, when, why) and a confidence score
+- **Memory Types** — Classify entries as facts, beliefs, or experiences with type-specific decay rates
 - **Copy-on-Write (CoW)** — Every write creates a new version; old versions are preserved as superseded
 - **Outcome back-propagation** — When an incident or clean deploy happens, confidence scores on causal entries are automatically adjusted
+- **Provenance Tiers** — Entries are automatically tiered by quality: production-validated, observed, dev, or manual
 - **Adapters** — Pluggable storage backends (filesystem, Postgres, Redis)
 
 ## Installation
@@ -84,6 +86,10 @@ mem.commit_outcome(
 |:--------|:------------|
 | Copy-on-Write versioning | Every write creates a new version. Full history is preserved. |
 | Confidence & outcomes | Entries carry confidence scores that evolve based on real-world outcomes. |
+| Memory types | Classify entries as `fact`, `belief`, or `experience` with type-specific decay. |
+| Provenance tiers | Entries auto-tier by quality: production-validated > observed > dev > manual. |
+| Temporal queries | Retrieve the full version history of any entry, filtered by time range. |
+| Causal explainability | Inspect which entries were read and how they connect to outcomes. |
 | Provenance tracking | Every entry records which agent wrote it, when, and from which session. |
 | Multiple adapters | Filesystem (default), Postgres, or build your own. |
 | MCP integration | First-class MCP server for Cursor, Claude Code, and any MCP client. |
@@ -109,12 +115,17 @@ Give your AI coding agents persistent, shared memory via MCP:
 
 **[Full MCP setup guide →](https://raia-live.github.io/amfs/guides/mcp/)**
 
+## OSS vs Pro
+
+AMFS is available in two editions. The OSS layer provides the full memory primitive. The Pro layer adds an intelligence layer with LLM-driven extraction, automated quality auditing, memory distillation, safety validation, and multi-strategy retrieval. [See the comparison →](https://raia-live.github.io/amfs/editions/)
+
 ## Documentation
 
 Visit **[raia-live.github.io/amfs](https://raia-live.github.io/amfs/)** for the full documentation:
 
 - [Getting Started](https://raia-live.github.io/amfs/getting-started/) — installation, quick start, configuration
 - [Core Concepts](https://raia-live.github.io/amfs/concepts/) — memory entries, CoW, confidence, provenance
+- [OSS vs Pro](https://raia-live.github.io/amfs/editions/) — feature comparison and when to use which
 - [Guides](https://raia-live.github.io/amfs/guides/) — Python SDK, TypeScript SDK, CLI, MCP setup
 - [Adapters](https://raia-live.github.io/amfs/adapters/) — filesystem, Postgres, custom adapters
 - [Integrations](https://raia-live.github.io/amfs/integrations/) — CrewAI, LangGraph, LangChain, AutoGen

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -1,7 +1,7 @@
 ---
 title: Adapters
 layout: default
-nav_order: 5
+nav_order: 6
 has_children: true
 description: "Storage backends for AMFS: filesystem, Postgres, and custom adapters."
 permalink: /adapters/

--- a/docs/adapters/postgres.md
+++ b/docs/adapters/postgres.md
@@ -78,6 +78,7 @@ The adapter auto-creates two tables and associated triggers:
 | `provenance` | `JSONB` | Agent, session, timestamp, pattern_refs |
 | `confidence` | `FLOAT` | Trust score |
 | `outcome_count` | `INT` | Outcomes applied |
+| `memory_type` | `TEXT` | Memory type: `fact`, `belief`, or `experience` (default: `fact`) |
 | `superseded_at` | `TIMESTAMP` | When this version was superseded (NULL = current) |
 
 ### `amfs_outcomes`

--- a/docs/concepts/confidence.md
+++ b/docs/concepts/confidence.md
@@ -100,6 +100,30 @@ This is powered by the **ReadTracker**, which logs every `read()` call during a 
 
 ---
 
+## Type-Specific Decay
+
+When `decay_half_life_days` is configured, confidence decays over time. The decay rate varies by memory type:
+
+| Memory Type | Decay Multiplier | Effect |
+|:------------|:----------------|:-------|
+| `fact` | 1.0× | Standard half-life |
+| `belief` | 0.5× | Half-life is halved (decays 2× faster) |
+| `experience` | 1.5× | Half-life is 50% longer (decays slower) |
+
+Additionally, entries with `outcome_count > 0` decay at **half the rate** of unvalidated entries. This means a production-validated fact with a 30-day half-life effectively has a 60-day half-life.
+
+```python
+mem = AgentMemory(
+    agent_id="my-agent",
+    decay_half_life_days=30.0,  # facts decay with 30-day half-life
+)
+
+# A belief with the same setting decays with a 15-day half-life
+# An experience decays with a 45-day half-life
+```
+
+---
+
 ## Filtering by Confidence
 
 Use `min_confidence` to filter out low-confidence entries:

--- a/docs/concepts/context-graphs.md
+++ b/docs/concepts/context-graphs.md
@@ -1,0 +1,230 @@
+---
+title: Context Graphs
+layout: default
+parent: Core Concepts
+nav_order: 5
+description: "How AMFS captures decision traces that explain not just what happened, but why."
+---
+
+# Context Graphs
+{: .no_toc }
+
+AMFS doesn't just store what agents know — it captures **why** they acted. Every read, write, tool consultation, and outcome forms a decision trace that becomes searchable precedent.
+{: .fs-6 .fw-300 }
+
+## Table of Contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## The Problem
+
+AI agents are stateless. Each session starts from scratch with no memory of past decisions, patterns, or mistakes. When something goes wrong, there's no way to answer:
+
+- **What information did the agent have when it decided?**
+- **What external sources did it consult?**
+- **Has a similar decision been made before, and what happened?**
+
+Traditional systems of record (CRMs, ERPs, ticketing systems) store the **final state** — the deal was closed, the ticket was resolved, the deploy succeeded. But the reasoning that connected data to action was never treated as data in the first place.
+
+---
+
+## Decision Traces
+
+A **decision trace** is a structured record of how an agent turned context into action:
+
+```
+Agent reads AMFS entries:
+  checkout-service/retry-pattern (v3, confidence: 0.92)
+  checkout-service/risk-race-condition (v1, confidence: 0.78)
+
+Agent consults external sources:
+  PagerDuty API → 3 SEV-1 incidents in last 24h
+  git log → 15 commits since last deploy, 3 touching retry logic
+
+Agent writes decision:
+  checkout-service/decision-rollback-retry → "Rolling back retry changes due to
+  incident correlation and high-risk signal from prior agent"
+
+Outcome recorded:
+  DEP-500 → clean_deploy → confidence on causal entries adjusted
+```
+
+This trace is queryable. The next agent — or a human auditor — can replay exactly what happened and why.
+
+---
+
+## How AMFS Captures Decision Traces
+
+AMFS's existing primitives map directly to each component of a decision trace:
+
+### 1. What the agent knew
+
+Every `read()` call is automatically logged by the `ReadTracker`. When the agent later commits an outcome, AMFS knows exactly which entries informed the decision.
+
+```python
+entry = mem.read("checkout-service", "retry-pattern")
+entry = mem.read("checkout-service", "risk-race-condition")
+```
+
+### 2. What external inputs were gathered
+
+`record_context()` captures tool calls, API responses, and other external inputs without writing to storage. These appear in the causal chain alongside AMFS reads.
+
+```python
+mem.record_context(
+    "pagerduty-incidents",
+    "3 SEV-1 incidents in last 24h for checkout-service",
+    source="PagerDuty API",
+)
+
+mem.record_context(
+    "git-log",
+    "15 commits since last deploy, 3 touching retry logic",
+    source="git",
+)
+```
+
+### 3. What the agent decided
+
+The agent's decision is written as a versioned, provenanced entry:
+
+```python
+mem.write(
+    "checkout-service",
+    "decision-rollback-retry",
+    "Rolling back retry changes due to incident correlation",
+    confidence=0.9,
+    memory_type=MemoryType.EXPERIENCE,
+    pattern_refs=["checkout-service/retry-pattern"],
+)
+```
+
+### 4. What happened next
+
+Outcomes close the feedback loop. Confidence on causal entries adjusts automatically:
+
+```python
+mem.commit_outcome("DEP-500", OutcomeType.CLEAN_DEPLOY)
+```
+
+### 5. Why did we do that?
+
+`explain()` returns the complete causal chain:
+
+```python
+chain = mem.explain("DEP-500")
+```
+
+Returns:
+
+```json
+{
+  "outcome_ref": "DEP-500",
+  "agent_id": "deploy-agent",
+  "session_id": "sess-a1b2c3d4",
+  "causal_chain_length": 2,
+  "causal_entries": [
+    {"entity_path": "checkout-service", "key": "retry-pattern", "confidence": 0.92, "...": "..."},
+    {"entity_path": "checkout-service", "key": "risk-race-condition", "confidence": 0.78, "...": "..."}
+  ],
+  "external_contexts": [
+    {"label": "pagerduty-incidents", "summary": "3 SEV-1 incidents in last 24h", "source": "PagerDuty API", "recorded_at": "..."},
+    {"label": "git-log", "summary": "15 commits since last deploy, 3 touching retry logic", "source": "git", "recorded_at": "..."}
+  ]
+}
+```
+
+---
+
+## From Traces to Graphs
+
+Individual decision traces accumulate into a **context graph**: entities connected by decision events with "why" links.
+
+```
+checkout-service/retry-pattern
+    ├── read by deploy-agent (sess-a1b2)
+    │   ├── also consulted: PagerDuty API, git log
+    │   ├── wrote: decision-rollback-retry
+    │   └── outcome: DEP-500 (clean_deploy) → confidence adjusted
+    │
+    ├── read by review-agent (sess-e5f6)
+    │   ├── also consulted: Sentry errors
+    │   ├── wrote: risk-timeout-regression
+    │   └── outcome: INC-1042 (p1_incident) → confidence boosted
+    │
+    └── read by onboard-agent (sess-g7h8)
+        └── wrote: task-summary-retry-review
+```
+
+Over time, this graph captures institutional knowledge that no single agent or person holds:
+
+- **Precedent** — "The last time we saw this pattern, we rolled back and it worked."
+- **Exception logic** — "We always check PagerDuty before deploying changes to retry logic."
+- **Cross-system synthesis** — "The decision combined AMFS memory, PagerDuty incidents, and git history."
+
+---
+
+## The Feedback Loop
+
+Decision traces compound through AMFS's outcome system:
+
+```
+Agent makes decision → writes entry + records trace
+                           │
+                           ▼
+                   Outcome occurs (deploy, incident)
+                           │
+                           ▼
+                   Confidence adjusts on causal entries
+                           │
+                           ▼
+                   Next agent sees high-confidence precedent
+                           │
+                           ▼
+                   Agent makes better decision → new trace
+```
+
+Entries validated by positive outcomes decay slower. Entries correlated with incidents get boosted. The system learns which decisions lead to good outcomes without any explicit training.
+
+---
+
+## Immutability and Replay
+
+Because AMFS uses Copy-on-Write versioning, decision traces are **immutable**. You can reconstruct the exact state of the world at any past decision point:
+
+```python
+from datetime import datetime, timezone
+
+decision_time = datetime(2026, 3, 15, 14, 30, tzinfo=timezone.utc)
+
+versions = mem.history(
+    "checkout-service",
+    "retry-pattern",
+    until=decision_time,
+)
+
+state_at_decision = versions[-1] if versions else None
+```
+
+This is the difference between a system of record (stores the current state) and a context graph (stores the decision lineage). AMFS preserves both.
+
+---
+
+## MCP Integration
+
+Via the MCP server, AI coding agents can build decision traces automatically:
+
+```
+1. amfs_search("checkout-service")           → find existing context
+2. amfs_read("checkout-service", "pattern")  → read relevant entries (auto-tracked)
+3. amfs_record_context("git-log", "...", "git")  → capture tool inputs
+4. amfs_write("checkout-service", "decision-...", "...")  → record the decision
+5. amfs_commit_outcome("DEP-500", "clean_deploy")  → close the loop
+6. amfs_explain("DEP-500")                   → inspect the full trace
+```
+
+No manual instrumentation required. The causal chain builds itself from normal agent workflow.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -12,7 +12,7 @@ permalink: /concepts/
 Understanding the building blocks of AMFS.
 {: .fs-6 .fw-300 }
 
-AMFS is built around a few core ideas that work together: **memory entries** store knowledge, **copy-on-write** preserves history, **provenance** tracks authorship, **confidence** scores reflect trust, and **outcomes** close the feedback loop.
+AMFS is built around a few core ideas that work together: **memory entries** store knowledge with a **memory type** (fact, belief, or experience), **copy-on-write** preserves history, **provenance** tracks authorship and **provenance tiers** rank quality, **confidence** scores reflect trust with type-specific decay, and **outcomes** close the feedback loop.
 
 ---
 
@@ -23,6 +23,7 @@ Agent writes →  MemoryEntry created
                   ├── entity_path: "checkout-service"
                   ├── key: "retry-pattern"
                   ├── value: { ... }
+                  ├── memory_type: fact   ← fact / belief / experience
                   ├── version: 3          ← CoW versioning
                   ├── confidence: 0.85    ← evolves with outcomes
                   └── provenance:

--- a/docs/concepts/memory-entries.md
+++ b/docs/concepts/memory-entries.md
@@ -26,8 +26,9 @@ Every memory entry has these fields:
 | `provenance` | `Provenance` | Who wrote it, when, and from which session |
 | `outcome_count` | `int` | Number of outcomes that have affected this entry |
 | `ttl_at` | `datetime?` | Optional expiration timestamp |
+| `memory_type` | `MemoryType` | Classification: `fact` (default), `belief`, or `experience` |
 | `embedding` | `list[float]?` | Optional vector embedding for semantic search |
-| `amfs_version` | `str` | Protocol version (currently `"0.1.0"`) |
+| `amfs_version` | `str` | Protocol version (currently `"0.2.0"`) |
 
 ---
 
@@ -63,6 +64,59 @@ myapp/auth/decision-jwt-strategy
 ```
 
 Entry keys are used in `causal_entry_keys` when recording outcomes, and in `pattern_refs` for cross-referencing.
+
+---
+
+## Memory Types
+
+Every entry has a `memory_type` that affects how it decays and how outcomes are applied:
+
+| Type | Description | Decay Rate |
+|:-----|:------------|:-----------|
+| `fact` | Objective, stable knowledge (default) | Normal |
+| `belief` | Subjective inference that may change | 2× faster decay |
+| `experience` | Append-only record of agent actions | 1.5× slower decay |
+
+```python
+from amfs import MemoryType
+
+# Record a belief (decays faster, signals it may be revised)
+mem.write(
+    "checkout-service",
+    "hypothesis-latency-source",
+    "Latency is likely caused by N+1 queries in order listing",
+    memory_type=MemoryType.BELIEF,
+    confidence=0.7,
+)
+
+# Record an experience (append-only, decays slower)
+mem.write(
+    "checkout-service",
+    "action-added-index",
+    "Added database index on orders.user_id to fix N+1 query",
+    memory_type=MemoryType.EXPERIENCE,
+)
+```
+
+---
+
+## Provenance Tiers
+
+Every entry has a computed `provenance_tier` that reflects its quality based on how it was created and validated:
+
+| Tier | Value | Meaning |
+|:-----|:------|:--------|
+| `PRODUCTION_VALIDATED` | 1 | Written by a production agent with outcome validation |
+| `PRODUCTION_OBSERVED` | 2 | Written by a production agent, no outcomes yet |
+| `DEVELOPMENT` | 3 | Written in a dev/staging environment |
+| `MANUAL` | 4 | Manually seeded by humans or scripts |
+
+The tier is computed from `provenance.agent_id` prefix and `outcome_count` — not stored separately. Production agents are identified by `agent/`, `prod/`, or `prod-` prefixes.
+
+```python
+entry = mem.read("checkout-service", "retry-pattern")
+print(entry.provenance_tier)  # ProvenanceTier.PRODUCTION_VALIDATED
+```
 
 ---
 

--- a/docs/concepts/provenance.md
+++ b/docs/concepts/provenance.md
@@ -73,6 +73,29 @@ export AMFS_AGENT_ID="deploy-bot"
 
 ---
 
+## Provenance Tiers
+
+AMFS computes a **provenance tier** for each entry based on the agent ID and outcome history. This enables downstream systems to prioritize production-validated knowledge over manually seeded assumptions.
+
+| Tier | Value | Criteria |
+|:-----|:------|:---------|
+| `PRODUCTION_VALIDATED` | 1 | Agent ID starts with `agent/`, `prod/`, or `prod-` AND `outcome_count > 0` |
+| `PRODUCTION_OBSERVED` | 2 | Production agent, no outcomes yet |
+| `DEVELOPMENT` | 3 | Agent ID starts with `dev/`, `test/`, `dev-`, or `test-` |
+| `MANUAL` | 4 | Agent ID starts with `manual/`, `seed/`, or `human/` |
+
+```python
+from amfs import ProvenanceTier
+
+entry = mem.read("svc", "pattern")
+if entry.provenance_tier == ProvenanceTier.PRODUCTION_VALIDATED:
+    print("This memory has been validated by production outcomes")
+```
+
+The tier is a computed property — it derives from `provenance.agent_id` and `outcome_count`, not stored as a separate field.
+
+---
+
 ## Querying by Provenance
 
 Search for entries written by a specific agent:

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -1,7 +1,7 @@
 ---
 title: Contributing
 layout: default
-nav_order: 8
+nav_order: 9
 description: "Set up a development environment and contribute to AMFS."
 permalink: /contributing/
 ---

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -1,0 +1,258 @@
+---
+title: OSS vs Pro
+layout: default
+nav_order: 4
+description: "What's in AMFS open-source vs. AMFS Pro — and when you need which."
+permalink: /editions/
+---
+
+# OSS vs Pro
+{: .no_toc }
+
+AMFS is split into two layers: a fully open-source core and a proprietary intelligence layer. The OSS layer gives you everything you need to build production-ready agent memory. The Pro layer adds LLM-powered automation on top.
+{: .fs-6 .fw-300 }
+
+## Table of Contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## At a Glance
+
+```
+┌──────────────────────────────────────────────────────┐
+│                   AMFS Pro (Proprietary)              │
+│                                                      │
+│  Extraction · Critic · Distiller · Safety · Retrieval │
+│                                                      │
+├──────────────────────────────────────────────────────┤
+│                   AMFS OSS (Apache 2.0)               │
+│                                                      │
+│  CoW Engine · Memory Types · Provenance Tiers         │
+│  Temporal Queries · Causal Explainability             │
+│  Adapters (Filesystem, Postgres) · MCP Server         │
+│  Python SDK · TypeScript SDK · CLI                    │
+└──────────────────────────────────────────────────────┘
+```
+
+---
+
+## Feature Comparison
+
+| Capability | OSS | Pro |
+|:-----------|:---:|:---:|
+| Copy-on-Write versioning | Yes | Yes |
+| Confidence scoring with outcome back-propagation | Yes | Yes |
+| Memory types (fact, belief, experience) | Yes | Yes |
+| Type-specific confidence decay | Yes | Yes |
+| Provenance tiers (production-validated → manual) | Yes | Yes |
+| Temporal queries (`history`) | Yes | Yes |
+| Causal explainability (`explain`) | Yes | Yes |
+| Filesystem adapter | Yes | Yes |
+| Postgres adapter (triggers, LISTEN/NOTIFY) | Yes | Yes |
+| MCP server (9 tools) | Yes | Yes |
+| Python SDK | Yes | Yes |
+| TypeScript SDK | Yes | Yes |
+| CLI tools | Yes | Yes |
+| Framework integrations (CrewAI, LangGraph, etc.) | Yes | Yes |
+| Bundled lightweight embedder | Yes | Yes |
+| LLM-driven memory extraction | — | Yes |
+| Automated memory critic | — | Yes |
+| Memory distillation & bootstrap sets | — | Yes |
+| Memory safety validation | — | Yes |
+| Multi-strategy retrieval (semantic + BM25 + temporal) | — | Yes |
+| Extended MCP server (Pro tools) | — | Yes |
+
+---
+
+## OSS Layer — What's Included
+
+The open-source layer ([github.com/raia-live/amfs](https://github.com/raia-live/amfs)) provides the full memory primitive: read, write, version, search, and learn from outcomes.
+
+### Packages
+
+| Package | Description |
+|:--------|:------------|
+| `amfs-core` | CoW engine, models (`MemoryEntry`, `MemoryType`, `ProvenanceTier`), read tracking, causal tagging, default embedder |
+| `amfs` (SDK) | `AgentMemory` class — `read`, `write`, `list`, `search`, `history`, `explain`, `commit_outcome` |
+| `amfs-adapter-filesystem` | JSON-file-based adapter for local development |
+| `amfs-adapter-postgres` | PostgreSQL adapter with PL/pgSQL triggers for outcome propagation and `LISTEN/NOTIFY` for watch |
+| `amfs-mcp-server` | MCP server exposing 9 tools: `amfs_read`, `amfs_write`, `amfs_search`, `amfs_list`, `amfs_stats`, `amfs_commit_outcome`, `amfs_record_context`, `amfs_history`, `amfs_explain` |
+| `amfs-cli` | Terminal tools for inspecting, diffing, snapshotting, and restoring memory |
+| `@amfs/sdk` | TypeScript SDK |
+
+### Key Primitives
+
+**Memory Types** — Every entry is classified as `fact`, `belief`, or `experience`, each with its own decay rate:
+
+```python
+from amfs import AgentMemory, MemoryType
+
+mem = AgentMemory(agent_id="my-agent")
+
+mem.write("svc", "config", {"pool": 10}, memory_type=MemoryType.FACT)
+mem.write("svc", "hypothesis", "Likely N+1", memory_type=MemoryType.BELIEF)
+mem.write("svc", "action-log", "Added index", memory_type=MemoryType.EXPERIENCE)
+```
+
+**Provenance Tiers** — Entries are automatically ranked by quality based on how they were created:
+
+```python
+from amfs import ProvenanceTier
+
+entry = mem.read("svc", "pattern")
+if entry.provenance_tier == ProvenanceTier.PRODUCTION_VALIDATED:
+    print("Validated by production outcomes")
+```
+
+**Temporal Queries** — Retrieve the full version history of any entry:
+
+```python
+versions = mem.history("svc", "retry-pattern", since=last_week)
+```
+
+**Causal Explainability** — See which entries were read and how they connect to outcomes:
+
+```python
+chain = mem.explain()
+```
+
+---
+
+## Pro Layer — What's Added
+
+The Pro layer builds an intelligence layer on top of the OSS primitives. It adds LLM-powered automation for extraction, quality control, compaction, safety, and retrieval.
+
+### Extraction
+
+Turns raw text (conversations, logs, documents) into structured memory operations using LLMs. Instead of blind writes, the extractor classifies each piece of information as an **ADD**, **UPDATE**, **DELETE**, or **NOOP** operation.
+
+```
+Raw input → LLM Extractor → [ADD "svc/pattern-retry", UPDATE "svc/config", NOOP, ...]
+```
+
+Supports multiple LLM backends (OpenAI, Anthropic) with a common `ExtractorABC` interface.
+
+### Memory Critic
+
+An automated quality analyzer that scans the memory store and detects problematic entries. Runs offline or on a schedule to keep the store healthy.
+
+Detects five issue classes:
+
+| Issue | Description |
+|:------|:------------|
+| **Toxic** | Entries with repeated negative outcome correlations |
+| **Stale** | Entries that haven't been read or validated in a long time |
+| **Contradictory** | Entries that conflict with other entries in the same entity |
+| **Uncalibrated** | Entries whose confidence doesn't match their outcome history |
+| **Orphaned** | Entries with no reads, no outcomes, and no cross-references |
+
+Produces a `CriticReport` with prioritized recommendations.
+
+### Memory Distiller
+
+Compacts large memory stores into smaller, higher-quality sets. Three operations:
+
+- **Pruning** — Removes low-value entries (orphaned, expired, low-confidence)
+- **Consolidation** — Merges related entries into unified summaries
+- **Bootstrap sets** — Generates compact `DistilledSet` packages that can onboard new agents quickly (teacher-to-student knowledge transfer)
+
+### Memory Safety Validator
+
+Pre-write guardrails that validate candidate memories before they enter the store:
+
+- **Contradiction detection** — Flags entries that conflict with existing knowledge
+- **Temporal consistency** — Ensures timestamps and version sequences are coherent
+- **Confidence thresholds** — Rejects entries with implausible confidence values
+- **Causal chain integrity** — Verifies that referenced causal keys exist
+
+### Multi-Strategy Retrieval
+
+Advanced search that goes beyond single-embedding lookup by combining multiple retrieval strategies:
+
+| Strategy | Signal |
+|:---------|:-------|
+| Semantic | Vector similarity via embeddings |
+| BM25 | Keyword relevance scoring |
+| Temporal | Recency weighting |
+| Confidence | Trust-score ranking |
+
+Results are merged using **Reciprocal Rank Fusion (RRF)** to produce a single ranked list.
+
+### Pro MCP Server
+
+Extends the OSS MCP server with 4 additional tools:
+
+| Tool | Description |
+|:-----|:------------|
+| `amfs_critique` | Run the Memory Critic and get a quality report |
+| `amfs_distill` | Trigger distillation (prune, consolidate, or generate bootstrap set) |
+| `amfs_validate` | Validate a candidate memory before writing |
+| `amfs_retrieve` | Multi-strategy retrieval with RRF-merged results |
+
+---
+
+## Architecture
+
+The Pro layer wraps the OSS layer — it never replaces it. All Pro features read from and write to the same memory store using the same adapters and SDK.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Agent / IDE                          │
+└────────────────────────────┬────────────────────────────────┘
+                             │
+              ┌──────────────┴──────────────┐
+              ▼                             ▼
+   ┌─────────────────┐          ┌─────────────────────┐
+   │  MCP Server OSS │          │  MCP Server Pro      │
+   │  (9 tools)      │          │  (9 + 4 tools)       │
+   └────────┬────────┘          └──────────┬──────────┘
+            │                              │
+            └──────────┬───────────────────┘
+                       ▼
+            ┌─────────────────┐
+            │   AgentMemory   │  ← Python SDK
+            │   (CoW Engine)  │
+            └────────┬────────┘
+                     │
+           ┌─────────┼─────────┐
+           ▼         ▼         ▼
+      Filesystem  Postgres    Custom
+       Adapter    Adapter    Adapter
+```
+
+The Pro MCP server imports and re-exports all 9 OSS tools, then adds the 4 Pro tools on top. You only run one server — either OSS or Pro.
+
+---
+
+## When to Use Which
+
+| Scenario | Recommendation |
+|:---------|:---------------|
+| Single developer, local memory | OSS |
+| Small team sharing via Postgres | OSS |
+| CI/CD outcome tracking | OSS |
+| Need memory quality auditing at scale | Pro |
+| Want LLM-driven extraction from conversations/logs | Pro |
+| Onboarding new agents with curated knowledge | Pro (bootstrap sets) |
+| Compliance or safety requirements for memory writes | Pro (safety validator) |
+| Advanced retrieval across large stores | Pro (multi-strategy) |
+
+---
+
+## Getting Started
+
+### OSS
+
+```bash
+pip install amfs
+```
+
+See the [Quick Start guide](/amfs/getting-started/quickstart/) to begin.
+
+### Pro
+
+Contact us at [raia.live](https://raia.live) for Pro access and setup instructions.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,7 +1,7 @@
 ---
 title: Guides
 layout: default
-nav_order: 4
+nav_order: 5
 has_children: true
 description: "In-depth guides for using AMFS with Python, TypeScript, CLI, and MCP."
 permalink: /guides/

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -21,7 +21,7 @@ AMFS provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)
 
 ## What You Get
 
-After setup, your AI agents have 6 memory tools:
+After setup, your AI agents have 9 memory tools:
 
 | Tool | Description |
 |:-----|:------------|
@@ -31,6 +31,9 @@ After setup, your AI agents have 6 memory tools:
 | `amfs_list` | List entries for an entity |
 | `amfs_stats` | Get a memory overview (entry counts, outcome counts) |
 | `amfs_commit_outcome` | Record outcomes with auto-causal linking |
+| `amfs_record_context` | Capture external tool/API inputs in the causal chain |
+| `amfs_history` | Retrieve version history of an entry with optional time range |
+| `amfs_explain` | Inspect the full decision trace for the current session |
 
 ---
 
@@ -219,9 +222,11 @@ Override with `AMFS_AGENT_ID`:
 
 1. **Agent starts** — MCP server launches, creates an `AgentMemory` instance with auto-detected agent ID.
 2. **Agent searches** — Before working, the agent calls `amfs_search` to check for existing context.
-3. **Agent writes** — After completing tasks, decisions and risks are recorded with `amfs_write`.
-4. **Outcomes propagate** — `amfs_commit_outcome` updates confidence on all entries the agent read.
-5. **Knowledge compounds** — The next agent starts with context instead of from scratch.
+3. **Agent gathers context** — External tool calls are captured with `amfs_record_context` so the decision trace is complete.
+4. **Agent writes** — After completing tasks, decisions and risks are recorded with `amfs_write` (optionally specifying `memory_type`: `fact`, `belief`, or `experience`).
+5. **Outcomes propagate** — `amfs_commit_outcome` updates confidence on all entries the agent read.
+6. **Agent reviews** — `amfs_history` shows how a memory evolved over time; `amfs_explain` reveals the full decision trace including external inputs.
+7. **Knowledge compounds** — The next agent starts with context instead of from scratch.
 
 ### Example Scenario
 

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -70,6 +70,7 @@ entry = mem.write(
     {"max_retries": 3},          # value (any JSON-serializable data)
     confidence=0.85,             # optional, default 1.0
     pattern_refs=["retry"],      # optional cross-references
+    memory_type=MemoryType.FACT, # optional: fact (default), belief, or experience
 )
 ```
 
@@ -162,6 +163,112 @@ OutcomeType.P2_INCIDENT    # × 1.10
 OutcomeType.REGRESSION     # × 1.08
 OutcomeType.CLEAN_DEPLOY   # × 0.97
 ```
+
+---
+
+## Memory Types
+
+Classify entries to control decay behavior:
+
+```python
+from amfs import MemoryType
+
+# Facts (default) — objective knowledge, standard decay
+mem.write("svc", "config", {"pool_size": 10}, memory_type=MemoryType.FACT)
+
+# Beliefs — subjective inferences, decay 2× faster
+mem.write("svc", "hypothesis", "Likely an N+1 query issue", memory_type=MemoryType.BELIEF)
+
+# Experiences — action logs, decay 1.5× slower
+mem.write("svc", "action-log", "Added index on user_id", memory_type=MemoryType.EXPERIENCE)
+```
+
+---
+
+## History (Temporal Queries)
+
+Retrieve the full version history of an entry with optional time filtering:
+
+```python
+from datetime import datetime, timedelta, timezone
+
+# All versions
+versions = mem.history("checkout-service", "retry-pattern")
+for v in versions:
+    print(f"v{v.version} — confidence: {v.confidence} — {v.provenance.written_at}")
+
+# Versions from the last 7 days
+since = datetime.now(timezone.utc) - timedelta(days=7)
+recent = mem.history("checkout-service", "retry-pattern", since=since)
+```
+
+---
+
+## Explainability
+
+Inspect the causal chain — which entries were read during the current session and how they connect to outcomes:
+
+```python
+chain = mem.explain()
+print(chain["session_id"])
+print(chain["causal_keys"])   # list of entity_path/key pairs that were read
+print(chain["entries"])       # full entry details for each causal key
+```
+
+Filter by outcome reference:
+
+```python
+chain = mem.explain(outcome_ref="INC-1042")
+```
+
+---
+
+## Tool Context
+
+When agents call external tools or APIs, there are two ways to capture that context in AMFS depending on your needs.
+
+### Record in the causal chain (lightweight)
+
+Use `record_context()` to add external inputs to the causal chain without writing to storage. This makes `explain()` return a complete decision trace:
+
+```python
+entry = mem.read("checkout-service", "retry-pattern")
+
+mem.record_context(
+    "pagerduty-incidents",
+    "3 SEV-1 incidents in the last 24h for checkout-service",
+    source="PagerDuty API",
+)
+mem.record_context(
+    "git-log",
+    "15 commits since last deploy, 3 touching retry logic",
+    source="git",
+)
+
+mem.commit_outcome("DEP-500", OutcomeType.CLEAN_DEPLOY)
+
+chain = mem.explain()
+print(chain["causal_entries"])     # AMFS entries that were read
+print(chain["external_contexts"])  # tool/API inputs that informed the decision
+```
+
+### Persist for other agents (durable)
+
+Use `MemoryType.EXPERIENCE` with a TTL to store tool results so downstream agents can retrieve them:
+
+```python
+from datetime import datetime, timedelta, timezone
+
+mem.write(
+    "checkout-service",
+    "tool-result-pagerduty",
+    {"incidents": 3, "sev1": True, "last_24h": True},
+    memory_type=MemoryType.EXPERIENCE,
+    ttl_at=datetime.now(timezone.utc) + timedelta(hours=1),
+)
+```
+
+The next agent reads it with `mem.read("checkout-service", "tool-result-pagerduty")` instead of re-calling the API.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,10 @@ entry = mem.read("checkout-service", "risk-race-condition")
 | **Copy-on-Write versioning** | Every write creates a new version. Full history is preserved. |
 | **Confidence scores** | Each entry carries a confidence score that evolves based on outcomes. |
 | **Outcome back-propagation** | Link deploys and incidents to memory entries. Confidence adjusts automatically. |
+| **Memory types** | Classify entries as `fact`, `belief`, or `experience` with type-specific decay rates. |
+| **Provenance tiers** | Automatically tier entries by quality: production-validated, observed, dev, or manual. |
+| **Temporal queries** | Retrieve the full version history of any entry, filtered by time range. |
+| **Causal explainability** | Inspect which entries were read and how they connect to outcomes. |
 | **Provenance tracking** | Every entry records which agent wrote it, when, and from which session. |
 | **Multiple adapters** | Filesystem (default), Postgres, or build your own. |
 | **MCP integration** | First-class MCP server for Cursor, Claude Code, and any MCP-compatible client. |
@@ -99,6 +103,14 @@ entry = mem.read("checkout-service", "risk-race-condition")
 | `amfs-cli` | Python | `pip install amfs-cli` |
 | `amfs-mcp-server` | Python | `pip install amfs-mcp-server` |
 | `@amfs/sdk` | TypeScript | `npm install @amfs/sdk` |
+
+---
+
+## OSS vs Pro
+
+AMFS is available in two editions. The open-source layer provides the full memory primitive — versioning, confidence, outcomes, adapters, and MCP. The Pro layer adds an intelligence layer with LLM-driven extraction, automated quality auditing, memory distillation, safety validation, and multi-strategy retrieval.
+
+[Compare editions](/amfs/editions/){: .btn .btn-outline .fs-5 .mb-4 .mb-md-0 }
 
 ---
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,7 +1,7 @@
 ---
 title: Integrations
 layout: default
-nav_order: 6
+nav_order: 7
 description: "Use AMFS with CrewAI, LangGraph, LangChain, and AutoGen."
 permalink: /integrations/
 ---

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -78,10 +78,11 @@ write(
     confidence: float = 1.0,
     ttl_at: datetime | None = None,
     pattern_refs: list[str] | None = None,
+    memory_type: MemoryType = MemoryType.FACT,
 ) -> MemoryEntry
 ```
 
-Creates a new version of the entry. If the key already exists, the previous version is superseded (CoW).
+Creates a new version of the entry. If the key already exists, the previous version is superseded (CoW). The `memory_type` parameter controls decay behavior — `belief` decays 2× faster, `experience` decays 1.5× slower.
 
 ---
 
@@ -159,6 +160,62 @@ Record an outcome and update confidence on causal entries. If `causal_entry_keys
 
 ---
 
+### history
+
+```python
+history(
+    entity_path: str,
+    key: str,
+    *,
+    since: datetime | None = None,
+    until: datetime | None = None,
+) -> list[MemoryEntry]
+```
+
+Returns all versions of an entry, optionally filtered by time range. Entries are sorted by version ascending.
+
+---
+
+### record_context
+
+```python
+record_context(
+    label: str,
+    summary: str,
+    *,
+    source: str | None = None,
+) -> None
+```
+
+Record external context (tool call, API response, database query) in the causal chain without writing to storage. These appear in the `external_contexts` field of `explain()` output, making decision traces complete.
+
+---
+
+### explain
+
+```python
+explain(
+    outcome_ref: str | None = None,
+) -> dict[str, Any]
+```
+
+Returns the causal chain for the current session: which AMFS entries were read, which external contexts were recorded, and their details. If `outcome_ref` is provided, labels the explanation with that reference.
+
+Returns:
+
+```python
+{
+    "outcome_ref": str | None,
+    "agent_id": str,
+    "session_id": str,
+    "causal_chain_length": int,
+    "causal_entries": list[dict],       # AMFS entries that were read
+    "external_contexts": list[dict],    # tool/API inputs via record_context()
+}
+```
+
+---
+
 ### stats
 
 ```python
@@ -173,20 +230,25 @@ Returns memory statistics.
 
 ```python
 class MemoryEntry:
-    amfs_version: str       # Protocol version ("0.1.0")
-    entity_path: str        # Entity scope
-    key: str                # Entry key
-    version: int            # Version number
-    value: Any              # Stored data
-    provenance: Provenance  # Authorship metadata
-    confidence: float       # Trust score
-    outcome_count: int      # Outcomes applied
-    ttl_at: datetime | None # Expiration timestamp
+    amfs_version: str           # Protocol version ("0.2.0")
+    entity_path: str            # Entity scope
+    key: str                    # Entry key
+    version: int                # Version number
+    value: Any                  # Stored data
+    provenance: Provenance      # Authorship metadata
+    confidence: float           # Trust score
+    outcome_count: int          # Outcomes applied
+    memory_type: MemoryType     # fact, belief, or experience
+    ttl_at: datetime | None     # Expiration timestamp
     embedding: list[float] | None  # Vector embedding
 
     @property
     def entry_key(self) -> str:
         """Canonical reference: 'entity_path/key'"""
+
+    @property
+    def provenance_tier(self) -> ProvenanceTier:
+        """Computed quality tier based on agent ID and outcome history."""
 ```
 
 ---
@@ -211,6 +273,29 @@ class OutcomeType(str, Enum):
     P2_INCIDENT = "p2_incident"      # × 1.10
     REGRESSION = "regression"        # × 1.08
     CLEAN_DEPLOY = "clean_deploy"    # × 0.97
+```
+
+---
+
+## MemoryType
+
+```python
+class MemoryType(str, Enum):
+    FACT = "fact"              # Objective knowledge, standard decay
+    BELIEF = "belief"          # Subjective inference, 2× faster decay
+    EXPERIENCE = "experience"  # Action log, 1.5× slower decay
+```
+
+---
+
+## ProvenanceTier
+
+```python
+class ProvenanceTier(int, Enum):
+    PRODUCTION_VALIDATED = 1   # Production agent + outcomes applied
+    PRODUCTION_OBSERVED = 2    # Production agent, no outcomes yet
+    DEVELOPMENT = 3            # Dev/test environment
+    MANUAL = 4                 # Manually seeded
 ```
 
 ---
@@ -255,6 +340,7 @@ amfs_write(
     value: str,
     confidence: float = 1.0,
     pattern_refs: list[str] | None = None,
+    memory_type: str = "fact",  # "fact" | "belief" | "experience"
 ) -> str (JSON)
 ```
 
@@ -294,3 +380,38 @@ amfs_commit_outcome(
     outcome_type: str,  # "p1_incident" | "p2_incident" | "regression" | "clean_deploy"
 ) -> str (JSON)
 ```
+
+### amfs_record_context
+
+```
+amfs_record_context(
+    label: str,
+    summary: str,
+    source: str = "",
+) -> str (JSON)
+```
+
+Record external context (tool call, API response) in the causal chain. Appears in `amfs_explain()` output.
+
+### amfs_history
+
+```
+amfs_history(
+    entity_path: str,
+    key: str,
+    since: str | None = None,  # ISO 8601 datetime
+    until: str | None = None,  # ISO 8601 datetime
+) -> str (JSON)
+```
+
+Returns all versions of an entry, optionally bounded by a time range. Dates are ISO 8601 strings.
+
+### amfs_explain
+
+```
+amfs_explain(
+    outcome_ref: str | None = None,
+) -> str (JSON)
+```
+
+Returns the causal read chain for the current session: which entries were read and their details.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -30,6 +30,7 @@ AMFS supports the following environment variables. They override values set in `
 | `AMFS_HOST` | HTTP server bind host | `0.0.0.0` |
 | `AMFS_PORT` | HTTP server bind port | `8000` |
 | `AMFS_PATH` | HTTP server URL path | `/mcp` |
+| `AMFS_TTL_SWEEP_INTERVAL` | Seconds between TTL sweep runs (set to enable automatic expiry) | — |
 
 ---
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,7 +1,7 @@
 ---
 title: Reference
 layout: default
-nav_order: 7
+nav_order: 8
 has_children: true
 description: "API reference, configuration options, and environment variables."
 permalink: /reference/

--- a/examples/mcp_setup.md
+++ b/examples/mcp_setup.md
@@ -4,16 +4,19 @@ This guide walks you through setting up AMFS as shared memory for AI coding agen
 
 ## What You Get
 
-After setup, your AI coding agents will have 6 memory tools available:
+After setup, your AI coding agents will have 9 memory tools available:
 
 | Tool | Description |
 |------|-------------|
 | `amfs_read` | Read a memory entry by entity path and key |
-| `amfs_write` | Write knowledge with automatic provenance |
+| `amfs_write` | Write knowledge with automatic provenance (supports `memory_type`: `fact`, `belief`, `experience`) |
 | `amfs_search` | Search across all entries with filters |
 | `amfs_list` | List entries for an entity |
 | `amfs_stats` | Memory overview |
 | `amfs_commit_outcome` | Record outcomes, auto-links to read log |
+| `amfs_record_context` | Capture external tool/API inputs in the decision trace |
+| `amfs_history` | Retrieve version history of an entry with optional time range |
+| `amfs_explain` | Inspect the full decision trace (AMFS reads + external contexts) |
 
 ## Prerequisites
 
@@ -215,6 +218,7 @@ Machine B (Claude Code/Alice):
 | `AMFS_HOST` | HTTP bind host (default: `0.0.0.0`) |
 | `AMFS_PORT` | HTTP bind port (default: `8000`) |
 | `AMFS_PATH` | HTTP URL path (default: `/mcp`) |
+| `AMFS_TTL_SWEEP_INTERVAL` | Seconds between TTL sweep runs |
 | `CURSOR_SESSION_ID` | Auto-set by Cursor (used for detection) |
 | `VSCODE_PID` | Auto-set by VS Code/Cursor (used for detection) |
 | `CLAUDE_CODE_SESSION` | Auto-set by Claude Code (used for detection) |

--- a/packages/cli/src/amfs_cli/init.py
+++ b/packages/cli/src/amfs_cli/init.py
@@ -11,7 +11,7 @@ console = Console()
 
 _DEFAULT_CONFIG = """\
 # AMFS Configuration
-# Docs: https://github.com/senselab/amfs
+# Docs: https://github.com/raia-live/amfs
 
 namespace: {namespace}
 

--- a/packages/core/src/amfs_core/engine.py
+++ b/packages/core/src/amfs_core/engine.py
@@ -9,6 +9,8 @@ from typing import Any
 from amfs_core.abc import AdapterABC
 from amfs_core.models import MemoryEntry, MemoryType, Provenance
 
+ExternalContext = dict[str, Any]
+
 
 class CausalTagger:
     """Stamps provenance metadata on every write.
@@ -50,16 +52,43 @@ class ReadTracker:
     def __init__(self) -> None:
         self._reads: dict[str, datetime] = {}
         self._versions: dict[str, int] = {}
+        self._contexts: list[ExternalContext] = []
 
     def record(self, entry: MemoryEntry) -> None:
         """Record that an entry was read during this session."""
         self._reads[entry.entry_key] = datetime.now(timezone.utc)
         self._versions[entry.entry_key] = entry.version
 
+    def record_context(
+        self,
+        label: str,
+        summary: str,
+        *,
+        source: str | None = None,
+    ) -> None:
+        """Record external context that influenced decisions in this session.
+
+        Unlike ``record()``, this doesn't correspond to an AMFS entry — it
+        captures external tool calls, API responses, and other inputs that
+        informed the agent's decisions.  These are included in the causal
+        chain returned by ``explain()`` so decision traces are complete.
+        """
+        self._contexts.append({
+            "label": label,
+            "summary": summary,
+            "source": source,
+            "recorded_at": datetime.now(timezone.utc).isoformat(),
+        })
+
     @property
     def causal_keys(self) -> list[str]:
         """All entry keys read in this session, ordered by read time."""
         return [k for k, _ in sorted(self._reads.items(), key=lambda x: x[1])]
+
+    @property
+    def external_contexts(self) -> list[ExternalContext]:
+        """All external contexts recorded in this session, in order."""
+        return list(self._contexts)
 
     @property
     def read_count(self) -> int:
@@ -73,6 +102,7 @@ class ReadTracker:
         """Reset the read log (e.g. between sub-tasks within a session)."""
         self._reads.clear()
         self._versions.clear()
+        self._contexts.clear()
 
     def contains(self, entry_key: str) -> bool:
         return entry_key in self._reads

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -343,6 +343,30 @@ def amfs_history(
 
 
 @mcp.tool
+def amfs_record_context(
+    label: str,
+    summary: str,
+    source: str = "",
+) -> str:
+    """Record external context that influenced this session's decisions.
+
+    Call this after consulting an external tool, API, or data source.
+    The context is added to the causal chain returned by amfs_explain(),
+    making decision traces complete.
+
+    Args:
+        label: Short name for the context (e.g. "pagerduty-incidents", "git-log")
+        summary: Brief summary of what was found
+        source: Optional source identifier (e.g. "PagerDuty API", "git")
+
+    Example: amfs_record_context("git-log", "15 commits since last deploy", "git")
+    """
+    mem = _get_memory()
+    mem.record_context(label, summary, source=source or None)
+    return json.dumps({"recorded": label, "source": source or None})
+
+
+@mcp.tool
 def amfs_explain(outcome_ref: str | None = None) -> str:
     """Explain the causal chain — which memories influenced this session's decisions.
 

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -332,11 +332,38 @@ class AgentMemory:
         """
         return self._engine.history(entity_path, key, since=since, until=until)
 
+    def record_context(
+        self,
+        label: str,
+        summary: str,
+        *,
+        source: str | None = None,
+    ) -> None:
+        """Record external context in the causal chain without writing to storage.
+
+        Call this after consulting an external tool, API, or data source so
+        that ``explain()`` returns a complete decision trace — not just which
+        AMFS entries were read, but also which external inputs informed the
+        agent's decisions.
+
+        Example::
+
+            mem.record_context(
+                "pagerduty-incidents",
+                "3 SEV-1 incidents in the last 24h for checkout-service",
+                source="PagerDuty API",
+            )
+        """
+        self._read_tracker.record_context(label, summary, source=source)
+
     def explain(self, outcome_ref: str | None = None) -> dict[str, Any]:
         """Return the causal chain for the current session or a specific outcome.
 
         Shows which memories were read (and in what order) before the outcome
-        was committed, enabling production-grounded explainability.
+        was committed, plus any external contexts recorded via
+        ``record_context()``.  This is production-grounded explainability:
+        not what the LLM inferred, but which stored knowledge and external
+        inputs actually drove the decision.
         """
         causal_keys = self._read_tracker.causal_keys
         entries: list[dict[str, Any]] = []
@@ -357,6 +384,7 @@ class AgentMemory:
             "session_id": self.session_id,
             "causal_chain_length": len(causal_keys),
             "causal_entries": entries,
+            "external_contexts": self._read_tracker.external_contexts,
         }
 
     # ------------------------------------------------------------------

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -226,6 +226,58 @@ class TestReadTracker:
         assert not tracker.contains("svc/other")
 
 
+class TestReadTrackerExternalContexts:
+    def test_record_context_adds_to_list(self) -> None:
+        tracker = ReadTracker()
+        tracker.record_context("git-log", "15 commits since last deploy", source="git")
+        assert len(tracker.external_contexts) == 1
+        ctx = tracker.external_contexts[0]
+        assert ctx["label"] == "git-log"
+        assert ctx["summary"] == "15 commits since last deploy"
+        assert ctx["source"] == "git"
+        assert "recorded_at" in ctx
+
+    def test_record_context_source_optional(self) -> None:
+        tracker = ReadTracker()
+        tracker.record_context("manual-check", "Verified deployment config")
+        ctx = tracker.external_contexts[0]
+        assert ctx["source"] is None
+
+    def test_record_context_preserves_order(self) -> None:
+        tracker = ReadTracker()
+        tracker.record_context("step-1", "first")
+        tracker.record_context("step-2", "second")
+        tracker.record_context("step-3", "third")
+        labels = [c["label"] for c in tracker.external_contexts]
+        assert labels == ["step-1", "step-2", "step-3"]
+
+    def test_external_contexts_returns_copy(self) -> None:
+        tracker = ReadTracker()
+        tracker.record_context("a", "b")
+        contexts = tracker.external_contexts
+        contexts.append({"label": "injected"})
+        assert len(tracker.external_contexts) == 1
+
+    def test_clear_removes_external_contexts(self) -> None:
+        tracker = ReadTracker()
+        entry = MemoryEntry(
+            entity_path="svc", key="k1", version=1, value="v",
+            provenance=Provenance(
+                agent_id="a", session_id="s",
+                written_at=datetime.now(timezone.utc),
+            ),
+        )
+        tracker.record(entry)
+        tracker.record_context("tool", "output")
+        assert tracker.read_count == 1
+        assert len(tracker.external_contexts) == 1
+
+        tracker.clear()
+        assert tracker.read_count == 0
+        assert tracker.causal_keys == []
+        assert tracker.external_contexts == []
+
+
 class TestCoWEngineWithReadTracker:
     def test_read_auto_tracks(self) -> None:
         adapter = MockAdapter()

--- a/tests/unit/test_sdk.py
+++ b/tests/unit/test_sdk.py
@@ -311,6 +311,46 @@ class TestAutoCausalTracking:
         mem.clear_read_log()
         assert mem.read_log == []
 
+    def test_record_context(self, mem: AgentMemory) -> None:
+        mem.record_context("git-log", "15 commits since last deploy", source="git")
+        chain = mem.explain()
+        assert len(chain["external_contexts"]) == 1
+        ctx = chain["external_contexts"][0]
+        assert ctx["label"] == "git-log"
+        assert ctx["summary"] == "15 commits since last deploy"
+        assert ctx["source"] == "git"
+
+    def test_record_context_source_optional(self, mem: AgentMemory) -> None:
+        mem.record_context("manual-check", "Verified config")
+        chain = mem.explain()
+        assert chain["external_contexts"][0]["source"] is None
+
+    def test_explain_includes_both_reads_and_contexts(self, mem: AgentMemory) -> None:
+        mem.write("svc", "pattern", "exponential backoff")
+        mem.read("svc", "pattern")
+        mem.record_context("pagerduty", "2 open incidents", source="PagerDuty API")
+
+        chain = mem.explain("DEP-100")
+        assert chain["outcome_ref"] == "DEP-100"
+        assert chain["agent_id"] == "causal-agent"
+        assert chain["causal_chain_length"] == 1
+        assert len(chain["causal_entries"]) == 1
+        assert chain["causal_entries"][0]["key"] == "pattern"
+        assert len(chain["external_contexts"]) == 1
+        assert chain["external_contexts"][0]["label"] == "pagerduty"
+
+    def test_clear_read_log_clears_contexts(self, mem: AgentMemory) -> None:
+        mem.record_context("tool", "output")
+        assert len(mem.explain()["external_contexts"]) == 1
+        mem.clear_read_log()
+        assert mem.explain()["external_contexts"] == []
+
+    def test_explain_empty_session(self, mem: AgentMemory) -> None:
+        chain = mem.explain()
+        assert chain["causal_chain_length"] == 0
+        assert chain["causal_entries"] == []
+        assert chain["external_contexts"] == []
+
 
 # ---------------------------------------------------------------------------
 # Confidence decay tests


### PR DESCRIPTION
## Summary

- **`record_context()` API** — Agents can now capture external tool/API inputs (PagerDuty, git, databases, etc.) in the causal chain without writing to storage. `explain()` returns complete decision traces showing both AMFS reads and external contexts that informed the decision.
- **Context Graphs docs** — New conceptual page mapping AMFS primitives to context graph: CoW = immutable traces, provenance = who/when, `explain()` = "why did we do that?", outcomes = feedback loop.
- **OSS vs Pro docs** — New `docs/editions.md` page with full feature comparison table, architecture diagrams, and guidance on when to use each edition.
- **Comprehensive doc updates** — All docs updated to reflect v0.2.0 changes from `feat/mem-improv`: memory types, provenance tiers, temporal queries, causal explainability, type-specific decay rates. Updated across 25 files including API reference, MCP guide, Python SDK guide, concepts, adapters, CLAUDE.md, and cursor rules.
- **MCP server** — New `amfs_record_context` tool (9 total OSS tools).

## Changes

### Implementation (4 files)
- `packages/core/src/amfs_core/engine.py` — `ReadTracker.record_context()`, `external_contexts` property, updated `clear()`
- `packages/sdk-python/src/amfs/memory.py` — `AgentMemory.record_context()`, updated `explain()` to include `external_contexts`
- `packages/mcp-server/src/amfs_mcp/server.py` — `amfs_record_context` MCP tool
- `packages/cli/src/amfs_cli/init.py` — Fixed stale `senselab/amfs` URL → `raia-live/amfs`

### Documentation (21 files)
- New: `docs/editions.md`, `docs/concepts/context-graphs.md`
- Updated: all concept, guide, reference, adapter, integration, and contributing docs
- Updated: `README.md`, `CLAUDE.md`, `.cursor/rules/amfs-memory.mdc`, `examples/mcp_setup.md`

### Tests (2 files)
- `tests/unit/test_engine.py` — 5 new tests for `ReadTracker` external contexts
- `tests/unit/test_sdk.py` — 5 new tests for `AgentMemory.record_context()` and `explain()`

## Test plan

- [x] All 94 unit tests pass (`uv run pytest tests/unit/ -v`)
- [ ] Verify docs render correctly on GitHub Pages
- [ ] Verify `amfs_record_context` works end-to-end via MCP in Cursor
- [ ] Verify `explain()` output includes both `causal_entries` and `external_contexts`