### PR TITLE
feat: add HTTP/REST API server with SSE and API key auth

### DIFF
--- a/packages/http-server/pyproject.toml
+++ b/packages/http-server/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "amfs-http-server"
+version = "0.1.0"
+description = "AMFS HTTP/REST API server with SSE support"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+dependencies = [
+    "amfs",
+    "amfs-core",
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.32",
+    "sse-starlette>=2.0",
+]
+
+[project.scripts]
+amfs-http = "amfs_http.server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/amfs_http"]

--- a/packages/http-server/src/amfs_http/__init__.py
+++ b/packages/http-server/src/amfs_http/__init__.py
@@ -1,0 +1,1 @@
+"""AMFS HTTP/REST API server — universal access to Agent Memory over HTTP."""

--- a/packages/http-server/src/amfs_http/auth.py
+++ b/packages/http-server/src/amfs_http/auth.py
@@ -1,0 +1,33 @@
+"""API key authentication for the AMFS HTTP server."""
+from __future__ import annotations
+
+import os
+import secrets
+
+from fastapi import HTTPException, Security, status
+from fastapi.security import APIKeyHeader
+
+API_KEY_HEADER = APIKeyHeader(name="X-AMFS-API-Key", auto_error=False)
+
+
+def get_api_keys() -> set[str]:
+    raw = os.environ.get("AMFS_API_KEYS", "")
+    if not raw:
+        return set()
+    return {k.strip() for k in raw.split(",") if k.strip()}
+
+
+def generate_api_key() -> str:
+    return f"amfs_{secrets.token_urlsafe(32)}"
+
+
+async def verify_api_key(api_key: str | None = Security(API_KEY_HEADER)) -> str | None:
+    valid_keys = get_api_keys()
+    if not valid_keys:
+        return None
+    if api_key is None or api_key not in valid_keys:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing API key",
+        )
+    return api_key

--- a/packages/http-server/src/amfs_http/models.py
+++ b/packages/http-server/src/amfs_http/models.py
@@ -1,0 +1,41 @@
+"""Request and response models for the AMFS HTTP API."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class WriteRequest(BaseModel):
+    entity_path: str
+    key: str
+    value: Any = None
+    confidence: float = 1.0
+    pattern_refs: list[str] = Field(default_factory=list)
+    memory_type: str = "fact"
+
+
+class OutcomeRequest(BaseModel):
+    outcome_ref: str
+    outcome_type: str
+    causal_entry_keys: list[str] | None = None
+    causal_confidence: float = 1.0
+
+
+class SearchRequest(BaseModel):
+    query: str | None = None
+    entity_path: str | None = None
+    min_confidence: float = 0.0
+    max_confidence: float | None = None
+    agent_id: str | None = None
+    since: datetime | None = None
+    pattern_ref: str | None = None
+    limit: int = 100
+    sort_by: str = "confidence"
+
+
+class ContextRequest(BaseModel):
+    label: str
+    summary: str
+    source: str | None = None

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -1,0 +1,402 @@
+"""AMFS HTTP/REST API server — universal access to Agent Memory over HTTP.
+
+Provides a FastAPI application exposing the full AMFS API as REST endpoints
+with SSE streaming for real-time watch notifications and optional API key
+authentication.
+
+Run directly::
+
+    amfs-http                          # default 0.0.0.0:8741
+    amfs-http --port 9000 --host 127.0.0.1
+    amfs-http --reload                 # development mode
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from datetime import datetime
+from typing import Any
+
+import uvicorn
+from fastapi import Depends, FastAPI, Query
+from fastapi.middleware.cors import CORSMiddleware
+from sse_starlette.sse import EventSourceResponse
+
+from amfs import AgentMemory, MemoryType, OutcomeType
+from amfs.config import load_config_or_default
+from amfs_core.models import AMFSConfig, LayerConfig, MemoryEntry
+
+from amfs_http.auth import verify_api_key
+from amfs_http.models import ContextRequest, OutcomeRequest, SearchRequest, WriteRequest
+from amfs_http.sse import SSEManager
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(
+    title="AMFS HTTP API",
+    description="Agent Memory File System — REST API with SSE support",
+    version="0.1.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+_memory: AgentMemory | None = None
+_sse_manager = SSEManager()
+
+
+def _get_memory() -> AgentMemory:
+    """Lazily initialise the shared AgentMemory singleton."""
+    global _memory
+    if _memory is not None:
+        return _memory
+
+    agent_id = os.environ.get("AMFS_AGENT_ID", "http-server")
+    config = _resolve_config()
+
+    ttl_interval_str = os.environ.get("AMFS_TTL_SWEEP_INTERVAL")
+    ttl_sweep_interval = float(ttl_interval_str) if ttl_interval_str else 300.0
+
+    logger.info("AMFS HTTP server starting — agent_id=%s", agent_id)
+    _memory = AgentMemory(
+        agent_id=agent_id,
+        config_path=None,
+        adapter=None,
+        ttl_sweep_interval=ttl_sweep_interval,
+    )
+
+    _memory._config = config
+    from amfs.factory import create_adapter_from_config
+
+    adapter = create_adapter_from_config(config)
+    _memory._adapter = adapter
+    _memory._engine._adapter = adapter
+    _memory._propagator._adapter = adapter
+
+    return _memory
+
+
+def _resolve_config() -> AMFSConfig:
+    """Resolve AMFS configuration from environment or config files.
+
+    Priority:
+    1. AMFS_POSTGRES_DSN env var -> Postgres adapter
+    2. AMFS_DATA_DIR env var -> filesystem adapter at that path
+    3. amfs.yaml discovery -> load from file
+    4. Default -> filesystem adapter at .amfs/
+    """
+    postgres_dsn = os.environ.get("AMFS_POSTGRES_DSN")
+    if postgres_dsn:
+        return AMFSConfig(
+            namespace="default",
+            layers={
+                "primary": LayerConfig(
+                    adapter="postgres",
+                    options={"dsn": postgres_dsn},
+                )
+            },
+        )
+
+    data_dir = os.environ.get("AMFS_DATA_DIR")
+    if data_dir:
+        return AMFSConfig(
+            namespace="default",
+            layers={
+                "primary": LayerConfig(
+                    adapter="filesystem",
+                    options={"root": data_dir},
+                )
+            },
+        )
+
+    return load_config_or_default()
+
+
+def _entry_to_response(entry: MemoryEntry) -> dict[str, Any]:
+    """Convert a MemoryEntry to a JSON-safe dict, stripping embeddings."""
+    data = entry.model_dump(mode="json")
+    data.pop("embedding", None)
+    return data
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Health
+# ──────────────────────────────────────────────────────────────────────
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Entries
+# ──────────────────────────────────────────────────────────────────────
+
+
+@app.get("/api/v1/entries/{entity_path:path}/{key}")
+async def read_entry(
+    entity_path: str,
+    key: str,
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    mem = _get_memory()
+    entry = mem.read(entity_path, key)
+    if entry is None:
+        return {"status": "not_found", "entity_path": entity_path, "key": key}
+    return _entry_to_response(entry)
+
+
+@app.post("/api/v1/entries")
+async def write_entry(
+    req: WriteRequest,
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    mem = _get_memory()
+
+    type_map = {
+        "fact": MemoryType.FACT,
+        "belief": MemoryType.BELIEF,
+        "experience": MemoryType.EXPERIENCE,
+    }
+    mt = type_map.get(req.memory_type.lower(), MemoryType.FACT)
+
+    entry = mem.write(
+        req.entity_path,
+        req.key,
+        req.value,
+        confidence=req.confidence,
+        pattern_refs=req.pattern_refs or None,
+        memory_type=mt,
+    )
+    _sse_manager.broadcast(entry)
+    return _entry_to_response(entry)
+
+
+@app.get("/api/v1/entries")
+async def list_entries(
+    entity_path: str | None = Query(None),
+    _auth: str | None = Depends(verify_api_key),
+) -> list[dict[str, Any]]:
+    mem = _get_memory()
+    entries = mem.list(entity_path)
+    return [_entry_to_response(e) for e in entries]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Search
+# ──────────────────────────────────────────────────────────────────────
+
+
+@app.post("/api/v1/search")
+async def search_entries(
+    req: SearchRequest,
+    _auth: str | None = Depends(verify_api_key),
+) -> list[dict[str, Any]]:
+    mem = _get_memory()
+    results = mem.search(
+        entity_path=req.entity_path,
+        min_confidence=req.min_confidence,
+        agent_id=req.agent_id,
+        sort_by=req.sort_by,
+        limit=req.limit,
+    )
+
+    if req.query:
+        query_lower = req.query.lower()
+        results = [
+            e
+            for e in results
+            if query_lower in e.key.lower()
+            or query_lower in str(e.value).lower()
+            or query_lower in e.entity_path.lower()
+        ]
+
+    return [_entry_to_response(e) for e in results]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Stats
+# ──────────────────────────────────────────────────────────────────────
+
+
+@app.get("/api/v1/stats")
+async def get_stats(
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    mem = _get_memory()
+    stats = mem.stats()
+    return json.loads(json.dumps(stats.model_dump(mode="json"), default=str))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# History
+# ──────────────────────────────────────────────────────────────────────
+
+
+@app.get("/api/v1/history/{entity_path:path}/{key}")
+async def get_history(
+    entity_path: str,
+    key: str,
+    since: str | None = Query(None),
+    until: str | None = Query(None),
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    mem = _get_memory()
+    since_dt = datetime.fromisoformat(since) if since else None
+    until_dt = datetime.fromisoformat(until) if until else None
+
+    versions = mem.history(entity_path, key, since=since_dt, until=until_dt)
+    return {
+        "entity_path": entity_path,
+        "key": key,
+        "version_count": len(versions),
+        "versions": [_entry_to_response(e) for e in versions],
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Outcomes
+# ──────────────────────────────────────────────────────────────────────
+
+_OUTCOME_TYPE_MAP = {
+    "p1_incident": OutcomeType.P1_INCIDENT,
+    "p2_incident": OutcomeType.P2_INCIDENT,
+    "regression": OutcomeType.REGRESSION,
+    "clean_deploy": OutcomeType.CLEAN_DEPLOY,
+}
+
+
+@app.post("/api/v1/outcomes")
+async def commit_outcome(
+    req: OutcomeRequest,
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    mem = _get_memory()
+
+    otype = _OUTCOME_TYPE_MAP.get(req.outcome_type.lower())
+    if otype is None:
+        valid = ", ".join(_OUTCOME_TYPE_MAP.keys())
+        return {"error": f"Invalid outcome_type '{req.outcome_type}'. Must be one of: {valid}"}
+
+    entries = mem.commit_outcome(
+        req.outcome_ref,
+        otype,
+        causal_entry_keys=req.causal_entry_keys,
+        causal_confidence=req.causal_confidence,
+    )
+    return {
+        "outcome_ref": req.outcome_ref,
+        "outcome_type": req.outcome_type,
+        "affected_entries": len(entries),
+        "entries": [_entry_to_response(e) for e in entries],
+    }
+
+
+@app.get("/api/v1/outcomes")
+async def list_outcomes(
+    entity_path: str | None = Query(None),
+    since: str | None = Query(None),
+    limit: int = Query(100),
+    _auth: str | None = Depends(verify_api_key),
+) -> list[dict[str, Any]]:
+    mem = _get_memory()
+    since_dt = datetime.fromisoformat(since) if since else None
+    records = mem._adapter.list_outcomes(
+        entity_path=entity_path,
+        since=since_dt,
+        limit=limit,
+    )
+    return [r.model_dump(mode="json") for r in records]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Context & Explain
+# ──────────────────────────────────────────────────────────────────────
+
+
+@app.post("/api/v1/context")
+async def record_context(
+    req: ContextRequest,
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    mem = _get_memory()
+    mem.record_context(req.label, req.summary, source=req.source)
+    return {"recorded": req.label, "source": req.source}
+
+
+@app.get("/api/v1/explain")
+async def explain(
+    outcome_ref: str | None = Query(None),
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    mem = _get_memory()
+    return mem.explain(outcome_ref)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# SSE Stream
+# ──────────────────────────────────────────────────────────────────────
+
+
+@app.get("/api/v1/stream")
+async def stream(
+    entity_path: str = Query("*"),
+    _auth: str | None = Depends(verify_api_key),
+) -> EventSourceResponse:
+    return EventSourceResponse(_sse_manager.event_generator(entity_path))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# CLI Entry Point
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="amfs-http",
+        description="AMFS HTTP/REST API server with SSE support",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("AMFS_HTTP_HOST", "0.0.0.0"),
+        help="Host to bind (default: 0.0.0.0)",
+    )
+    parser.add_argument(
+        "--port",
+        "-p",
+        type=int,
+        default=int(os.environ.get("AMFS_HTTP_PORT", "8741")),
+        help="Port to bind (default: 8741)",
+    )
+    parser.add_argument(
+        "--reload",
+        action="store_true",
+        default=False,
+        help="Enable auto-reload for development",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run the AMFS HTTP server via uvicorn."""
+    args = _parse_args()
+    logger.info("Starting AMFS HTTP server on %s:%d", args.host, args.port)
+    uvicorn.run(
+        "amfs_http.server:app",
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/http-server/src/amfs_http/sse.py
+++ b/packages/http-server/src/amfs_http/sse.py
@@ -1,0 +1,56 @@
+"""Server-Sent Events for real-time AMFS watch notifications."""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from amfs_core.models import MemoryEntry
+
+logger = logging.getLogger(__name__)
+
+
+class SSEManager:
+    def __init__(self) -> None:
+        self._subscribers: dict[str, list[asyncio.Queue[dict[str, Any]]]] = {}
+
+    def subscribe(self, entity_path: str = "*") -> asyncio.Queue[dict[str, Any]]:
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        if entity_path not in self._subscribers:
+            self._subscribers[entity_path] = []
+        self._subscribers[entity_path].append(queue)
+        return queue
+
+    def unsubscribe(self, entity_path: str, queue: asyncio.Queue[dict[str, Any]]) -> None:
+        subs = self._subscribers.get(entity_path, [])
+        if queue in subs:
+            subs.remove(queue)
+
+    def broadcast(self, entry: MemoryEntry) -> None:
+        data = entry.model_dump(mode="json")
+        data.pop("embedding", None)
+        event = {"type": "write", "entry": data}
+        for pattern, queues in self._subscribers.items():
+            if (
+                pattern == "*"
+                or entry.entity_path == pattern
+                or entry.entity_path.startswith(pattern + "/")
+            ):
+                for queue in queues:
+                    try:
+                        queue.put_nowait(event)
+                    except asyncio.QueueFull:
+                        logger.debug("SSE queue full, dropping event")
+
+    async def event_generator(self, entity_path: str = "*"):
+        queue = self.subscribe(entity_path)
+        try:
+            while True:
+                event = await queue.get()
+                yield {
+                    "event": event["type"],
+                    "data": json.dumps(event["entry"], default=str),
+                }
+        finally:
+            self.unsubscribe(entity_path, queue)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ members = [
     "packages/sdk-python",
     "packages/cli",
     "packages/mcp-server",
+    "packages/http-server",
 ]
 
 [tool.pytest.ini_options]
@@ -43,6 +44,7 @@ amfs-adapter-filesystem = { workspace = true }
 amfs = { workspace = true }
 amfs-cli = { workspace = true }
 amfs-mcp-server = { workspace = true }
+amfs-http-server = { workspace = true }
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
## Summary
- New `amfs-http-server` package with a FastAPI application exposing 12 REST endpoints for all AgentMemory operations
- SSE endpoint (`/api/v1/stream`) for real-time memory event streaming
- API key authentication via `X-AMFS-API-Key` header (configurable via `AMFS_API_KEYS` env var)
- CORS middleware for browser-based dashboards
- CLI entry point: `amfs-http --host 0.0.0.0 --port 8080`
- OpenAPI docs available at `/docs`

## Test plan
- [ ] Verify all 12 endpoints return correct responses
- [ ] Verify SSE stream receives events on write and outcome
- [ ] Verify API key auth rejects unauthorized requests
- [ ] Verify CORS headers are set correctly
- [ ] Test with filesystem, Postgres, and S3 backends
- [ ] Verify `/health` endpoint for container health checks