### PR TITLE
feat: OSS connector framework with manifest, registry, and test harness

### DIFF
--- a/packages/connectors/pyproject.toml
+++ b/packages/connectors/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "amfs-connectors"
+version = "0.1.0"
+description = "AMFS connector framework: build, install, and manage external system connectors"
+requires-python = ">=3.11"
+dependencies = [
+    "amfs-core",
+    "amfs",
+    "pydantic>=2.0",
+    "httpx>=0.27",
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+cli = ["typer>=0.12"]
+
+[project.entry-points."amfs.connectors"]
+pagerduty = "amfs_connectors.providers.pagerduty:PagerDutyConnector"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/amfs_connectors"]

--- a/packages/connectors/src/amfs_connectors/__init__.py
+++ b/packages/connectors/src/amfs_connectors/__init__.py
@@ -1,0 +1,19 @@
+"""AMFS connector framework: build, install, and manage external system connectors."""
+
+from amfs_connectors.base import ConnectorABC, ConnectorConfig, IngestionResult
+from amfs_connectors.webhook import WebhookIngester, WebhookEvent, WebhookConfig
+from amfs_connectors.manifest import ConnectorManifest, load_manifest, validate_manifest
+from amfs_connectors.registry import ConnectorRegistry
+
+__all__ = [
+    "ConnectorABC",
+    "ConnectorConfig",
+    "ConnectorRegistry",
+    "ConnectorManifest",
+    "IngestionResult",
+    "WebhookConfig",
+    "WebhookEvent",
+    "WebhookIngester",
+    "load_manifest",
+    "validate_manifest",
+]

--- a/packages/connectors/src/amfs_connectors/base.py
+++ b/packages/connectors/src/amfs_connectors/base.py
@@ -1,0 +1,76 @@
+"""Base classes for external system connectors.
+
+Every connector transforms external events into AMFS memory operations
+(write + record_context). The abstract interface ensures all connectors
+follow the same lifecycle: configure -> connect -> ingest -> disconnect.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+
+class ConnectorConfig(BaseModel):
+    """Base configuration for any connector."""
+
+    id: UUID = Field(default_factory=uuid4)
+    name: str
+    connector_type: str
+    entity_path: str
+    enabled: bool = True
+    settings: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime | None = None
+
+
+class IngestionResult(BaseModel):
+    """Result of processing a single ingested event."""
+
+    connector_id: UUID
+    event_id: str
+    entity_path: str
+    key: str
+    action: str  # "write", "context", "skip"
+    success: bool = True
+    error: str | None = None
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class ConnectorABC(ABC):
+    """Abstract base class for external system connectors.
+
+    Subclasses implement the transformation logic for turning
+    external events into AMFS memory operations.
+    """
+
+    def __init__(self, config: ConnectorConfig) -> None:
+        self._config = config
+
+    @property
+    def config(self) -> ConnectorConfig:
+        return self._config
+
+    @property
+    def name(self) -> str:
+        return self._config.name
+
+    @abstractmethod
+    def transform(self, raw_event: dict[str, Any]) -> list[IngestionResult]:
+        """Transform a raw external event into AMFS operations."""
+        ...
+
+    @abstractmethod
+    def validate_event(self, raw_event: dict[str, Any]) -> bool:
+        """Validate that a raw event is well-formed for this connector."""
+        ...
+
+    def extract_event_id(self, raw_event: dict[str, Any]) -> str:
+        """Extract a unique event ID from the raw event.
+
+        Default implementation uses a UUID. Override for idempotency.
+        """
+        return str(uuid4())

--- a/packages/connectors/src/amfs_connectors/manifest.py
+++ b/packages/connectors/src/amfs_connectors/manifest.py
@@ -1,0 +1,92 @@
+"""Connector manifest (connector.yaml) schema, loader, and validator.
+
+Every connector -- built-in or community -- is described by a standardized
+``connector.yaml`` manifest that the CLI, registry, and Pro dashboard use
+for discovery, installation, and configuration UI generation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+
+class ConfigField(BaseModel):
+    """Schema for a single connector configuration field."""
+
+    type: str = "string"
+    required: bool = False
+    default: Any = None
+    description: str = ""
+    enum: list[str] | None = None
+
+
+class ConnectorManifest(BaseModel):
+    """Parsed and validated connector.yaml manifest."""
+
+    name: str
+    version: str = "0.1.0"
+    description: str = ""
+    author: str = ""
+    license: str = "Apache-2.0"
+    homepage: str = ""
+    tags: list[str] = Field(default_factory=list)
+
+    events: list[str] = Field(default_factory=list)
+
+    outputs: dict[str, Any] = Field(default_factory=dict)
+
+    entry_point: str = ""
+
+    dependencies: list[str] = Field(default_factory=list)
+
+    config_schema: dict[str, ConfigField] = Field(default_factory=dict)
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, v: str) -> str:
+        if not v or not v.replace("-", "").replace("_", "").isalnum():
+            raise ValueError(f"Invalid connector name: {v!r}")
+        return v.lower().replace("_", "-")
+
+
+def load_manifest(path: str | Path) -> ConnectorManifest:
+    """Load and parse a connector.yaml file."""
+    p = Path(path)
+    if p.is_dir():
+        p = p / "connector.yaml"
+    if not p.exists():
+        raise FileNotFoundError(f"Manifest not found: {p}")
+    with open(p) as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid manifest format in {p}")
+    return ConnectorManifest(**data)
+
+
+def validate_manifest(path: str | Path) -> list[str]:
+    """Validate a connector.yaml and return a list of warnings (empty = valid)."""
+    warnings: list[str] = []
+    try:
+        manifest = load_manifest(path)
+    except Exception as e:
+        return [f"Failed to load manifest: {e}"]
+
+    if not manifest.entry_point:
+        warnings.append("No entry_point specified -- connector won't be auto-discoverable")
+    elif ":" not in manifest.entry_point:
+        warnings.append(f"entry_point should be 'module:ClassName', got: {manifest.entry_point!r}")
+
+    if not manifest.description:
+        warnings.append("Missing description")
+
+    if not manifest.events:
+        warnings.append("No events listed -- consider documenting which events this connector handles")
+
+    if not manifest.tags:
+        warnings.append("No tags -- adding tags improves discoverability")
+
+    return warnings

--- a/packages/connectors/src/amfs_connectors/providers/__init__.py
+++ b/packages/connectors/src/amfs_connectors/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in connector providers for common external systems."""

--- a/packages/connectors/src/amfs_connectors/providers/pagerduty.py
+++ b/packages/connectors/src/amfs_connectors/providers/pagerduty.py
@@ -1,0 +1,117 @@
+"""PagerDuty connector -- transforms PD incident webhooks into AMFS context.
+
+PagerDuty webhook v3 events are transformed into:
+- record_context() calls for incident metadata
+- memory writes for high-severity incident patterns
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from amfs_connectors.base import ConnectorABC, ConnectorConfig, IngestionResult
+from amfs_connectors.webhook import WebhookEvent
+
+
+class PagerDutyConfig(ConnectorConfig):
+    """PagerDuty-specific connector configuration."""
+
+    connector_type: str = "pagerduty"
+    routing_key: str | None = None
+    severity_threshold: str = "high"
+
+
+SEVERITY_ORDER = {"critical": 0, "high": 1, "warning": 2, "info": 3}
+
+
+class PagerDutyConnector(ConnectorABC):
+    """PagerDuty incident connector.
+
+    Registered as the ``pagerduty`` entry point.
+    """
+
+    def __init__(self, config: ConnectorConfig | None = None) -> None:
+        super().__init__(config or ConnectorConfig(
+            name="pagerduty",
+            connector_type="pagerduty",
+            entity_path="incidents",
+        ))
+
+    def validate_event(self, raw_event: dict[str, Any]) -> bool:
+        return "event" in raw_event or "data" in raw_event
+
+    def transform(self, raw_event: dict[str, Any]) -> list[IngestionResult]:
+        event = WebhookEvent(
+            connector_id=self._config.id,
+            source="pagerduty",
+            event_type=raw_event.get("event", {}).get("event_type", "incident"),
+            payload=raw_event,
+            headers={},
+        )
+        return transform_pagerduty_incident(event)
+
+
+def transform_pagerduty_incident(event: WebhookEvent) -> list[IngestionResult]:
+    """Transform a PagerDuty incident webhook into AMFS operations."""
+    payload = event.payload
+    results: list[IngestionResult] = []
+
+    pd_event = payload.get("event", payload)
+    event_type = pd_event.get("event_type", event.event_type)
+    data = pd_event.get("data", pd_event)
+
+    incident_id = data.get("id", str(uuid4())[:8])
+    title = data.get("title", "Unknown incident")
+    severity = data.get("severity", data.get("urgency", "info"))
+    service_name = _extract_service(data)
+    status = data.get("status", "triggered")
+
+    entity_path = event.payload.get("_amfs_entity_path", f"incidents/{service_name}")
+    key = f"pd-{incident_id}"
+
+    value = {
+        "incident_id": incident_id,
+        "title": title,
+        "severity": severity,
+        "service": service_name,
+        "status": status,
+        "event_type": event_type,
+        "assignees": _extract_assignees(data),
+        "created_at": data.get("created_at"),
+        "resolved_at": data.get("resolved_at"),
+        "html_url": data.get("html_url"),
+    }
+
+    action = "context" if event_type in ("incident.resolved", "incident.acknowledged") else "write"
+
+    results.append(IngestionResult(
+        connector_id=event.connector_id,
+        event_id=incident_id,
+        entity_path=entity_path,
+        key=key,
+        action=action,
+        success=True,
+        details=value,
+    ))
+
+    return results
+
+
+def _extract_service(data: dict[str, Any]) -> str:
+    service = data.get("service", {})
+    if isinstance(service, dict):
+        return service.get("name", service.get("summary", "unknown-service"))
+    return str(service) if service else "unknown-service"
+
+
+def _extract_assignees(data: dict[str, Any]) -> list[str]:
+    assignees = data.get("assignees", data.get("assignments", []))
+    names: list[str] = []
+    for a in assignees:
+        if isinstance(a, dict):
+            assignee = a.get("assignee", a)
+            names.append(assignee.get("summary", assignee.get("name", "unknown")))
+        else:
+            names.append(str(a))
+    return names

--- a/packages/connectors/src/amfs_connectors/registry.py
+++ b/packages/connectors/src/amfs_connectors/registry.py
@@ -1,0 +1,108 @@
+"""Connector registry with automatic entry-point discovery.
+
+Installed connectors register themselves via the ``amfs.connectors``
+entry-point group in their ``pyproject.toml``::
+
+    [project.entry-points."amfs.connectors"]
+    pagerduty = "amfs_connector_pagerduty:PagerDutyConnector"
+
+The registry auto-discovers all installed connectors at import time
+and provides lookup by name.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import Any
+
+from amfs_connectors.base import ConnectorABC, ConnectorConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _load_entry_points() -> dict[str, str]:
+    """Discover connectors registered via importlib.metadata entry points."""
+    discovered: dict[str, str] = {}
+    try:
+        from importlib.metadata import entry_points
+
+        eps = entry_points()
+        connector_eps = eps.get("amfs.connectors", []) if isinstance(eps, dict) else eps.select(group="amfs.connectors")
+        for ep in connector_eps:
+            discovered[ep.name] = ep.value
+            logger.debug("Discovered connector entry point: %s = %s", ep.name, ep.value)
+    except Exception:
+        logger.debug("Entry point discovery failed", exc_info=True)
+    return discovered
+
+
+class ConnectorRegistry:
+    """Registry of available connectors, populated from entry points and manual registration."""
+
+    def __init__(self, *, auto_discover: bool = True) -> None:
+        self._entry_points: dict[str, str] = {}
+        self._instances: dict[str, ConnectorABC] = {}
+        self._classes: dict[str, type[ConnectorABC]] = {}
+        if auto_discover:
+            self._entry_points = _load_entry_points()
+
+    def register(self, name: str, connector_cls: type[ConnectorABC]) -> None:
+        """Manually register a connector class."""
+        self._classes[name] = connector_cls
+
+    def get(self, name: str) -> ConnectorABC | None:
+        """Get a connector instance by name, instantiating on first access."""
+        if name in self._instances:
+            return self._instances[name]
+
+        cls = self._resolve_class(name)
+        if cls is None:
+            return None
+
+        try:
+            config = ConnectorConfig(
+                name=name,
+                connector_type=name,
+                entity_path=name,
+            )
+            instance = cls(config)
+            self._instances[name] = instance
+            return instance
+        except Exception:
+            logger.error("Failed to instantiate connector %r", name, exc_info=True)
+            return None
+
+    def _resolve_class(self, name: str) -> type[ConnectorABC] | None:
+        """Resolve a connector class from manual registrations or entry points."""
+        if name in self._classes:
+            return self._classes[name]
+
+        ep_value = self._entry_points.get(name)
+        if not ep_value:
+            return None
+
+        try:
+            module_path, class_name = ep_value.rsplit(":", 1)
+            module = importlib.import_module(module_path)
+            cls = getattr(module, class_name)
+            self._classes[name] = cls
+            return cls
+        except Exception:
+            logger.error("Failed to load connector %r from %r", name, ep_value, exc_info=True)
+            return None
+
+    def list_available(self) -> list[str]:
+        """List names of all available connectors (registered + entry points)."""
+        return sorted(set(self._classes.keys()) | set(self._entry_points.keys()))
+
+    def list_installed(self) -> list[dict[str, Any]]:
+        """List installed connectors with metadata."""
+        result = []
+        for name in self.list_available():
+            info: dict[str, Any] = {"name": name, "source": "manual"}
+            if name in self._entry_points:
+                info["source"] = "entry_point"
+                info["entry_point"] = self._entry_points[name]
+            result.append(info)
+        return result

--- a/packages/connectors/src/amfs_connectors/testing.py
+++ b/packages/connectors/src/amfs_connectors/testing.py
@@ -1,0 +1,127 @@
+"""MockAMFS test harness for connector authors.
+
+Provides a lightweight in-memory AMFS substitute that records all
+write() and record_context() calls, so connector tests can verify
+their transform logic without a real AMFS instance or database.
+
+Usage::
+
+    from amfs_connectors.testing import MockAMFS
+
+    def test_my_connector():
+        mock = MockAMFS()
+        connector = MyConnector(config)
+        results = connector.transform(sample_event)
+
+        # Apply results to mock
+        mock.apply_results(results)
+
+        assert mock.writes[0].key == "expected-key"
+        assert len(mock.contexts) == 1
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from amfs_connectors.base import IngestionResult
+
+
+class MockWrite(BaseModel):
+    """A recorded write() call."""
+
+    entity_path: str
+    key: str
+    value: Any
+    confidence: float = 1.0
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class MockContext(BaseModel):
+    """A recorded record_context() call."""
+
+    label: str
+    summary: str
+    source: str | None = None
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class MockAMFS:
+    """In-memory AMFS substitute for testing connectors.
+
+    Records all memory operations so tests can assert on what the
+    connector would have written to a real AMFS instance.
+    """
+
+    def __init__(self) -> None:
+        self.writes: list[MockWrite] = []
+        self.contexts: list[MockContext] = []
+        self._entries: dict[str, dict[str, Any]] = {}
+
+    def write(
+        self,
+        entity_path: str,
+        key: str,
+        value: Any,
+        *,
+        confidence: float = 1.0,
+        **kwargs: Any,
+    ) -> None:
+        """Record a write operation."""
+        self.writes.append(MockWrite(
+            entity_path=entity_path,
+            key=key,
+            value=value,
+            confidence=confidence,
+        ))
+        self._entries.setdefault(entity_path, {})[key] = value
+
+    def record_context(
+        self,
+        label: str,
+        summary: str,
+        *,
+        source: str | None = None,
+    ) -> None:
+        """Record a context operation."""
+        self.contexts.append(MockContext(
+            label=label,
+            summary=summary,
+            source=source,
+        ))
+
+    def read(self, entity_path: str, key: str) -> Any:
+        """Read a previously written value."""
+        return self._entries.get(entity_path, {}).get(key)
+
+    def apply_results(self, results: list[IngestionResult]) -> None:
+        """Apply a list of IngestionResults to the mock.
+
+        - ``action="write"`` -> recorded as a write
+        - ``action="context"`` -> recorded as context
+        - ``action="skip"`` -> ignored
+        """
+        for r in results:
+            if not r.success:
+                continue
+            if r.action == "write":
+                self.write(r.entity_path, r.key, r.details)
+            elif r.action == "context":
+                self.record_context(
+                    label=f"{r.entity_path}/{r.key}",
+                    summary=str(r.details)[:500] if r.details else "",
+                    source=r.entity_path,
+                )
+
+    def reset(self) -> None:
+        """Clear all recorded operations."""
+        self.writes.clear()
+        self.contexts.clear()
+        self._entries.clear()
+
+    @property
+    def total_operations(self) -> int:
+        return len(self.writes) + len(self.contexts)

--- a/packages/connectors/src/amfs_connectors/webhook.py
+++ b/packages/connectors/src/amfs_connectors/webhook.py
@@ -1,0 +1,206 @@
+"""Generic webhook ingester for receiving events from external systems.
+
+Provides HMAC signature verification, deduplication, size checks,
+and a configurable transformation pipeline.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Callable
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+from amfs_connectors.base import ConnectorConfig, IngestionResult
+
+logger = logging.getLogger(__name__)
+
+
+class WebhookConfig(ConnectorConfig):
+    """Configuration for a webhook ingestion endpoint."""
+
+    connector_type: str = "webhook"
+    secret: str | None = None
+    signature_header: str = "X-Webhook-Signature"
+    signature_algo: str = "sha256"
+    dedup_window_seconds: int = 300
+    max_payload_bytes: int = 1_048_576  # 1MB
+
+
+class WebhookEvent(BaseModel):
+    """A received and validated webhook event."""
+
+    id: UUID = Field(default_factory=uuid4)
+    connector_id: UUID
+    source: str
+    event_type: str
+    payload: dict[str, Any]
+    headers: dict[str, str] = Field(default_factory=dict)
+    received_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    signature_valid: bool | None = None
+
+
+TransformFn = Callable[[WebhookEvent], list[IngestionResult]]
+
+
+class WebhookIngester:
+    """Receives, validates, and processes webhook events.
+
+    Pipeline: size check -> signature verify -> dedup -> transform -> record.
+    """
+
+    def __init__(self, config: WebhookConfig, memory: Any = None) -> None:
+        self._config = config
+        self._memory = memory
+        self._transforms: dict[str, TransformFn] = {}
+        self._seen_events: dict[str, datetime] = {}
+
+    @property
+    def config(self) -> WebhookConfig:
+        return self._config
+
+    def register_transform(self, event_type_pattern: str, fn: TransformFn) -> None:
+        """Register a transform function for an event type pattern.
+
+        Patterns use simple prefix matching: ``pagerduty.incident.*``
+        matches ``pagerduty.incident.triggered``, etc.  Use ``*`` as
+        a catch-all.
+        """
+        self._transforms[event_type_pattern] = fn
+
+    def verify_signature(self, payload: bytes, headers: dict[str, str]) -> bool:
+        """Verify the HMAC signature of an incoming webhook payload."""
+        if not self._config.secret:
+            return True
+
+        sig_header = headers.get(self._config.signature_header, "")
+        if not sig_header:
+            return False
+
+        expected = hmac.new(
+            self._config.secret.encode(),
+            payload,
+            getattr(hashlib, self._config.signature_algo),
+        ).hexdigest()
+
+        sig_value = sig_header.split("=", 1)[-1] if "=" in sig_header else sig_header
+        return hmac.compare_digest(expected, sig_value)
+
+    def is_duplicate(self, event_id: str) -> bool:
+        """Check if we've already processed this event (idempotency guard)."""
+        now = datetime.now(timezone.utc)
+        cutoff = now.timestamp() - self._config.dedup_window_seconds
+        expired = [k for k, v in self._seen_events.items() if v.timestamp() < cutoff]
+        for k in expired:
+            del self._seen_events[k]
+
+        if event_id in self._seen_events:
+            return True
+        self._seen_events[event_id] = now
+        return False
+
+    def _find_transform(self, event_type: str) -> TransformFn | None:
+        if event_type in self._transforms:
+            return self._transforms[event_type]
+        for pattern, fn in self._transforms.items():
+            if pattern.endswith("*") and event_type.startswith(pattern[:-1]):
+                return fn
+        return self._transforms.get("*")
+
+    def ingest(
+        self,
+        payload: bytes,
+        headers: dict[str, str],
+        *,
+        source: str = "webhook",
+        event_type: str = "generic",
+        event_id: str | None = None,
+    ) -> list[IngestionResult]:
+        """Process an incoming webhook payload end-to-end."""
+        results: list[IngestionResult] = []
+
+        if len(payload) > self._config.max_payload_bytes:
+            results.append(IngestionResult(
+                connector_id=self._config.id,
+                event_id=event_id or "unknown",
+                entity_path=self._config.entity_path,
+                key="error",
+                action="skip",
+                success=False,
+                error=f"Payload too large: {len(payload)} bytes (max {self._config.max_payload_bytes})",
+            ))
+            return results
+
+        if not self.verify_signature(payload, headers):
+            results.append(IngestionResult(
+                connector_id=self._config.id,
+                event_id=event_id or "unknown",
+                entity_path=self._config.entity_path,
+                key="error",
+                action="skip",
+                success=False,
+                error="Invalid webhook signature",
+            ))
+            return results
+
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as e:
+            results.append(IngestionResult(
+                connector_id=self._config.id,
+                event_id=event_id or "unknown",
+                entity_path=self._config.entity_path,
+                key="error",
+                action="skip",
+                success=False,
+                error=f"Invalid JSON: {e}",
+            ))
+            return results
+
+        eid = event_id or data.get("id") or str(uuid4())
+
+        if self.is_duplicate(eid):
+            results.append(IngestionResult(
+                connector_id=self._config.id,
+                event_id=eid,
+                entity_path=self._config.entity_path,
+                key="duplicate",
+                action="skip",
+                success=True,
+                details={"reason": "duplicate_event"},
+            ))
+            return results
+
+        event = WebhookEvent(
+            connector_id=self._config.id,
+            source=source,
+            event_type=event_type,
+            payload=data,
+            headers=headers,
+        )
+
+        transform = self._find_transform(event_type)
+        if transform:
+            results.extend(transform(event))
+        else:
+            if self._memory:
+                self._memory.record_context(
+                    label=f"{source}/{event_type}",
+                    summary=json.dumps(data)[:500],
+                    source=source,
+                )
+            results.append(IngestionResult(
+                connector_id=self._config.id,
+                event_id=eid,
+                entity_path=self._config.entity_path,
+                key=f"event-{eid[:8]}",
+                action="context",
+                success=True,
+            ))
+
+        return results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ members = [
     "packages/cli",
     "packages/mcp-server",
     "packages/http-server",
+    "packages/connectors",
     "packages/integrations/crewai",
 ]
 
@@ -47,6 +48,7 @@ amfs = { workspace = true }
 amfs-cli = { workspace = true }
 amfs-mcp-server = { workspace = true }
 amfs-http-server = { workspace = true }
+amfs-connectors = { workspace = true }
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
## Summary

- Move connector base classes (ConnectorABC, WebhookIngester) and PagerDuty provider from Pro to OSS
- Add ConnectorManifest Pydantic model for connector.yaml spec
- Add ConnectorRegistry with importlib.metadata entry-point auto-discovery
- Add MockAMFS test harness for connector authors

## Test plan

- [ ] Import amfs_connectors and verify all exports
- [ ] Validate connector.yaml loading and validation
- [ ] Test registry auto-discovery of PagerDuty entry point
- [ ] Test MockAMFS write/context recording
