### PR TITLE
feat: add list_outcomes() adapter API and document Pro ML layer

### DIFF
--- a/docs/editions.md
+++ b/docs/editions.md
@@ -27,6 +27,7 @@ AMFS is split into two layers: a fully open-source core and a proprietary intell
 │                   AMFS Pro (Proprietary)              │
 │                                                      │
 │  Extraction · Critic · Distiller · Safety · Retrieval │
+│  Learned Ranking · Confidence Calibration · ML Export │
 │                                                      │
 ├──────────────────────────────────────────────────────┤
 │                   AMFS OSS (Apache 2.0)               │
@@ -64,6 +65,9 @@ AMFS is split into two layers: a fully open-source core and a proprietary intell
 | Memory distillation & bootstrap sets | — | Yes |
 | Memory safety validation | — | Yes |
 | Multi-strategy retrieval (semantic + BM25 + temporal) | — | Yes |
+| Learned retrieval ranking from outcome data | — | Yes |
+| Adaptive confidence calibration | — | Yes |
+| Training data export (SFT, DPO, reward model) | — | Yes |
 | Extended MCP server (Pro tools) | — | Yes |
 
 ---
@@ -182,16 +186,47 @@ Advanced search that goes beyond single-embedding lookup by combining multiple r
 
 Results are merged using **Reciprocal Rank Fusion (RRF)** to produce a single ranked list.
 
+### ML Layer
+
+The ML layer learns from your outcome data to make AMFS smarter over time. Three capabilities:
+
+**Learned Retrieval Ranking** — Trains a gradient-boosted model on your outcome history to predict which memories are most useful. Entries read before clean deploys are positive signals; entries read before incidents are negative. Once trained, the model automatically enhances `amfs_retrieve` results. Falls back to heuristic ranking when insufficient data (< 20 outcome-linked entries).
+
+Features extracted from each `MemoryEntry`:
+
+| Feature | Signal |
+|:--------|:-------|
+| Confidence | Current trust score |
+| Outcome count | How many outcomes validated this entry |
+| Version | How many times it's been updated |
+| Age | Time since creation (days and log-hours) |
+| Memory type | Fact, belief, or experience (one-hot) |
+| Provenance tier | Production-validated through manual (one-hot) |
+| Pattern refs | Whether cross-references exist and how many |
+
+**Adaptive Confidence Calibration** — Learns optimal outcome multipliers from historical data instead of the fixed defaults (P1 = 1.15, clean_deploy = 0.97). Analyzes how entries linked to each outcome type perform in subsequent outcomes, then computes calibrated multipliers per entity. Also estimates optimal decay half-life from the age distribution of actively-used entries.
+
+**Training Data Export** — Exports your decision traces as fine-tuning datasets. AMFS doesn't train your LLMs — it generates the structured training data from its outcome-linked causal chains:
+
+| Format | Description |
+|:-------|:------------|
+| **SFT** | Successful decision traces as (context, decision) examples |
+| **DPO** | Paired (chosen, rejected) from positive vs negative outcomes |
+| **Reward Model** | Entries labeled by outcome quality score |
+
 ### Pro MCP Server
 
-Extends the OSS MCP server with 4 additional tools:
+Extends the OSS MCP server with 7 additional tools:
 
 | Tool | Description |
 |:-----|:------------|
 | `amfs_critique` | Run the Memory Critic and get a quality report |
 | `amfs_distill` | Trigger distillation (prune, consolidate, or generate bootstrap set) |
 | `amfs_validate` | Validate a candidate memory before writing |
-| `amfs_retrieve` | Multi-strategy retrieval with RRF-merged results |
+| `amfs_retrieve` | Multi-strategy retrieval with RRF-merged results (+ learned ranking) |
+| `amfs_retrain` | Train the learned ranking model from outcome data |
+| `amfs_calibrate` | Learn optimal confidence multipliers from outcome history |
+| `amfs_export_training_data` | Export decision traces as SFT/DPO/reward model datasets |
 
 ---
 
@@ -206,12 +241,20 @@ The Pro layer wraps the OSS layer — it never replaces it. All Pro features rea
                              │
               ┌──────────────┴──────────────┐
               ▼                             ▼
-   ┌─────────────────┐          ┌─────────────────────┐
-   │  MCP Server OSS │          │  MCP Server Pro      │
-   │  (9 tools)      │          │  (9 + 4 tools)       │
-   └────────┬────────┘          └──────────┬──────────┘
-            │                              │
-            └──────────┬───────────────────┘
+   ┌─────────────────┐          ┌───────────────────────────┐
+   │  MCP Server OSS │          │  MCP Server Pro            │
+   │  (9 tools)      │          │  (9 + 7 tools)             │
+   └────────┬────────┘          │                           │
+            │                   │  Intelligence Layer:       │
+            │                   │  Critic · Distiller        │
+            │                   │  Safety · Retrieval        │
+            │                   │                           │
+            │                   │  ML Layer:                │
+            │                   │  Ranking · Calibration    │
+            │                   │  Training Data Export     │
+            │                   └─────────────┬─────────────┘
+            │                                 │
+            └──────────┬──────────────────────┘
                        ▼
             ┌─────────────────┐
             │   AgentMemory   │  ← Python SDK
@@ -224,7 +267,7 @@ The Pro layer wraps the OSS layer — it never replaces it. All Pro features rea
        Adapter    Adapter    Adapter
 ```
 
-The Pro MCP server imports and re-exports all 9 OSS tools, then adds the 4 Pro tools on top. You only run one server — either OSS or Pro.
+The Pro MCP server imports and re-exports all 9 OSS tools, then adds the 7 Pro tools on top. You only run one server — either OSS or Pro.
 
 ---
 
@@ -239,7 +282,10 @@ The Pro MCP server imports and re-exports all 9 OSS tools, then adds the 4 Pro t
 | Want LLM-driven extraction from conversations/logs | Pro |
 | Onboarding new agents with curated knowledge | Pro (bootstrap sets) |
 | Compliance or safety requirements for memory writes | Pro (safety validator) |
-| Advanced retrieval across large stores | Pro (multi-strategy) |
+| Advanced retrieval across large stores | Pro (multi-strategy + learned ranking) |
+| Want retrieval that improves as outcomes accumulate | Pro (ML layer) |
+| Need optimized confidence multipliers per entity | Pro (adaptive calibration) |
+| Want to fine-tune agents on your decision history | Pro (training data export) |
 
 ---
 

--- a/docs/guides/ml-layer.md
+++ b/docs/guides/ml-layer.md
@@ -1,0 +1,322 @@
+---
+title: ML Layer
+layout: default
+parent: Guides
+nav_order: 5
+description: "Use AMFS Pro's ML layer for learned ranking, confidence calibration, and training data export."
+---
+
+# ML Layer
+{: .no_toc }
+
+AMFS Pro's ML layer learns from your outcome data to make retrieval smarter, confidence scoring more accurate, and your agents' decision traces exportable as fine-tuning datasets.
+{: .fs-6 .fw-300 }
+
+{: .note }
+The ML layer is a Pro-only feature. The OSS layer captures all the data — reads, writes, outcomes, causal chains — and the ML layer learns from it.
+
+## Table of Contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Prerequisites
+
+- AMFS Pro MCP server running (see [MCP Setup](/amfs/guides/mcp/))
+- Outcome data in your memory store — the ML layer trains on `commit_outcome` history
+- At least 20 outcome-linked entries for learned ranking, 5 per outcome type for calibration
+
+---
+
+## Learned Retrieval Ranking
+
+### The Problem
+
+AMFS's multi-strategy retrieval uses fixed weights (semantic: 0.4, keyword: 0.2, temporal: 0.2, confidence: 0.2) merged via Reciprocal Rank Fusion. These work well as defaults, but they can't capture domain-specific patterns like "for this entity, recency matters more than confidence" or "entries from production agents are more reliable for deployment decisions."
+
+### How It Works
+
+The learned ranker trains a gradient-boosted model on your outcome history:
+
+- **Positive labels**: entries that were read before clean deploys
+- **Negative labels**: entries read before incidents, or entries never linked to any outcome
+
+The model learns which `MemoryEntry` features predict usefulness and integrates as an additional strategy in the retrieval pipeline. When trained, it automatically gets 30% weight in RRF fusion.
+
+### Via MCP
+
+```
+amfs_retrain()
+```
+
+Train from all available data. Returns metrics:
+
+```json
+{
+  "num_samples": 156,
+  "num_positive": 98,
+  "num_negative": 58,
+  "accuracy": 0.82,
+  "feature_importances": {
+    "confidence": 0.23,
+    "outcome_count": 0.18,
+    "log_age_hours": 0.15,
+    "tier_production_validated": 0.12,
+    "version": 0.09
+  },
+  "trained_at": "2026-04-01T14:30:00Z"
+}
+```
+
+Train for a specific entity:
+
+```
+amfs_retrain(entity_path="checkout-service")
+```
+
+### Via Python SDK
+
+```python
+from amfs_ml import LearnedRanker
+
+ranker = LearnedRanker(adapter, model_path=Path(".amfs/ml/ranker.pkl"))
+
+# Train
+metrics = ranker.train()
+print(f"Accuracy: {metrics.accuracy:.1%}")
+print(f"Top feature: {max(metrics.feature_importances, key=metrics.feature_importances.get)}")
+
+# Score entries
+scored = ranker.score(entries)
+for entry, probability in scored[:5]:
+    print(f"{entry.entry_key}: {probability:.3f}")
+```
+
+### Graceful Degradation
+
+With fewer than 20 training samples, the ranker falls back to confidence-based scoring. The `amfs_retrieve` tool works identically whether a model is trained or not — the learned strategy simply receives zero weight until training completes.
+
+---
+
+## Adaptive Confidence Calibration
+
+### The Problem
+
+AMFS uses fixed outcome multipliers:
+
+| Outcome | Default Multiplier |
+|:--------|:-------------------|
+| P1 Incident | × 1.15 |
+| P2 Incident | × 1.10 |
+| Regression | × 1.08 |
+| Clean Deploy | × 0.97 |
+
+These are reasonable defaults, but the actual signal strength of each outcome type varies by domain. A P1 incident in a payment service carries different weight than a P1 in a logging service.
+
+### How It Works
+
+The calibrator analyzes your outcome history to learn domain-specific multipliers:
+
+1. Groups outcomes by type
+2. For each type, measures how often causally-linked entries later appear in incidents vs clean deploys
+3. Adjusts multipliers based on observed signal strength
+4. Estimates optimal decay half-life from the age distribution of actively-used entries
+
+### Via MCP
+
+```
+amfs_calibrate()
+```
+
+Returns calibrated multipliers and analysis:
+
+```json
+{
+  "global_multipliers": {
+    "entity_path": null,
+    "multipliers": {
+      "p1_incident": 1.1845,
+      "p2_incident": 1.123,
+      "regression": 1.1016,
+      "clean_deploy": 0.9797
+    },
+    "decay_half_life_days": 21.5,
+    "num_outcomes_analyzed": 89
+  },
+  "entity_multipliers": [],
+  "total_outcomes": 89,
+  "total_entries": 234
+}
+```
+
+With per-entity overrides:
+
+```
+amfs_calibrate(per_entity=true)
+```
+
+Returns global multipliers plus entity-specific overrides for any entity with enough data (5+ outcomes per type).
+
+### Via Python SDK
+
+```python
+from amfs_ml import ConfidenceCalibrator
+
+calibrator = ConfidenceCalibrator(adapter)
+
+# Global calibration
+report = calibrator.calibrate()
+print(report.global_multipliers.multipliers)
+
+# Per-entity calibration
+report = calibrator.calibrate(per_entity=True)
+for em in report.entity_multipliers:
+    print(f"{em.entity_path}: {em.multipliers}")
+    if em.decay_half_life_days:
+        print(f"  Estimated decay: {em.decay_half_life_days} days")
+```
+
+---
+
+## Training Data Export
+
+### The Problem
+
+AMFS captures structured decision traces: what the agent read, what it decided, and what happened next. These traces are the exact data structure needed for fine-tuning — `(context, action, reward)` tuples — but they're locked inside the memory store.
+
+### How It Works
+
+The exporter queries historical outcomes and their causally-linked entries, then formats them as training datasets in three formats:
+
+**SFT (Supervised Fine-Tuning)** — Each successful decision trace becomes a training example. Context entries (what was read) pair with the decision entry (what was written). Only clean deploys produce SFT examples.
+
+**DPO (Direct Preference Optimization)** — Pairs a successful decision trace (chosen) with a failed one (rejected) for the same entity. The outcome replaces human preference annotation.
+
+**Reward Model** — Each entry is labeled with a score based on its outcome history: clean deploys score +1.0, P1 incidents score -1.0, with intermediate values for P2 and regressions.
+
+### Via MCP
+
+Export as SFT:
+
+```
+amfs_export_training_data(format="sft")
+```
+
+Export as DPO:
+
+```
+amfs_export_training_data(format="dpo")
+```
+
+Export as reward model data:
+
+```
+amfs_export_training_data(format="reward_model", entity_path="checkout-service")
+```
+
+Returns:
+
+```json
+{
+  "format": "reward_model",
+  "num_examples": 42,
+  "examples": [
+    {
+      "entry": {"entity_path": "checkout-service", "key": "retry-pattern", "...": "..."},
+      "label": 0.85,
+      "outcome_type": "clean_deploy",
+      "outcome_count": 7
+    }
+  ],
+  "exported_at": "2026-04-01T15:00:00Z"
+}
+```
+
+### Via Python SDK
+
+```python
+from amfs_ml import TrainingDataExporter
+from amfs_ml.export.exporter import ExportFormat
+
+exporter = TrainingDataExporter(adapter)
+
+# Export as structured result
+result = exporter.export(format=ExportFormat.DPO, entity_path="checkout-service")
+print(f"Generated {result.num_examples} DPO pairs")
+
+# Export as JSONL (ready for fine-tuning pipelines)
+jsonl = exporter.export_jsonl(format=ExportFormat.SFT, limit=1000)
+with open("training_data.jsonl", "w") as f:
+    f.write(jsonl)
+```
+
+### Integration with Fine-Tuning Pipelines
+
+AMFS generates the data; you bring the training infrastructure. The exported formats are compatible with common fine-tuning workflows:
+
+| Format | Compatible With |
+|:-------|:----------------|
+| SFT | OpenAI fine-tuning API, Hugging Face `SFTTrainer`, Axolotl |
+| DPO | TRL `DPOTrainer`, OpenRLHF |
+| Reward Model | TRL `RewardTrainer`, custom reward model training |
+
+---
+
+## Data Requirements
+
+The ML layer needs outcome data to learn from. Here's the minimum for each feature:
+
+| Feature | Minimum Data | Recommended |
+|:--------|:-------------|:------------|
+| Learned Ranking | 20 outcome-linked entries | 100+ entries with mixed outcomes |
+| Confidence Calibration | 5 outcomes per type | 20+ per type for reliable calibration |
+| Training Data Export (SFT) | 1 clean deploy with 2+ causal entries | Dozens of successful traces |
+| Training Data Export (DPO) | 1 positive + 1 negative outcome per entity | Multiple of each per entity |
+| Training Data Export (Reward) | 1 outcome-linked entry | Hundreds of entries for a useful dataset |
+
+{: .tip }
+The ML layer works best with Postgres, which persists outcome records. The filesystem adapter tracks outcome effects on entries but doesn't persist the outcome records themselves, limiting the data available for training.
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|:---------|:--------|:------------|
+| `AMFS_ML_MODEL_DIR` | `.amfs/ml` | Directory for persisted ML models (ranker pickle files) |
+
+---
+
+## How the Pieces Fit Together
+
+```
+Agents use AMFS normally:
+  read → decide → write → commit_outcome
+      │                        │
+      │                        ▼
+      │               Outcome data accumulates
+      │                        │
+      ▼                        ▼
+  amfs_retrieve ◄── amfs_retrain (learns which entries are useful)
+      │
+      │            amfs_calibrate (learns optimal multipliers)
+      │
+      │            amfs_export_training_data (generates fine-tuning datasets)
+      │                        │
+      ▼                        ▼
+  Better retrieval      Better agents (via your fine-tuning pipeline)
+```
+
+The feedback loop: agents produce outcome data by working normally. The ML layer consumes that data to improve retrieval and generate training datasets. Better retrieval leads to better decisions, which produce more outcome data.
+
+---
+
+## Next Steps
+
+- [MCP Setup](/amfs/guides/mcp/) — Configure the Pro MCP server
+- [Confidence & Outcomes](/amfs/concepts/confidence/) — Understand the outcome system that feeds the ML layer
+- [Context Graphs](/amfs/concepts/context-graphs/) — How decision traces are captured
+- [OSS vs Pro](/amfs/editions/) — Full feature comparison

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -415,3 +415,88 @@ amfs_explain(
 ```
 
 Returns the causal read chain for the current session: which entries were read and their details.
+
+---
+
+## Pro MCP Tools
+
+The following tools are available only with the AMFS Pro MCP server.
+
+### amfs_critique
+
+```
+amfs_critique() -> str (JSON)
+```
+
+Run the Memory Critic to detect toxic, stale, contradictory, uncalibrated, and orphaned entries.
+
+### amfs_distill
+
+```
+amfs_distill(
+    min_confidence: float = 0.3,
+    max_entries: int = 500,
+) -> str (JSON)
+```
+
+Generate a distilled memory set for bootstrapping new agents.
+
+### amfs_validate
+
+```
+amfs_validate(
+    entity_path: str,
+    key: str,
+    value: str,
+    confidence: float = 1.0,
+    memory_type: str = "fact",
+) -> str (JSON)
+```
+
+Validate a proposed memory write against safety checks (contradiction detection, temporal consistency, confidence thresholds).
+
+### amfs_retrieve
+
+```
+amfs_retrieve(
+    query: str,
+    entity_path: str | None = None,
+    min_confidence: float = 0.0,
+    limit: int = 10,
+) -> str (JSON)
+```
+
+Multi-strategy retrieval combining semantic, keyword, temporal, confidence, and learned ranking signals via Reciprocal Rank Fusion. When a learned model is trained (via `amfs_retrain`), it automatically contributes to ranking.
+
+### amfs_retrain
+
+```
+amfs_retrain(
+    entity_path: str | None = None,
+) -> str (JSON)
+```
+
+Train (or retrain) the learned ranking model from outcome data. Requires at least 20 outcome-linked entries. Returns training metrics including accuracy, sample counts, and feature importances. Once trained, the model enhances `amfs_retrieve` results automatically.
+
+### amfs_calibrate
+
+```
+amfs_calibrate(
+    entity_path: str | None = None,
+    per_entity: bool = false,
+) -> str (JSON)
+```
+
+Learn optimal confidence multipliers from historical outcome data. Returns calibrated multipliers and estimated decay half-life. Set `per_entity=true` to also produce entity-specific overrides.
+
+### amfs_export_training_data
+
+```
+amfs_export_training_data(
+    format: str = "sft",
+    entity_path: str | None = None,
+    limit: int = 10000,
+) -> str (JSON)
+```
+
+Export decision traces as fine-tuning datasets. Format options: `"sft"` (supervised fine-tuning), `"dpo"` (direct preference optimization), `"reward_model"` (reward model training). See the [ML Layer guide](/amfs/guides/ml-layer/) for format details.

--- a/docs/vs-competitors.md
+++ b/docs/vs-competitors.md
@@ -42,6 +42,8 @@ The AI memory space is evolving fast. Here's how AMFS compares to the leading al
 | Self-hosted / OSS | Apache 2.0 | OSS + Cloud | OSS + Cloud | OSS + Cloud | OSS |
 | Pluggable storage backends | Yes | No | No | No | No |
 | TTL / automatic expiry | Yes | No | No | Yes | No |
+| Learned ranking from outcomes | Pro | No | No | No | No |
+| Training data export (SFT/DPO) | Pro | No | No | No | No |
 
 ---
 
@@ -142,4 +144,6 @@ Across all competitors, AMFS's differentiators are:
 4. **Multi-agent native** — Provenance tracking, conflict detection (`LAST_WRITE_WINS` / `RAISE`), auto-causal linking, and per-agent identity are built in. Competitors are primarily designed for single-agent or single-user use.
 
 5. **Framework and infrastructure agnostic** — Works with any agent framework, any IDE via MCP, any storage backend via adapters. Not locked into one ecosystem.
+
+6. **ML that improves with use** (Pro) — Outcome data trains a learned ranking model that gets better at surfacing useful memories. Confidence multipliers calibrate to your domain. Decision traces export as fine-tuning datasets (SFT, DPO, reward model) so your agents themselves improve from their own history.
 

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -276,6 +276,61 @@ class PostgresAdapter(AdapterABC):
         return updated
 
     # ------------------------------------------------------------------
+    # list_outcomes
+    # ------------------------------------------------------------------
+
+    def list_outcomes(
+        self,
+        *,
+        entity_path: str | None = None,
+        since: datetime | None = None,
+        limit: int = 1000,
+    ) -> list["OutcomeRecord"]:
+        conditions = ["namespace = %s"]
+        params: list[Any] = [self._namespace]
+
+        if entity_path is not None:
+            conditions.append("EXISTS (SELECT 1 FROM unnest(causal_entry_keys) AS ek WHERE ek LIKE %s)")
+            params.append(f"{entity_path}/%")
+
+        if since is not None:
+            conditions.append("committed_at >= %s")
+            params.append(since)
+
+        where = " AND ".join(conditions)
+        query = f"""
+            SELECT outcome_ref, outcome_type, causal_confidence,
+                   committed_at, causal_entry_keys, agent_id
+            FROM amfs_outcomes
+            WHERE {where}
+            ORDER BY committed_at DESC
+            LIMIT %s
+        """
+        params.append(limit)
+
+        from amfs_core.models import OutcomeRecord, OutcomeType
+
+        with self._conn.cursor() as cur:
+            cur.execute(query, params)
+            rows = cur.fetchall()
+
+        results: list[OutcomeRecord] = []
+        for row in rows:
+            try:
+                otype = OutcomeType(row["outcome_type"])
+            except ValueError:
+                continue
+            results.append(OutcomeRecord(
+                outcome_ref=row["outcome_ref"],
+                outcome_type=otype,
+                causal_confidence=float(row["causal_confidence"]),
+                committed_at=row["committed_at"],
+                causal_entry_keys=row.get("causal_entry_keys") or [],
+                agent_id=row["agent_id"],
+            ))
+        return results
+
+    # ------------------------------------------------------------------
     # helpers
     # ------------------------------------------------------------------
 

--- a/packages/core/src/amfs_core/abc.py
+++ b/packages/core/src/amfs_core/abc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import Callable
 
 from amfs_core.embedder import EmbedderABC, cosine_similarity
@@ -85,6 +86,21 @@ class AdapterABC(ABC):
 
         Returns the list of entries whose confidence was updated.
         """
+
+    def list_outcomes(
+        self,
+        *,
+        entity_path: str | None = None,
+        since: datetime | None = None,
+        limit: int = 1000,
+    ) -> list[OutcomeRecord]:
+        """Return historical outcome records.
+
+        Used by the Pro ML layer for training ranking models and calibrating
+        confidence multipliers.  Default implementation returns an empty list;
+        adapters that persist outcomes (e.g. Postgres) should override.
+        """
+        return []
 
     def search(self, query: SearchQuery) -> list[MemoryEntry]:
         """Search entries with rich filters. Default: filter over list().


### PR DESCRIPTION
## Summary

- Add `list_outcomes()` method to `AdapterABC` with default empty-list return, enabling the Pro ML layer to query historical outcome data for training
- Implement `list_outcomes()` in `PostgresAdapter` querying the `amfs_outcomes` table with optional `entity_path` and `since` filters
- Update `docs/editions.md`: feature comparison table (3 new rows), new ML Layer subsection, Pro MCP Server table (4 → 7 tools), updated architecture diagram, expanded "When to Use Which" table
- Add new `docs/guides/ml-layer.md` guide covering learned ranking, confidence calibration, and training data export with MCP and Python SDK examples
- Add Pro MCP tool signatures to `docs/reference/api.md` (all 7 Pro tools documented)
- Add ML differentiators to `docs/vs-competitors.md` (feature matrix + unique section)

## OSS adapter change

`list_outcomes()` is a non-breaking addition with a default empty-list return. Filesystem adapter inherits the default. Postgres adapter queries the existing `amfs_outcomes` table. All 158 unit tests and 12 integration tests pass.

## Companion PR

The Pro ML layer implementation lives in [raia-live/amfs-internal feat/ml-layer](https://github.com/raia-live/amfs-internal/pull/new/feat/ml-layer) — new `amfs-ml` package with learned ranking, confidence calibration, and training data export.

## Test plan

- [x] All 158 OSS unit tests pass
- [x] All 12 filesystem adapter integration tests pass
- [ ] Verify docs render correctly on GitHub Pages
- [ ] Verify Postgres `list_outcomes()` with live database