### PR TITLE
docs: add AMFS vs Vector Databases and AMFS vs Competitors pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Visit **[raia-live.github.io/amfs](https://raia-live.github.io/amfs/)** for the 
 - [Getting Started](https://raia-live.github.io/amfs/getting-started/) — installation, quick start, configuration
 - [Core Concepts](https://raia-live.github.io/amfs/concepts/) — memory entries, CoW, confidence, provenance
 - [OSS vs Pro](https://raia-live.github.io/amfs/editions/) — feature comparison and when to use which
+- [AMFS vs Vector Databases](https://raia-live.github.io/amfs/vs-vector-databases/) — when to use which, and how they complement each other
+- [AMFS vs Competitors](https://raia-live.github.io/amfs/vs-competitors/) — comparison with Mem0, Cognee, Zep/Graphiti, LangMem
 - [Guides](https://raia-live.github.io/amfs/guides/) — Python SDK, TypeScript SDK, CLI, MCP setup
 - [Adapters](https://raia-live.github.io/amfs/adapters/) — filesystem, Postgres, custom adapters
 - [Integrations](https://raia-live.github.io/amfs/integrations/) — CrewAI, LangGraph, LangChain, AutoGen

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -1,7 +1,7 @@
 ---
 title: Adapters
 layout: default
-nav_order: 6
+nav_order: 8
 has_children: true
 description: "Storage backends for AMFS: filesystem, Postgres, and custom adapters."
 permalink: /adapters/

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -1,7 +1,7 @@
 ---
 title: Contributing
 layout: default
-nav_order: 9
+nav_order: 11
 description: "Set up a development environment and contribute to AMFS."
 permalink: /contributing/
 ---

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,7 +1,7 @@
 ---
 title: Guides
 layout: default
-nav_order: 5
+nav_order: 7
 has_children: true
 description: "In-depth guides for using AMFS with Python, TypeScript, CLI, and MCP."
 permalink: /guides/

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,6 +111,8 @@ entry = mem.read("checkout-service", "risk-race-condition")
 AMFS is available in two editions. The open-source layer provides the full memory primitive — versioning, confidence, outcomes, adapters, and MCP. The Pro layer adds an intelligence layer with LLM-driven extraction, automated quality auditing, memory distillation, safety validation, and multi-strategy retrieval.
 
 [Compare editions](/amfs/editions/){: .btn .btn-outline .fs-5 .mb-4 .mb-md-0 }
+[AMFS vs Vector DBs](/amfs/vs-vector-databases/){: .btn .btn-outline .fs-5 .mb-4 .mb-md-0 }
+[AMFS vs Competitors](/amfs/vs-competitors/){: .btn .btn-outline .fs-5 .mb-4 .mb-md-0 }
 
 ---
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,7 +1,7 @@
 ---
 title: Integrations
 layout: default
-nav_order: 7
+nav_order: 9
 description: "Use AMFS with CrewAI, LangGraph, LangChain, and AutoGen."
 permalink: /integrations/
 ---

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,7 +1,7 @@
 ---
 title: Reference
 layout: default
-nav_order: 8
+nav_order: 10
 has_children: true
 description: "API reference, configuration options, and environment variables."
 permalink: /reference/

--- a/docs/vs-competitors.md
+++ b/docs/vs-competitors.md
@@ -1,0 +1,196 @@
+---
+title: AMFS vs Competitors
+layout: default
+nav_order: 6
+description: "How AMFS compares to Mem0, Cognee, Zep/Graphiti, LangMem, and other AI memory systems."
+permalink: /vs-competitors/
+---
+
+# AMFS vs Competitors
+{: .no_toc }
+
+The AI memory space is evolving fast. Here's how AMFS compares to the leading alternatives and where each excels.
+{: .fs-6 .fw-300 }
+
+## Table of Contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Feature Matrix
+
+| Feature | AMFS | Mem0 | Cognee | Zep / Graphiti | LangMem |
+|:--------|:----:|:----:|:------:|:--------------:|:-------:|
+| Persistent memory across sessions | Yes | Yes | Yes | Yes | Yes |
+| Versioning (full history) | CoW | No | No | Temporal | No |
+| Provenance (who wrote, when) | Yes | No | No | Partial | No |
+| Confidence scoring | Yes | No | No | No | No |
+| Outcome back-propagation | Yes | No | No | No | No |
+| Memory types (fact/belief/experience) | Yes | No | No | No | No |
+| Provenance tiers | Yes | No | No | No | No |
+| Causal explainability | Yes | No | No | No | No |
+| Decision trace capture | Yes | No | No | Partial | No |
+| Knowledge graph | Via pattern_refs | No | Yes | Yes | No |
+| Semantic search | Yes | Yes | Yes | Yes | Yes |
+| Multi-agent support | Native | Partial | No | No | No |
+| Conflict detection | Yes | No | No | No | No |
+| MCP server | Yes | Yes | No | No | No |
+| Framework integrations | Yes | Yes | Yes | Yes | Yes |
+| Self-hosted / OSS | Apache 2.0 | OSS + Cloud | OSS + Cloud | OSS + Cloud | OSS |
+| Pluggable storage backends | Yes | No | No | No | No |
+| TTL / automatic expiry | Yes | No | No | Yes | No |
+
+---
+
+## AMFS vs Mem0
+
+[Mem0](https://mem0.ai) is a popular memory layer for LLM applications. It focuses on storing user preferences and conversational context.
+
+### Where Mem0 Excels
+
+- **Conversational memory** — Extracts and manages user preferences from chat history automatically.
+- **Cloud-hosted option** — Managed service with minimal setup.
+- **Simple API** — `add()`, `search()`, `get()` — easy to get started.
+- **Graph memory** — Optional knowledge graph for relationship extraction.
+
+### Where AMFS Differs
+
+- **Outcome-driven confidence** — AMFS entries carry confidence scores that evolve when deploys succeed or incidents occur. Mem0 stores facts without a trust signal.
+- **Copy-on-Write versioning** — Every AMFS write creates a new version. You can replay history, compare versions, and answer "what did we know at the time?" Mem0 overwrites.
+- **Provenance** — AMFS records which agent wrote each entry, in which session, with which cross-references. Mem0 doesn't track authorship.
+- **Multi-agent native** — AMFS supports conflict detection, auto-causal linking, and per-agent identity. Mem0 is designed primarily for single-user conversational context.
+- **Decision traces** — AMFS's `explain()` API and `record_context()` capture the full causal chain. Mem0 doesn't track why decisions were made.
+
+### Best Fit
+
+| Use Case | Better Choice |
+|:---------|:-------------|
+| Chatbot remembers user preferences | Mem0 |
+| Multi-agent coding workflows with outcome tracking | AMFS |
+| Personal AI assistant memory | Mem0 |
+| Production-grade agent memory with audit trail | AMFS |
+
+---
+
+## AMFS vs Cognee
+
+[Cognee](https://cognee.ai) builds knowledge graphs from documents using LLM-powered extraction, with a focus on multi-hop reasoning benchmarks.
+
+### Where Cognee Excels
+
+- **Knowledge graph construction** — Automatically builds structured graphs from unstructured documents.
+- **Multi-hop reasoning** — Strong performance on HotpotQA and similar benchmarks that require connecting information across sources.
+- **Dreamify optimization** — Proprietary tool for rewiring knowledge graph connections to improve accuracy.
+- **Ontology-based validation** — Uses ontologies to ground extracted knowledge in structured schemas.
+
+### Where AMFS Differs
+
+- **Agent-oriented, not document-oriented** — AMFS is designed for agents that read, write, and act on knowledge. Cognee is designed for processing documents into queryable graphs.
+- **Outcome feedback loop** — AMFS connects knowledge to real-world outcomes. Cognee's knowledge graph doesn't learn from what happens after retrieval.
+- **Versioning and provenance** — AMFS preserves full history and tracks authorship. Cognee's graph is a living structure that's updated in place.
+- **Pluggable storage** — AMFS runs on filesystem or Postgres. Cognee has its own storage layer.
+- **Decision explainability** — AMFS can explain why a decision was made (what was read, what external context was gathered). Cognee focuses on what's in the graph, not how it was used.
+
+### Best Fit
+
+| Use Case | Better Choice |
+|:---------|:-------------|
+| Build knowledge graph from document corpus | Cognee |
+| Multi-hop QA over research papers | Cognee |
+| Agent memory with versioning and outcomes | AMFS |
+| Multi-agent shared knowledge with decision traces | AMFS |
+
+---
+
+## AMFS vs Zep / Graphiti
+
+[Zep](https://getzep.com) provides memory for AI assistants and agents. [Graphiti](https://github.com/getzep/graphiti) is Zep's temporal knowledge graph library.
+
+### Where Zep/Graphiti Excels
+
+- **Temporal knowledge graphs** — Graphiti maintains a graph where facts have valid-time ranges, supporting queries like "what was true at time T?"
+- **Conversation memory** — Zep excels at managing dialog history with summarization and entity extraction.
+- **Episodic + semantic memory** — Combines conversation episodes with extracted facts.
+- **Built-in entity resolution** — Automatically links mentions of the same entity across conversations.
+
+### Where AMFS Differs
+
+- **Outcome back-propagation** — AMFS's confidence scoring evolves based on production outcomes. Zep tracks temporal validity but doesn't learn from what happens after retrieval.
+- **Copy-on-Write vs. temporal graph** — AMFS versions individual entries with full history. Graphiti maintains a graph with time-bounded edges. Different models with different strengths: AMFS is simpler to reason about; Graphiti captures richer relationships.
+- **Agent provenance** — AMFS records which agent wrote each entry and supports multi-agent conflict detection. Zep is designed for single-assistant use.
+- **Pluggable backends** — AMFS supports filesystem (dev) and Postgres (production) with the same API. Zep requires its own infrastructure.
+- **Decision traces** — AMFS captures the full causal chain including external tool context. Zep focuses on conversation-derived knowledge.
+
+### Best Fit
+
+| Use Case | Better Choice |
+|:---------|:-------------|
+| AI assistant with conversation history | Zep |
+| Temporal knowledge graph with entity resolution | Graphiti |
+| Multi-agent memory with production feedback | AMFS |
+| Decision audit trail and causal explainability | AMFS |
+
+---
+
+## AMFS vs LangMem
+
+[LangMem](https://langchain-ai.github.io/long-term-memory/) is LangChain's long-term memory library, designed to work within the LangChain/LangGraph ecosystem.
+
+### Where LangMem Excels
+
+- **LangGraph integration** — First-class integration with LangGraph state management.
+- **Managed service** — Available as part of LangSmith's hosted platform.
+- **Namespace scoping** — Organize memories by user, thread, or custom namespace.
+
+### Where AMFS Differs
+
+- **Framework-agnostic** — AMFS works with CrewAI, LangGraph, LangChain, AutoGen, or standalone. LangMem is tied to the LangChain ecosystem.
+- **Outcome-driven confidence** — AMFS's core differentiator. Knowledge quality improves based on what actually happens in production.
+- **Full versioning** — Every AMFS write creates a new CoW version with history. LangMem stores current state.
+- **Provenance and explainability** — AMFS tracks who wrote what and can explain the full decision chain. LangMem doesn't provide provenance or causal tracing.
+- **MCP-native** — AMFS has a built-in MCP server for IDE integration (Cursor, Claude Code). LangMem doesn't support MCP.
+- **Self-hosted with pluggable storage** — AMFS runs on filesystem or Postgres. LangMem is primarily a managed service.
+
+### Best Fit
+
+| Use Case | Better Choice |
+|:---------|:-------------|
+| Memory inside a LangGraph pipeline | LangMem |
+| Framework-agnostic agent memory | AMFS |
+| MCP-based IDE integration (Cursor, Claude Code) | AMFS |
+| Memory that learns from production outcomes | AMFS |
+
+---
+
+## What Makes AMFS Unique
+
+Across all competitors, AMFS's differentiators are:
+
+1. **Memory that learns from production** — No other system connects memory to real-world outcomes. AMFS's confidence scoring evolves based on incidents, deployments, and regressions.
+
+2. **Complete decision traces** — `explain()` + `record_context()` capture the full picture: what AMFS entries were read, what external tools were consulted, and what happened afterward. No competitor offers this.
+
+3. **Copy-on-Write versioning** — Every write is immutable. You can replay the state of knowledge at any point in time, compare versions, and audit how decisions evolved. Most competitors overwrite.
+
+4. **Multi-agent native** — Provenance tracking, conflict detection (`LAST_WRITE_WINS` / `RAISE`), auto-causal linking, and per-agent identity are built in. Competitors are primarily designed for single-agent or single-user use.
+
+5. **Framework and infrastructure agnostic** — Works with any agent framework, any IDE via MCP, any storage backend via adapters. Not locked into one ecosystem.
+
+---
+
+## Choosing the Right Tool
+
+| Your Situation | Recommendation |
+|:---------------|:---------------|
+| Building a chatbot that remembers user preferences | Mem0 or Zep |
+| Processing documents into a knowledge graph | Cognee |
+| Building a temporal knowledge graph from conversations | Graphiti |
+| Need memory inside LangGraph only | LangMem |
+| Multi-agent system that needs shared memory with provenance | **AMFS** |
+| Agent memory that learns from production outcomes | **AMFS** |
+| Need decision traces and audit trail for agent actions | **AMFS** |
+| IDE integration for AI coding agents (Cursor, Claude Code) | **AMFS** |
+| Need versioned, explainable agent memory across frameworks | **AMFS** |

--- a/docs/vs-vector-databases.md
+++ b/docs/vs-vector-databases.md
@@ -1,0 +1,178 @@
+---
+title: AMFS vs Vector Databases
+layout: default
+nav_order: 5
+description: "When to use AMFS, when to use a vector database, and how they work together."
+permalink: /vs-vector-databases/
+---
+
+# AMFS vs Vector Databases
+{: .no_toc }
+
+Vector databases and AMFS solve different problems. Understanding the distinction helps you pick the right tool — or use both.
+{: .fs-6 .fw-300 }
+
+## Table of Contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## The Short Version
+
+**Vector databases** store embeddings and retrieve them by similarity. They answer: *"what is most relevant to this query?"*
+
+**AMFS** stores versioned, provenanced knowledge and evolves it based on outcomes. It answers: *"what does this agent know, who wrote it, how confident are we, and what happened when we acted on it?"*
+
+A vector database is a **retrieval engine**. AMFS is a **memory system**.
+
+---
+
+## Side-by-Side Comparison
+
+| Dimension | Vector Database | AMFS |
+|:----------|:----------------|:-----|
+| **Primary operation** | Similarity search over embeddings | Read/write versioned knowledge with provenance |
+| **Data model** | Vectors + metadata | Structured entries with entity/key scoping, confidence, memory type, provenance |
+| **Versioning** | Overwrite or append | Copy-on-Write — every write creates a new version, full history preserved |
+| **Who wrote it?** | Not tracked | Provenance: agent ID, session ID, timestamp, pattern refs |
+| **Trust signal** | None | Confidence score that evolves based on real-world outcomes |
+| **Feedback loop** | None | Outcome back-propagation — incidents boost confidence, clean deploys decay it |
+| **Query style** | "Find similar to X" | "Read key Y", "Search by entity/agent/confidence", "What happened over time?" |
+| **Temporal queries** | Snapshot at query time | Full version history with time-range filtering |
+| **Explainability** | None | Causal chain: which entries + external contexts informed a decision |
+| **Multi-agent** | Shared index | Shared memory with per-agent provenance, conflict detection, auto-causal linking |
+| **Typical size** | Millions–billions of vectors | Thousands–millions of knowledge entries |
+| **Update pattern** | Re-embed and upsert | CoW write with automatic version increment |
+
+---
+
+## What Vector Databases Do Well
+
+Vector databases excel at **large-scale semantic retrieval**:
+
+- **RAG (Retrieval-Augmented Generation)** — Finding relevant document chunks to inject into an LLM prompt. When you have 10M documents and need the top-10 most relevant passages, a vector database is the right tool.
+- **Similarity search** — "Find products similar to this one", "Find code snippets that match this pattern."
+- **Multimodal retrieval** — Searching across text, images, and audio using shared embedding spaces.
+- **Real-time recommendation** — High-throughput, low-latency nearest-neighbor queries.
+
+Popular options include Pinecone, Weaviate, Qdrant, Milvus, and Chroma.
+
+---
+
+## What Vector Databases Don't Do
+
+Vector databases are **stateless retrieval indexes**. They don't track:
+
+- **Who wrote the data** — No provenance. You don't know which agent or process created an entry.
+- **How trust evolves** — No confidence scoring. A vector's relevance score is similarity to a query, not a measure of how trustworthy the information is.
+- **What happened when you used it** — No outcome tracking. If an agent retrieves a vector and acts on it, and that action causes an incident, the vector database has no way to learn from that.
+- **How data changed over time** — Vectors are overwritten or appended. You can't ask "what did this entry say last week?"
+- **Why a decision was made** — No causal chain linking retrieved data to actions and outcomes.
+
+---
+
+## What AMFS Does Differently
+
+AMFS is designed for **agent memory** — the layer between retrieval and action:
+
+### Knowledge has identity
+
+Every entry has an `entity_path` and `key` that give it a stable address. Agents read and write to specific keys, not anonymous vectors.
+
+```python
+mem.write("checkout-service", "retry-pattern", {"max_retries": 3})
+entry = mem.read("checkout-service", "retry-pattern")
+```
+
+### Knowledge has provenance
+
+Every entry records who wrote it, when, and in which session:
+
+```python
+print(entry.provenance.agent_id)    # "review-agent"
+print(entry.provenance.written_at)  # 2026-03-15T14:30:00Z
+```
+
+### Knowledge evolves with outcomes
+
+When a deploy succeeds or an incident occurs, confidence scores on related entries adjust automatically:
+
+```python
+mem.commit_outcome("INC-1042", OutcomeType.P1_INCIDENT)
+# All entries this agent read get their confidence boosted
+```
+
+### Knowledge has full history
+
+Every write creates a new version. You can replay the state at any point in time:
+
+```python
+versions = mem.history("checkout-service", "retry-pattern", since=last_week)
+```
+
+### Decisions are explainable
+
+The causal chain shows exactly what informed a decision — both AMFS entries and external tool context:
+
+```python
+chain = mem.explain("DEP-500")
+# → causal_entries: entries the agent read
+# → external_contexts: tool/API inputs the agent consulted
+```
+
+---
+
+## When to Use Which
+
+| Scenario | Use |
+|:---------|:----|
+| RAG over large document corpus | Vector database |
+| Semantic search across millions of records | Vector database |
+| Agent memory that persists across sessions | AMFS |
+| Multi-agent shared knowledge with provenance | AMFS |
+| Confidence scoring based on real-world outcomes | AMFS |
+| Decision audit trail and explainability | AMFS |
+| Temporal queries ("what did we know last week?") | AMFS |
+| Real-time similarity recommendations | Vector database |
+| Knowledge that needs to learn from production | AMFS |
+
+---
+
+## Using Both Together
+
+AMFS and vector databases are complementary. A common architecture:
+
+```
+                    Agent
+                   /     \
+                  /       \
+         ┌──────▼──┐  ┌──▼──────────┐
+         │  AMFS   │  │ Vector DB   │
+         │ Memory  │  │ (RAG index) │
+         └─────────┘  └─────────────┘
+         What we know  What's relevant
+         + trust       to this query
+         + history
+         + outcomes
+```
+
+1. **Vector DB for retrieval** — Agent queries the vector database to find relevant documents or code snippets for the current task.
+2. **AMFS for memory** — Agent reads AMFS for known patterns, risks, and past decisions about the entity it's working on.
+3. **AMFS for recording** — After completing its task, the agent writes findings, decisions, and risks to AMFS with provenance and confidence.
+4. **AMFS for learning** — Outcomes (deploys, incidents) back-propagate through AMFS, adjusting confidence scores so future agents see which patterns are trustworthy.
+
+AMFS even supports semantic search via pluggable embedders — so for small-to-medium memory stores, you can search by meaning without a separate vector database. For large-scale RAG over millions of documents, a dedicated vector database is the right choice.
+
+---
+
+## Summary
+
+| | Vector Database | AMFS |
+|:--|:----------------|:-----|
+| **Think of it as** | A search index for embeddings | A version-controlled knowledge base for agents |
+| **Best for** | Finding relevant data | Remembering, learning, and explaining decisions |
+| **Data lifecycle** | Write once, query many | Write, version, track outcomes, decay, explain |
+| **Multi-agent** | Shared index | Shared memory with provenance, conflicts, and causal chains |


### PR DESCRIPTION
## Summary

- **AMFS vs Vector Databases** (`docs/vs-vector-databases.md`) — explains the fundamental difference between a retrieval engine (vector DB) and a memory system (AMFS), includes a side-by-side feature comparison, when-to-use-which table, and an architecture diagram showing how they complement each other.
- **AMFS vs Competitors** (`docs/vs-competitors.md`) — detailed comparison with Mem0, Cognee, Zep/Graphiti, and LangMem. Includes a feature matrix, per-competitor analysis (strengths + where AMFS differs), best-fit guidance tables, and a summary of AMFS's unique differentiators.
- Updates nav ordering across all doc sections to accommodate the two new top-level pages.
- Adds links to both pages from the docs homepage and README.

## Test plan

- [ ] Verify Jekyll builds cleanly with `bundle exec jekyll serve`
- [ ] Confirm both pages appear in the nav sidebar between "OSS vs Pro" and "Guides"
- [ ] Verify all internal links resolve correctly
- [ ] Review competitor claims for accuracy against current product docs