### PR TITLE
feat: add artifact references to MemoryEntry

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -17,6 +17,7 @@ from amfs_core.abc import AdapterABC, WatchHandle
 from amfs_core.exceptions import AdapterError, VersionConflictError
 from amfs_core.models import (
     OUTCOME_MULTIPLIERS,
+    ArtifactRef,
     MemoryEntry,
     MemoryType,
     OutcomeRecord,
@@ -136,8 +137,9 @@ class PostgresAdapter(AdapterABC):
                     INSERT INTO amfs_memory_entries (
                         id, namespace, entity_path, key, version, value,
                         agent_id, session_id, written_at, pattern_refs,
-                        confidence, outcome_count, ttl_at, memory_type
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        confidence, outcome_count, ttl_at, memory_type,
+                        artifact_refs
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     """,
                     (
                         str(entry_id),
@@ -154,6 +156,7 @@ class PostgresAdapter(AdapterABC):
                         entry.outcome_count,
                         entry.ttl_at,
                         entry.memory_type.value,
+                        json.dumps([ref.model_dump(mode="json") for ref in entry.artifact_refs], default=str),
                     ),
                 )
 
@@ -358,6 +361,7 @@ class PostgresAdapter(AdapterABC):
             confidence=float(row["confidence"]),
             outcome_count=row["outcome_count"],
             ttl_at=row.get("ttl_at"),
+            artifact_refs=[ArtifactRef.model_validate(r) for r in (row.get("artifact_refs") or [])],
             memory_type=memory_type,
         )
 

--- a/packages/adapters/postgres/src/amfs_postgres/migrations/002_artifact_refs.sql
+++ b/packages/adapters/postgres/src/amfs_postgres/migrations/002_artifact_refs.sql
@@ -1,0 +1,2 @@
+-- Migration: Add artifact_refs column for external blob references
+ALTER TABLE amfs_memory_entries ADD COLUMN IF NOT EXISTS artifact_refs JSONB DEFAULT '[]';

--- a/packages/adapters/postgres/src/amfs_postgres/schema.sql
+++ b/packages/adapters/postgres/src/amfs_postgres/schema.sql
@@ -16,6 +16,7 @@ CREATE TABLE IF NOT EXISTS amfs_memory_entries (
     outcome_count INTEGER DEFAULT 0,
     ttl_at TIMESTAMPTZ,
     memory_type TEXT DEFAULT 'fact',
+    artifact_refs JSONB DEFAULT '[]',
     superseded_at TIMESTAMPTZ,
     CONSTRAINT uq_entry_version UNIQUE (namespace, entity_path, key, version)
 );
@@ -88,12 +89,14 @@ BEGIN
             INSERT INTO amfs_memory_entries (
                 namespace, entity_path, key, version, value,
                 agent_id, session_id, written_at, pattern_refs,
-                confidence, outcome_count, ttl_at, memory_type
+                confidence, outcome_count, ttl_at, memory_type,
+                artifact_refs
             ) VALUES (
                 cur.namespace, cur.entity_path, cur.key, cur.version + 1, cur.value,
                 cur.agent_id, cur.session_id, cur.written_at, cur.pattern_refs,
                 cur.confidence * multiplier * NEW.causal_confidence,
-                cur.outcome_count + 1, cur.ttl_at, cur.memory_type
+                cur.outcome_count + 1, cur.ttl_at, cur.memory_type,
+                cur.artifact_refs
             );
         END IF;
     END LOOP;

--- a/packages/core/src/amfs_core/engine.py
+++ b/packages/core/src/amfs_core/engine.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from amfs_core.abc import AdapterABC
-from amfs_core.models import MemoryEntry, MemoryType, Provenance
+from amfs_core.models import ArtifactRef, MemoryEntry, MemoryType, Provenance
 
 ExternalContext = dict[str, Any]
 
@@ -172,6 +172,7 @@ class CoWEngine:
         ttl_at: datetime | None = None,
         pattern_refs: list[str] | None = None,
         memory_type: MemoryType = MemoryType.FACT,
+        artifact_refs: list[ArtifactRef] | None = None,
     ) -> MemoryEntry:
         """Write a new version of a key with CoW semantics.
 
@@ -191,6 +192,7 @@ class CoWEngine:
             confidence=confidence,
             outcome_count=current.outcome_count if current else 0,
             ttl_at=ttl_at,
+            artifact_refs=artifact_refs or [],
             memory_type=memory_type,
         )
 

--- a/packages/core/src/amfs_core/models.py
+++ b/packages/core/src/amfs_core/models.py
@@ -71,6 +71,14 @@ class Provenance(BaseModel):
     pattern_refs: list[str] = Field(default_factory=list)
 
 
+class ArtifactRef(BaseModel):
+    """Reference to an external artifact (blob, file, model checkpoint, etc.)."""
+    uri: str  # s3://bucket/path, file:///path, https://...
+    media_type: str | None = None  # e.g. "application/json", "model/onnx"
+    label: str | None = None  # human-readable description
+    size_bytes: int | None = None
+
+
 class MemoryEntry(BaseModel):
     """A single versioned memory entry within the AMFS namespace."""
 
@@ -84,6 +92,7 @@ class MemoryEntry(BaseModel):
     outcome_count: int = 0
     ttl_at: datetime | None = None
     embedding: list[float] | None = None
+    artifact_refs: list[ArtifactRef] = Field(default_factory=list)
     memory_type: MemoryType = MemoryType.FACT
 
     def effective_confidence(self, *, decay_half_life_days: float | None = None) -> float:

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -145,6 +145,7 @@ def amfs_write(
     confidence: float = 1.0,
     pattern_refs: list[str] | None = None,
     memory_type: str = "fact",
+    artifact_refs: list[dict[str, Any]] | None = None,
 ) -> str:
     """Write a memory entry with automatic provenance tracking.
 
@@ -159,9 +160,14 @@ def amfs_write(
         confidence: How confident you are (0.0-1.0, default 1.0)
         pattern_refs: Optional list of related pattern keys for cross-referencing
         memory_type: One of "fact" (default), "belief", or "experience"
+        artifact_refs: Optional list of external artifact references. Each dict
+            should have "uri" (required), and optionally "media_type", "label",
+            "size_bytes".
 
     Example: amfs_write("checkout-service", "retry-pattern", '{"max_retries": 3}')
     """
+    from amfs_core.models import ArtifactRef
+
     mem = _get_memory()
 
     parsed_value: Any = value
@@ -173,6 +179,10 @@ def amfs_write(
     type_map = {"fact": MemoryType.FACT, "belief": MemoryType.BELIEF, "experience": MemoryType.EXPERIENCE}
     mt = type_map.get(memory_type.lower(), MemoryType.FACT)
 
+    parsed_artifact_refs = [
+        ArtifactRef.model_validate(r) for r in (artifact_refs or [])
+    ]
+
     entry = mem.write(
         entity_path,
         key,
@@ -180,6 +190,7 @@ def amfs_write(
         confidence=confidence,
         pattern_refs=pattern_refs,
         memory_type=mt,
+        artifact_refs=parsed_artifact_refs,
     )
     return json.dumps(_serialize_entry(entry), default=str)
 

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -149,6 +149,7 @@ class AgentMemory:
         ttl_at: datetime | None = None,
         pattern_refs: list[str] | None = None,
         memory_type: MemoryType = MemoryType.FACT,
+        artifact_refs: list | None = None,
     ) -> MemoryEntry:
         """Write a new version of a key with automatic provenance.
 
@@ -195,6 +196,7 @@ class AgentMemory:
             ttl_at=ttl_at,
             pattern_refs=pattern_refs,
             memory_type=memory_type,
+            artifact_refs=artifact_refs,
         )
 
         if self._embedder is not None:

--- a/packages/sdk-typescript/src/models.ts
+++ b/packages/sdk-typescript/src/models.ts
@@ -23,6 +23,13 @@ export interface Provenance {
   patternRefs: string[];
 }
 
+export interface ArtifactRef {
+  uri: string;
+  mediaType?: string | null;
+  label?: string | null;
+  sizeBytes?: number | null;
+}
+
 export interface MemoryEntry {
   amfsVersion: string;
   entityPath: string;
@@ -33,6 +40,7 @@ export interface MemoryEntry {
   confidence: number;
   outcomeCount: number;
   ttlAt: string | null;
+  artifactRefs?: ArtifactRef[];
 }
 
 export interface OutcomeRecord {


### PR DESCRIPTION
## Summary
- Add `ArtifactRef` model for linking memory entries to external blobs (S3 objects, files, URLs) with optional `media_type`, `label`, and `size_bytes`
- Add `artifact_refs` field to `MemoryEntry` and propagate through the SDK, engine, Postgres adapter (with migration), MCP server, and TypeScript SDK
- Enables agents to associate binary artifacts (model weights, datasets, logs, screenshots) with structured memory entries

## Test plan
- [ ] Verify `artifact_refs` round-trips through write → read for filesystem adapter
- [ ] Verify `artifact_refs` round-trips through write → read for Postgres adapter
- [ ] Run Postgres migration `002_artifact_refs.sql` on a fresh database
- [ ] Verify MCP `amfs_write` accepts `artifact_refs` parameter
- [ ] Verify TypeScript SDK types include `ArtifactRef` interface