### PR TITLE
feat(sdk-ts): TypeScript SDK parity + updated editions doc

### DIFF
--- a/docs/editions.md
+++ b/docs/editions.md
@@ -9,7 +9,7 @@ permalink: /editions/
 # OSS vs Pro
 {: .no_toc }
 
-AMFS is split into two layers: a fully open-source core and a proprietary intelligence layer. The OSS layer gives you everything you need to build production-ready agent memory. The Pro layer adds LLM-powered automation on top.
+AMFS is split into two layers: a fully open-source core and a proprietary Pro layer. The OSS layer gives you everything you need to build production-ready agent memory. Pro adds multi-tenant SaaS infrastructure, persistent decision traces, LLM-powered intelligence, and an enterprise dashboard.
 {: .fs-6 .fw-300 }
 
 ## Table of Contents
@@ -23,20 +23,38 @@ AMFS is split into two layers: a fully open-source core and a proprietary intell
 ## At a Glance
 
 ```
-┌──────────────────────────────────────────────────────┐
-│                   AMFS Pro (Proprietary)              │
-│                                                      │
-│  Extraction · Critic · Distiller · Safety · Retrieval │
-│  Learned Ranking · Confidence Calibration · ML Export │
-│                                                      │
-├──────────────────────────────────────────────────────┤
-│                   AMFS OSS (Apache 2.0)               │
-│                                                      │
-│  CoW Engine · Memory Types · Provenance Tiers         │
-│  Temporal Queries · Causal Explainability             │
-│  Adapters (Filesystem, Postgres) · MCP Server         │
-│  Python SDK · TypeScript SDK · CLI                    │
-└──────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────┐
+│                    AMFS Pro (Proprietary)                  │
+│                                                          │
+│  ┌─ Multi-Tenant SaaS ─────────────────────────────────┐ │
+│  │  Accounts · RBAC · Scoped API Keys · Audit · Quotas │ │
+│  │  Row-Level Security · OAuth/OIDC · Rate Limiting     │ │
+│  └──────────────────────────────────────────────────────┘ │
+│                                                          │
+│  ┌─ Persistent Decision Traces ─────────────────────────┐ │
+│  │  Durable Causal Chains · Historical explain()        │ │
+│  │  Precedent Search · Cross-Session Trace Queries      │ │
+│  └──────────────────────────────────────────────────────┘ │
+│                                                          │
+│  ┌─ Intelligence Layer ─────────────────────────────────┐ │
+│  │  Extraction · Critic · Distiller · Safety · Retrieval │ │
+│  │  Learned Ranking · Confidence Calibration · ML Export │ │
+│  └──────────────────────────────────────────────────────┘ │
+│                                                          │
+│  ┌─ Dashboard ──────────────────────────────────────────┐ │
+│  │  Memory Explorer · Trace Visualizer · Team Mgmt      │ │
+│  │  API Key Console · Audit Viewer · Usage Analytics    │ │
+│  └──────────────────────────────────────────────────────┘ │
+│                                                          │
+├──────────────────────────────────────────────────────────┤
+│                    AMFS OSS (Apache 2.0)                  │
+│                                                          │
+│  CoW Engine · Memory Types · Provenance Tiers             │
+│  Temporal Queries · Session-Level Causal Explainability   │
+│  Adapters (Filesystem, Postgres, S3) · HTTP/REST API      │
+│  MCP Server · Python SDK · TypeScript SDK · CLI           │
+│  Docker + Helm Charts                                     │
+└──────────────────────────────────────────────────────────┘
 ```
 
 ---
@@ -45,21 +63,40 @@ AMFS is split into two layers: a fully open-source core and a proprietary intell
 
 | Capability | OSS | Pro |
 |:-----------|:---:|:---:|
+| **Core Memory Primitives** | | |
 | Copy-on-Write versioning | Yes | Yes |
 | Confidence scoring with outcome back-propagation | Yes | Yes |
 | Memory types (fact, belief, experience) | Yes | Yes |
 | Type-specific confidence decay | Yes | Yes |
 | Provenance tiers (production-validated → manual) | Yes | Yes |
 | Temporal queries (`history`) | Yes | Yes |
-| Causal explainability (`explain`) | Yes | Yes |
+| Session-level causal explainability (`explain`) | Yes | Yes |
+| **Adapters & Infrastructure** | | |
 | Filesystem adapter | Yes | Yes |
 | Postgres adapter (triggers, LISTEN/NOTIFY) | Yes | Yes |
+| S3 adapter | Yes | Yes |
+| HTTP/REST API server | Yes | Yes |
+| Docker + Docker Compose + Helm charts | Yes | Yes |
 | MCP server (9 tools) | Yes | Yes |
-| Python SDK | Yes | Yes |
-| TypeScript SDK | Yes | Yes |
+| **SDKs & Clients** | | |
+| Python SDK (full parity) | Yes | Yes |
+| TypeScript SDK (full parity) | Yes | Yes |
 | CLI tools | Yes | Yes |
 | Framework integrations (CrewAI, LangGraph, etc.) | Yes | Yes |
 | Bundled lightweight embedder | Yes | Yes |
+| **Multi-Tenant SaaS (Pro)** | | |
+| Account-level tenant isolation (RLS) | — | Yes |
+| RBAC (Admin, Developer, User) | — | Yes |
+| Scoped API keys with entity-path permissions | — | Yes |
+| OAuth 2.0 / OIDC for dashboard users | — | Yes |
+| Append-only audit logging | — | Yes |
+| Usage quotas + rate limiting | — | Yes |
+| **Persistent Decision Traces (Pro)** | | |
+| Durable causal chains across sessions | — | Yes |
+| Historical `explain(outcome_ref)` | — | Yes |
+| `search_traces` / precedent search API | — | Yes |
+| Cross-agent, cross-session trace queries | — | Yes |
+| **Intelligence Layer (Pro)** | | |
 | LLM-driven memory extraction | — | Yes |
 | Automated memory critic | — | Yes |
 | Memory distillation & bootstrap sets | — | Yes |
@@ -68,6 +105,12 @@ AMFS is split into two layers: a fully open-source core and a proprietary intell
 | Learned retrieval ranking from outcome data | — | Yes |
 | Adaptive confidence calibration | — | Yes |
 | Training data export (SFT, DPO, reward model) | — | Yes |
+| **Dashboard (Pro)** | | |
+| Memory explorer with graph visualization | — | Yes |
+| Decision trace visualizer | — | Yes |
+| Team & API key management | — | Yes |
+| Audit log viewer | — | Yes |
+| Usage analytics & billing | — | Yes |
 | Extended MCP server (Pro tools) | — | Yes |
 
 ---
@@ -81,12 +124,14 @@ The open-source layer ([github.com/raia-live/amfs](https://github.com/raia-live/
 | Package | Description |
 |:--------|:------------|
 | `amfs-core` | CoW engine, models (`MemoryEntry`, `MemoryType`, `ProvenanceTier`), read tracking, causal tagging, default embedder |
-| `amfs` (SDK) | `AgentMemory` class — `read`, `write`, `list`, `search`, `history`, `explain`, `commit_outcome` |
+| `amfs` (SDK) | `AgentMemory` class — `read`, `write`, `list`, `search`, `history`, `explain`, `commit_outcome`, `record_context` |
 | `amfs-adapter-filesystem` | JSON-file-based adapter for local development |
 | `amfs-adapter-postgres` | PostgreSQL adapter with PL/pgSQL triggers for outcome propagation and `LISTEN/NOTIFY` for watch |
+| `amfs-adapter-s3` | Amazon S3 / S3-compatible adapter for cloud-native storage |
+| `amfs-http-server` | REST API server (FastAPI/Uvicorn) for remote access |
 | `amfs-mcp-server` | MCP server exposing 9 tools: `amfs_read`, `amfs_write`, `amfs_search`, `amfs_list`, `amfs_stats`, `amfs_commit_outcome`, `amfs_record_context`, `amfs_history`, `amfs_explain` |
 | `amfs-cli` | Terminal tools for inspecting, diffing, snapshotting, and restoring memory |
-| `@amfs/sdk` | TypeScript SDK |
+| `@amfs/sdk` | TypeScript SDK (full parity with Python: ReadTracker, search, stats, history, explain, recordContext) |
 
 ### Key Primitives
 
@@ -128,91 +173,75 @@ chain = mem.explain()
 
 ## Pro Layer — What's Added
 
-The Pro layer builds an intelligence layer on top of the OSS primitives. It adds LLM-powered automation for extraction, quality control, compaction, safety, and retrieval.
+The Pro layer wraps the OSS layer — it never replaces it. All Pro features read from and write to the same memory store using the same adapters and SDK.
 
-### Extraction
+### Multi-Tenant SaaS Foundation
 
-Turns raw text (conversations, logs, documents) into structured memory operations using LLMs. Instead of blind writes, the extractor classifies each piece of information as an **ADD**, **UPDATE**, **DELETE**, or **NOOP** operation.
+The foundation for running AMFS as a hosted service. Every API request is authenticated, authorized, scoped, and audited.
+
+**Account Isolation** — Hard isolation between tenants using Postgres Row-Level Security. Company A cannot see Company B's data, even if there's a bug in application code.
+
+**RBAC** — Three roles with graduated permissions:
+
+| Role | Can do |
+|:-----|:-------|
+| **Admin** | Full account management, user invites, key management, all memory ops |
+| **Developer** | Create/revoke API keys, read/write memory, view audit logs |
+| **User** | Read memory within scoped paths |
+
+**Scoped API Keys** — Each agent/tool gets its own key with entity-path permissions:
 
 ```
-Raw input → LLM Extractor → [ADD "svc/pattern-retry", UPDATE "svc/config", NOOP, ...]
+amfs_sk_live_...  →  checkout-service/**  [READ_WRITE]
+                     shared/patterns/*     [READ]
 ```
 
-Supports multiple LLM backends (OpenAI, Anthropic) with a common `ExtractorABC` interface.
+Agents can only access memory within their permitted scope — this is **permissioned inference** enforced at the database level.
 
-### Memory Critic
+**Audit Logging** — Every state-changing operation is recorded in an append-only audit log with actor, action, resource, and IP address.
 
-An automated quality analyzer that scans the memory store and detects problematic entries. Runs offline or on a schedule to keep the store healthy.
+**Usage Quotas** — Tiered limits on entries, API keys, users, and decision traces. Hard-capped at the database level, with external billing integration (Stripe, etc.) for metering.
 
-Detects five issue classes:
+### Persistent Decision Traces
 
-| Issue | Description |
-|:------|:------------|
-| **Toxic** | Entries with repeated negative outcome correlations |
-| **Stale** | Entries that haven't been read or validated in a long time |
-| **Contradictory** | Entries that conflict with other entries in the same entity |
-| **Uncalibrated** | Entries whose confidence doesn't match their outcome history |
-| **Orphaned** | Entries with no reads, no outcomes, and no cross-references |
+The OSS `explain()` only works within the active session. Pro persists the full causal chain — which AMFS entries were read, which external tools were consulted, what decision was made, and what outcome occurred — so it's queryable forever.
 
-Produces a `CriticReport` with prioritized recommendations.
+```python
+from amfs_traces import TraceRecorder, InMemoryTraceStore
 
-### Memory Distiller
+recorder = TraceRecorder(memory, store, account_id=acct.id)
 
-Compacts large memory stores into smaller, higher-quality sets. Three operations:
+# Reads and external contexts are tracked automatically
+recorder.memory.read("svc", "retry-pattern")
+recorder.memory.record_context("pagerduty", "3 SEV-1", source="PagerDuty API")
 
-- **Pruning** — Removes low-value entries (orphaned, expired, low-confidence)
-- **Consolidation** — Merges related entries into unified summaries
-- **Bootstrap sets** — Generates compact `DistilledSet` packages that can onboard new agents quickly (teacher-to-student knowledge transfer)
+# Outcome commits automatically persist the trace
+updated, trace = recorder.commit_outcome("DEP-500", OutcomeType.CLEAN_DEPLOY)
 
-### Memory Safety Validator
+# Months later, explain still works
+result = recorder.explain("DEP-500")
 
-Pre-write guardrails that validate candidate memories before they enter the store:
+# Search across all decisions
+traces = recorder.search_traces(entity_path="checkout-service", outcome_type="p1_incident")
+```
 
-- **Contradiction detection** — Flags entries that conflict with existing knowledge
-- **Temporal consistency** — Ensures timestamps and version sequences are coherent
-- **Confidence thresholds** — Rejects entries with implausible confidence values
-- **Causal chain integrity** — Verifies that referenced causal keys exist
+### Intelligence Layer
 
-### Multi-Strategy Retrieval
+**Extraction** — Turns raw text (conversations, logs, documents) into structured memory operations using LLMs. The extractor classifies each piece of information as an **ADD**, **UPDATE**, **DELETE**, or **NOOP** operation.
 
-Advanced search that goes beyond single-embedding lookup by combining multiple retrieval strategies:
+**Memory Critic** — Automated quality analyzer that scans the memory store and detects five issue classes: Toxic (repeated negative correlations), Stale, Contradictory, Uncalibrated, and Orphaned entries.
 
-| Strategy | Signal |
-|:---------|:-------|
-| Semantic | Vector similarity via embeddings |
-| BM25 | Keyword relevance scoring |
-| Temporal | Recency weighting |
-| Confidence | Trust-score ranking |
+**Memory Distiller** — Compacts large stores into smaller, higher-quality sets via pruning, consolidation, and bootstrap set generation for agent onboarding.
 
-Results are merged using **Reciprocal Rank Fusion (RRF)** to produce a single ranked list.
+**Memory Safety Validator** — Pre-write guardrails: contradiction detection, temporal consistency, confidence thresholds, and causal chain integrity.
 
-### ML Layer
+**Multi-Strategy Retrieval** — Combines semantic, BM25, temporal, and confidence signals via Reciprocal Rank Fusion (RRF).
 
-The ML layer learns from your outcome data to make AMFS smarter over time. Three capabilities:
+**ML Layer** — Learned retrieval ranking (gradient-boosted model on outcome history), adaptive confidence calibration (learns optimal multipliers per entity), and training data export (SFT, DPO, reward model datasets from decision traces).
 
-**Learned Retrieval Ranking** — Trains a gradient-boosted model on your outcome history to predict which memories are most useful. Entries read before clean deploys are positive signals; entries read before incidents are negative. Once trained, the model automatically enhances `amfs_retrieve` results. Falls back to heuristic ranking when insufficient data (< 20 outcome-linked entries).
+### Dashboard
 
-Features extracted from each `MemoryEntry`:
-
-| Feature | Signal |
-|:--------|:-------|
-| Confidence | Current trust score |
-| Outcome count | How many outcomes validated this entry |
-| Version | How many times it's been updated |
-| Age | Time since creation (days and log-hours) |
-| Memory type | Fact, belief, or experience (one-hot) |
-| Provenance tier | Production-validated through manual (one-hot) |
-| Pattern refs | Whether cross-references exist and how many |
-
-**Adaptive Confidence Calibration** — Learns optimal outcome multipliers from historical data instead of the fixed defaults (P1 = 1.15, clean_deploy = 0.97). Analyzes how entries linked to each outcome type perform in subsequent outcomes, then computes calibrated multipliers per entity. Also estimates optimal decay half-life from the age distribution of actively-used entries.
-
-**Training Data Export** — Exports your decision traces as fine-tuning datasets. AMFS doesn't train your LLMs — it generates the structured training data from its outcome-linked causal chains:
-
-| Format | Description |
-|:-------|:------------|
-| **SFT** | Successful decision traces as (context, decision) examples |
-| **DPO** | Paired (chosen, rejected) from positive vs negative outcomes |
-| **Reward Model** | Entries labeled by outcome quality score |
+A web dashboard (Next.js 15 + React 19) for non-technical team members to explore memory, visualize decision traces, manage teams and API keys, review audit logs, and monitor usage.
 
 ### Pro MCP Server
 
@@ -232,8 +261,6 @@ Extends the OSS MCP server with 7 additional tools:
 
 ## Architecture
 
-The Pro layer wraps the OSS layer — it never replaces it. All Pro features read from and write to the same memory store using the same adapters and SDK.
-
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                        Agent / IDE                          │
@@ -245,6 +272,13 @@ The Pro layer wraps the OSS layer — it never replaces it. All Pro features rea
    │  MCP Server OSS │          │  MCP Server Pro            │
    │  (9 tools)      │          │  (9 + 7 tools)             │
    └────────┬────────┘          │                           │
+            │                   │  Multi-Tenant Layer:      │
+            │                   │  Auth · RBAC · RLS        │
+            │                   │  Scopes · Audit · Quotas  │
+            │                   │                           │
+            │                   │  Decision Traces:         │
+            │                   │  Recorder · Store · Search │
+            │                   │                           │
             │                   │  Intelligence Layer:       │
             │                   │  Critic · Distiller        │
             │                   │  Safety · Retrieval        │
@@ -257,17 +291,17 @@ The Pro layer wraps the OSS layer — it never replaces it. All Pro features rea
             └──────────┬──────────────────────┘
                        ▼
             ┌─────────────────┐
-            │   AgentMemory   │  ← Python SDK
+            │   AgentMemory   │  ← Python / TypeScript SDK
             │   (CoW Engine)  │
             └────────┬────────┘
                      │
            ┌─────────┼─────────┐
            ▼         ▼         ▼
-      Filesystem  Postgres    Custom
-       Adapter    Adapter    Adapter
+      Filesystem  Postgres    S3
+       Adapter    Adapter   Adapter
 ```
 
-The Pro MCP server imports and re-exports all 9 OSS tools, then adds the 7 Pro tools on top. You only run one server — either OSS or Pro.
+The Pro API layer wraps `AgentMemory` and `CoWEngine` with authentication, tenant isolation, scope enforcement, and audit logging — all backed by Postgres RLS for defense-in-depth.
 
 ---
 
@@ -278,14 +312,22 @@ The Pro MCP server imports and re-exports all 9 OSS tools, then adds the 7 Pro t
 | Single developer, local memory | OSS |
 | Small team sharing via Postgres | OSS |
 | CI/CD outcome tracking | OSS |
-| Need memory quality auditing at scale | Pro |
-| Want LLM-driven extraction from conversations/logs | Pro |
-| Onboarding new agents with curated knowledge | Pro (bootstrap sets) |
-| Compliance or safety requirements for memory writes | Pro (safety validator) |
-| Advanced retrieval across large stores | Pro (multi-strategy + learned ranking) |
-| Want retrieval that improves as outcomes accumulate | Pro (ML layer) |
-| Need optimized confidence multipliers per entity | Pro (adaptive calibration) |
-| Want to fine-tune agents on your decision history | Pro (training data export) |
+| Remote HTTP API access | OSS |
+| S3-based cloud storage | OSS |
+| Multi-tenant SaaS with account isolation | **Pro** |
+| Scoped API keys per agent/tool | **Pro** |
+| Compliance audit logging | **Pro** |
+| Persistent decision traces that survive sessions | **Pro** |
+| Precedent search ("how did we handle similar situations?") | **Pro** |
+| Need memory quality auditing at scale | **Pro** |
+| Want LLM-driven extraction from conversations/logs | **Pro** |
+| Onboarding new agents with curated knowledge | **Pro** (bootstrap sets) |
+| Compliance or safety requirements for memory writes | **Pro** (safety validator) |
+| Advanced retrieval across large stores | **Pro** (multi-strategy + learned ranking) |
+| Retrieval that improves as outcomes accumulate | **Pro** (ML layer) |
+| Need optimized confidence multipliers per entity | **Pro** (adaptive calibration) |
+| Want to fine-tune agents on your decision history | **Pro** (training data export) |
+| Team dashboard for non-technical users | **Pro** (dashboard) |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -553,9 +553,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -570,9 +567,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -587,9 +581,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -604,9 +595,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -621,9 +609,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -638,9 +623,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -655,9 +637,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -672,9 +651,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -689,9 +665,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -706,9 +679,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -723,9 +693,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -740,9 +707,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -757,9 +721,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/sdk-typescript/src/__tests__/sdk.test.ts
+++ b/packages/sdk-typescript/src/__tests__/sdk.test.ts
@@ -4,6 +4,7 @@ import {
   InMemoryAdapter,
   CausalTagger,
   CoWEngine,
+  ReadTracker,
   OutcomeBackPropagator,
   OutcomeType,
   OUTCOME_MULTIPLIERS,
@@ -268,5 +269,129 @@ describe("AgentMemory", () => {
     mem.write("svc", "key", "val", { confidence: 0.3 });
     expect(mem.read("svc", "key", { minConfidence: 0.5 })).toBeNull();
     expect(mem.read("svc", "key", { minConfidence: 0.2 })).not.toBeNull();
+  });
+
+  it("read tracker records reads automatically", () => {
+    const mem = new AgentMemory("test-agent");
+    mem.write("svc", "k1", "v1");
+    mem.write("svc", "k2", "v2");
+    mem.read("svc", "k1");
+    mem.read("svc", "k2");
+    expect(mem.readTracker.readCount).toBe(2);
+    expect(mem.readTracker.causalKeys).toContain("svc/k1");
+    expect(mem.readTracker.causalKeys).toContain("svc/k2");
+  });
+
+  it("auto-causal commitOutcome uses read tracker", () => {
+    const mem = new AgentMemory("test-agent");
+    mem.write("svc", "k1", "v1");
+    mem.read("svc", "k1");
+    const updated = mem.commitOutcome("DEP-1", OutcomeType.CLEAN_DEPLOY);
+    expect(updated).toHaveLength(1);
+    expect(updated[0].confidence).toBeCloseTo(0.97);
+  });
+
+  it("clearReadLog resets tracker", () => {
+    const mem = new AgentMemory("test-agent");
+    mem.write("svc", "k1", "v1");
+    mem.read("svc", "k1");
+    expect(mem.readTracker.readCount).toBe(1);
+    mem.clearReadLog();
+    expect(mem.readTracker.readCount).toBe(0);
+  });
+
+  it("history returns all versions", () => {
+    const mem = new AgentMemory("test-agent");
+    mem.write("svc", "k", "v1");
+    mem.write("svc", "k", "v2");
+    mem.write("svc", "k", "v3");
+    const versions = mem.history("svc", "k");
+    expect(versions).toHaveLength(3);
+    expect(versions[0].version).toBe(1);
+    expect(versions[2].version).toBe(3);
+  });
+
+  it("search with confidence filter", () => {
+    const mem = new AgentMemory("test-agent");
+    mem.write("svc", "high", "v", { confidence: 0.9 });
+    mem.write("svc", "low", "v", { confidence: 0.2 });
+    const results = mem.search({ minConfidence: 0.5 });
+    expect(results).toHaveLength(1);
+    expect(results[0].key).toBe("high");
+  });
+
+  it("search with limit", () => {
+    const mem = new AgentMemory("test-agent");
+    for (let i = 0; i < 10; i++) {
+      mem.write("svc", `k${i}`, `v${i}`);
+    }
+    const results = mem.search({ limit: 3 });
+    expect(results).toHaveLength(3);
+  });
+
+  it("stats returns correct counts", () => {
+    const mem = new AgentMemory("test-agent");
+    mem.write("svc-a", "k1", "v1");
+    mem.write("svc-b", "k2", "v2");
+    const s = mem.stats();
+    expect(s.totalEntries).toBe(2);
+    expect(s.totalEntities).toBe(2);
+    expect(s.totalAgents).toBe(1);
+  });
+
+  it("recordContext and explain", () => {
+    const mem = new AgentMemory("test-agent");
+    mem.write("svc", "pattern", "retry logic");
+    mem.read("svc", "pattern");
+    mem.recordContext("pagerduty", "3 SEV-1 incidents", { source: "PagerDuty API" });
+    const result = mem.explain("DEP-500");
+    expect(result.outcomeRef).toBe("DEP-500");
+    expect(result.agentId).toBe("test-agent");
+    expect(result.causalChainLength).toBe(1);
+    expect((result.causalEntries as unknown[]).length).toBe(1);
+    expect((result.externalContexts as unknown[]).length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------
+// ReadTracker
+// ---------------------------------------------------------------
+
+describe("ReadTracker", () => {
+  it("records reads and returns causal keys in order", () => {
+    const tracker = new ReadTracker();
+    tracker.record(makeEntry({ entityPath: "svc", key: "k1" }));
+    tracker.record(makeEntry({ entityPath: "svc", key: "k2" }));
+    expect(tracker.causalKeys).toEqual(["svc/k1", "svc/k2"]);
+  });
+
+  it("records external contexts", () => {
+    const tracker = new ReadTracker();
+    tracker.recordContext("pd", "3 incidents", { source: "PagerDuty" });
+    expect(tracker.externalContexts).toHaveLength(1);
+    expect(tracker.externalContexts[0].source).toBe("PagerDuty");
+  });
+
+  it("read version tracking", () => {
+    const tracker = new ReadTracker();
+    tracker.record(makeEntry({ entityPath: "svc", key: "k1", version: 5 }));
+    expect(tracker.readVersion("svc/k1")).toBe(5);
+    expect(tracker.readVersion("svc/missing")).toBeUndefined();
+  });
+
+  it("clear resets everything", () => {
+    const tracker = new ReadTracker();
+    tracker.record(makeEntry({ entityPath: "svc", key: "k1" }));
+    tracker.recordContext("test", "test");
+    tracker.clear();
+    expect(tracker.readCount).toBe(0);
+    expect(tracker.externalContexts).toHaveLength(0);
+  });
+
+  it("contains check", () => {
+    const tracker = new ReadTracker();
+    tracker.record(makeEntry({ entityPath: "svc", key: "k1" }));
+    expect(tracker.contains("svc/k1")).toBe(true);
+    expect(tracker.contains("svc/k2")).toBe(false);
   });
 });

--- a/packages/sdk-typescript/src/engine.ts
+++ b/packages/sdk-typescript/src/engine.ts
@@ -4,6 +4,7 @@
 
 import type { AmfsAdapter } from "./adapter.js";
 import type { MemoryEntry, Provenance } from "./models.js";
+import { ReadTracker } from "./tracker.js";
 
 export class CausalTagger {
   readonly agentId: string;
@@ -28,10 +29,16 @@ export class CausalTagger {
 export class CoWEngine {
   readonly adapter: AmfsAdapter;
   readonly tagger: CausalTagger;
+  readonly readTracker: ReadTracker | null;
 
-  constructor(adapter: AmfsAdapter, tagger: CausalTagger) {
+  constructor(
+    adapter: AmfsAdapter,
+    tagger: CausalTagger,
+    readTracker?: ReadTracker
+  ) {
     this.adapter = adapter;
     this.tagger = tagger;
+    this.readTracker = readTracker ?? null;
   }
 
   read(
@@ -39,7 +46,11 @@ export class CoWEngine {
     key: string,
     options?: { minConfidence?: number }
   ): MemoryEntry | null {
-    return this.adapter.read(entityPath, key, options);
+    const entry = this.adapter.read(entityPath, key, options);
+    if (entry && this.readTracker) {
+      this.readTracker.record(entry);
+    }
+    return entry;
   }
 
   write(
@@ -75,5 +86,28 @@ export class CoWEngine {
     options?: { includeSuperseded?: boolean }
   ): MemoryEntry[] {
     return this.adapter.list(entityPath, options);
+  }
+
+  history(
+    entityPath: string,
+    key: string,
+    options?: { since?: string; until?: string }
+  ): MemoryEntry[] {
+    const all = this.adapter.list(entityPath, { includeSuperseded: true });
+    let versions = all
+      .filter((e) => e.key === key)
+      .sort((a, b) => a.version - b.version);
+
+    if (options?.since) {
+      versions = versions.filter(
+        (e) => e.provenance.writtenAt >= options.since!
+      );
+    }
+    if (options?.until) {
+      versions = versions.filter(
+        (e) => e.provenance.writtenAt <= options.until!
+      );
+    }
+    return versions;
   }
 }

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -3,11 +3,13 @@
  */
 
 export { AgentMemory } from "./memory.js";
-export type { AgentMemoryOptions } from "./memory.js";
+export type { AgentMemoryOptions, SearchOptions, MemoryStats } from "./memory.js";
 export type { AmfsAdapter, WatchHandle } from "./adapter.js";
 export { createWatchHandle } from "./adapter.js";
 export { InMemoryAdapter } from "./adapters/filesystem.js";
 export { CausalTagger, CoWEngine } from "./engine.js";
+export { ReadTracker } from "./tracker.js";
+export type { ExternalContext } from "./tracker.js";
 export { OutcomeBackPropagator } from "./outcome.js";
 export { defaultConfig } from "./config.js";
 export {
@@ -18,6 +20,7 @@ export type {
   MemoryEntry,
   OutcomeRecord,
   Provenance,
+  ArtifactRef,
   AMFSConfig,
   LayerConfig,
 } from "./models.js";

--- a/packages/sdk-typescript/src/memory.ts
+++ b/packages/sdk-typescript/src/memory.ts
@@ -9,6 +9,7 @@ import { CausalTagger, CoWEngine } from "./engine.js";
 import type { AMFSConfig, MemoryEntry } from "./models.js";
 import { OutcomeType } from "./models.js";
 import { OutcomeBackPropagator } from "./outcome.js";
+import { ReadTracker } from "./tracker.js";
 
 export interface AgentMemoryOptions {
   sessionId?: string;
@@ -16,11 +17,30 @@ export interface AgentMemoryOptions {
   config?: AMFSConfig;
 }
 
+export interface SearchOptions {
+  entityPath?: string;
+  minConfidence?: number;
+  agentId?: string;
+  limit?: number;
+  sortBy?: "confidence" | "recency" | "version";
+}
+
+export interface MemoryStats {
+  totalEntries: number;
+  totalEntities: number;
+  totalAgents: number;
+  agents: Record<string, number>;
+  entities: Record<string, number>;
+  confidenceAvg: number;
+  outcomeLinkedCount: number;
+}
+
 export class AgentMemory {
   readonly agentId: string;
   readonly sessionId: string;
   readonly namespace: string;
   readonly adapter: AmfsAdapter;
+  readonly readTracker: ReadTracker;
 
   private engine: CoWEngine;
   private propagator: OutcomeBackPropagator;
@@ -30,10 +50,11 @@ export class AgentMemory {
     this.agentId = agentId;
     this.adapter = options?.adapter ?? new InMemoryAdapter();
     this.namespace = config.namespace;
+    this.readTracker = new ReadTracker();
 
     const tagger = new CausalTagger(agentId, options?.sessionId);
     this.sessionId = tagger.sessionId;
-    this.engine = new CoWEngine(this.adapter, tagger);
+    this.engine = new CoWEngine(this.adapter, tagger, this.readTracker);
     this.propagator = new OutcomeBackPropagator(this.adapter);
   }
 
@@ -72,19 +93,135 @@ export class AgentMemory {
     return this.adapter.watch(entityPath, callback);
   }
 
+  /** Return the full version history of a key, ordered by version. */
+  history(
+    entityPath: string,
+    key: string,
+    options?: { since?: string; until?: string }
+  ): MemoryEntry[] {
+    return this.engine.history(entityPath, key, options);
+  }
+
+  /** Search entries with filters. */
+  search(options?: SearchOptions): MemoryEntry[] {
+    let entries = this.engine.list(options?.entityPath);
+
+    if (options?.minConfidence) {
+      entries = entries.filter((e) => e.confidence >= options.minConfidence!);
+    }
+    if (options?.agentId) {
+      entries = entries.filter(
+        (e) => e.provenance.agentId === options.agentId
+      );
+    }
+
+    const sortBy = options?.sortBy ?? "confidence";
+    if (sortBy === "confidence") {
+      entries.sort((a, b) => b.confidence - a.confidence);
+    } else if (sortBy === "recency") {
+      entries.sort((a, b) =>
+        b.provenance.writtenAt.localeCompare(a.provenance.writtenAt)
+      );
+    } else if (sortBy === "version") {
+      entries.sort((a, b) => b.version - a.version);
+    }
+
+    return entries.slice(0, options?.limit ?? 100);
+  }
+
+  /** Aggregate statistics about current memory state. */
+  stats(): MemoryStats {
+    const entries = this.engine.list();
+    const agents: Record<string, number> = {};
+    const entities: Record<string, number> = {};
+    let totalConfidence = 0;
+    let outcomeLinked = 0;
+
+    for (const e of entries) {
+      agents[e.provenance.agentId] = (agents[e.provenance.agentId] ?? 0) + 1;
+      entities[e.entityPath] = (entities[e.entityPath] ?? 0) + 1;
+      totalConfidence += e.confidence;
+      if (e.outcomeCount > 0) outcomeLinked++;
+    }
+
+    return {
+      totalEntries: entries.length,
+      totalEntities: Object.keys(entities).length,
+      totalAgents: Object.keys(agents).length,
+      agents,
+      entities,
+      confidenceAvg: entries.length > 0 ? totalConfidence / entries.length : 0,
+      outcomeLinkedCount: outcomeLinked,
+    };
+  }
+
+  /**
+   * Record external context in the causal chain without writing to storage.
+   * Call after consulting external tools/APIs so explain() is complete.
+   */
+  recordContext(
+    label: string,
+    summary: string,
+    options?: { source?: string }
+  ): void {
+    this.readTracker.recordContext(label, summary, options);
+  }
+
+  /**
+   * Return the causal chain for the current session.
+   * Shows which memories were read, external contexts, and their order.
+   */
+  explain(outcomeRef?: string): Record<string, unknown> {
+    const causalKeys = this.readTracker.causalKeys;
+    const entries: Record<string, unknown>[] = [];
+
+    for (const ek of causalKeys) {
+      const lastSlash = ek.lastIndexOf("/");
+      if (lastSlash === -1) continue;
+      const ep = ek.substring(0, lastSlash);
+      const k = ek.substring(lastSlash + 1);
+      const entry = this.adapter.read(ep, k);
+      if (entry) {
+        entries.push({
+          ...entry,
+          readVersion: this.readTracker.readVersion(ek),
+        });
+      }
+    }
+
+    return {
+      outcomeRef: outcomeRef ?? null,
+      agentId: this.agentId,
+      sessionId: this.sessionId,
+      causalChainLength: causalKeys.length,
+      causalEntries: entries,
+      externalContexts: this.readTracker.externalContexts,
+    };
+  }
+
+  /**
+   * Commit an outcome and back-propagate confidence changes.
+   * If causalEntryKeys is omitted, uses the session's read log automatically.
+   */
   commitOutcome(
     outcomeRef: string,
     outcomeType: OutcomeType,
-    causalEntryKeys: string[],
+    causalEntryKeys?: string[],
     options?: { causalConfidence?: number }
   ): MemoryEntry[] {
+    const keys = causalEntryKeys ?? this.readTracker.causalKeys;
     const record = OutcomeBackPropagator.makeRecord(
       outcomeRef,
       outcomeType,
-      causalEntryKeys,
+      keys,
       this.agentId,
       { causalConfidence: options?.causalConfidence }
     );
     return this.propagator.propagate(record);
+  }
+
+  /** Reset the session read log. */
+  clearReadLog(): void {
+    this.readTracker.clear();
   }
 }

--- a/packages/sdk-typescript/src/tracker.ts
+++ b/packages/sdk-typescript/src/tracker.ts
@@ -1,0 +1,77 @@
+/**
+ * ReadTracker — automatically records every read within a session for
+ * causal linking and conflict detection.
+ *
+ * TypeScript port of the Python ReadTracker from amfs-core.
+ */
+
+import type { MemoryEntry } from "./models.js";
+
+export interface ExternalContext {
+  label: string;
+  summary: string;
+  source?: string | null;
+  recordedAt: string; // ISO 8601
+}
+
+export class ReadTracker {
+  private reads: Map<string, string> = new Map(); // entry_key -> ISO timestamp
+  private versions: Map<string, number> = new Map(); // entry_key -> version
+  private contexts: ExternalContext[] = [];
+
+  /** Record that an entry was read during this session. */
+  record(entry: MemoryEntry): void {
+    const entryKey = `${entry.entityPath}/${entry.key}`;
+    this.reads.set(entryKey, new Date().toISOString());
+    this.versions.set(entryKey, entry.version);
+  }
+
+  /**
+   * Record external context that influenced decisions in this session.
+   * Included in the causal chain returned by explain().
+   */
+  recordContext(
+    label: string,
+    summary: string,
+    options?: { source?: string }
+  ): void {
+    this.contexts.push({
+      label,
+      summary,
+      source: options?.source ?? null,
+      recordedAt: new Date().toISOString(),
+    });
+  }
+
+  /** All entry keys read in this session, ordered by read time. */
+  get causalKeys(): string[] {
+    return [...this.reads.entries()]
+      .sort(([, a], [, b]) => a.localeCompare(b))
+      .map(([k]) => k);
+  }
+
+  /** All external contexts recorded in this session, in order. */
+  get externalContexts(): ExternalContext[] {
+    return [...this.contexts];
+  }
+
+  get readCount(): number {
+    return this.reads.size;
+  }
+
+  /** Return the version we last read for an entry, or undefined if never read. */
+  readVersion(entryKey: string): number | undefined {
+    return this.versions.get(entryKey);
+  }
+
+  /** Reset the read log (e.g. between sub-tasks within a session). */
+  clear(): void {
+    this.reads.clear();
+    this.versions.clear();
+    this.contexts = [];
+  }
+
+  contains(entryKey: string): boolean {
+    return this.reads.has(entryKey);
+  }
+}


### PR DESCRIPTION
## Summary
- **ReadTracker**: auto-records every read for causal linking and conflict detection; tracks versions for stale-write detection; records external contexts for complete decision traces
- **CoWEngine enhancements**: accepts ReadTracker, auto-logs reads; adds `history()` with optional since/until filtering
- **AgentMemory parity**: adds `search()` (confidence/agent/sort/limit), `stats()`, `history()`, `recordContext()`, `explain()`, `clearReadLog()`, auto-causal `commitOutcome()` (uses read tracker when keys omitted)
- **docs/editions.md**: updated to reflect revised OSS vs Pro boundary (multi-tenant SaaS, persistent traces, dashboard sections)
- New exports: `ReadTracker`, `ExternalContext`, `SearchOptions`, `MemoryStats`, `ArtifactRef`

## Test plan
- [x] 37 tests passing (24 existing + 13 new)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Verify TS SDK works end-to-end in a sample agent project
