### PR TITLE
feat: add GitHub, Slack, and Jira reference connectors

### DIFF
--- a/packages/connectors/pyproject.toml
+++ b/packages/connectors/pyproject.toml
@@ -16,6 +16,9 @@ cli = ["typer>=0.12"]
 
 [project.entry-points."amfs.connectors"]
 pagerduty = "amfs_connectors.providers.pagerduty:PagerDutyConnector"
+github = "amfs_connectors.providers.github_events:GitHubConnector"
+slack = "amfs_connectors.providers.slack:SlackConnector"
+jira = "amfs_connectors.providers.jira:JiraConnector"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/connectors/src/amfs_connectors/providers/__init__.py
+++ b/packages/connectors/src/amfs_connectors/providers/__init__.py
@@ -1,1 +1,13 @@
 """Built-in connector providers for common external systems."""
+
+from amfs_connectors.providers.github_events import GitHubConnector
+from amfs_connectors.providers.jira import JiraConnector
+from amfs_connectors.providers.pagerduty import PagerDutyConnector
+from amfs_connectors.providers.slack import SlackConnector
+
+__all__ = [
+    "GitHubConnector",
+    "JiraConnector",
+    "PagerDutyConnector",
+    "SlackConnector",
+]

--- a/packages/connectors/src/amfs_connectors/providers/github_events.py
+++ b/packages/connectors/src/amfs_connectors/providers/github_events.py
@@ -1,0 +1,221 @@
+"""GitHub connector -- transforms GitHub webhook events into AMFS memory.
+
+Handles push, pull_request, issues, and deployment_status events,
+transforming them into structured AMFS writes keyed by repository.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from amfs_connectors.base import ConnectorABC, ConnectorConfig, IngestionResult
+from amfs_connectors.webhook import WebhookEvent
+
+
+class GitHubConfig(ConnectorConfig):
+    """GitHub-specific connector configuration."""
+
+    connector_type: str = "github"
+    webhook_secret: str | None = None
+    tracked_events: list[str] = [
+        "push",
+        "pull_request",
+        "issues",
+        "deployment_status",
+    ]
+
+
+class GitHubConnector(ConnectorABC):
+    """GitHub webhook event connector.
+
+    Registered as the ``github`` entry point.
+    """
+
+    def __init__(self, config: ConnectorConfig | None = None) -> None:
+        super().__init__(config or ConnectorConfig(
+            name="github",
+            connector_type="github",
+            entity_path="github",
+        ))
+
+    def validate_event(self, raw_event: dict[str, Any]) -> bool:
+        if "action" in raw_event and "repository" in raw_event:
+            return True
+        if "ref" in raw_event and "commits" in raw_event:
+            return True
+        if "deployment_status" in raw_event:
+            return True
+        return False
+
+    def extract_event_id(self, raw_event: dict[str, Any]) -> str:
+        if "hook_id" in raw_event and "action" in raw_event:
+            return f"gh-{raw_event['hook_id']}-{raw_event['action']}"
+        return f"gh-{uuid4().hex[:12]}"
+
+    def transform(self, raw_event: dict[str, Any]) -> list[IngestionResult]:
+        event = WebhookEvent(
+            connector_id=self._config.id,
+            source="github",
+            event_type=_detect_event_type(raw_event),
+            payload=raw_event,
+            headers={},
+        )
+        return _transform_github_event(event)
+
+
+def _detect_event_type(payload: dict[str, Any]) -> str:
+    if "commits" in payload and "ref" in payload:
+        return "push"
+    if "pull_request" in payload:
+        return "pull_request"
+    if "issue" in payload and "pull_request" not in payload:
+        return "issues"
+    if "deployment_status" in payload:
+        return "deployment_status"
+    return payload.get("action", "unknown")
+
+
+def _transform_github_event(event: WebhookEvent) -> list[IngestionResult]:
+    handler = _HANDLERS.get(event.event_type)
+    if handler:
+        return handler(event)
+
+    return [IngestionResult(
+        connector_id=event.connector_id,
+        event_id=str(uuid4())[:8],
+        entity_path=_repo_entity(event.payload),
+        key=f"gh-event-{event.event_type}",
+        action="context",
+        success=True,
+        details={"event_type": event.event_type},
+    )]
+
+
+def _repo_entity(payload: dict[str, Any]) -> str:
+    repo = payload.get("repository", {})
+    name = repo.get("full_name", repo.get("name", "unknown"))
+    return f"github/{name}"
+
+
+def _handle_push(event: WebhookEvent) -> list[IngestionResult]:
+    payload = event.payload
+    repo = _repo_entity(payload)
+    ref = payload.get("ref", "")
+    branch = ref.rsplit("/", 1)[-1] if "/" in ref else ref
+    commits = payload.get("commits", [])
+    pusher = payload.get("pusher", {}).get("name", "unknown")
+    head_commit = payload.get("head_commit", {})
+
+    return [IngestionResult(
+        connector_id=event.connector_id,
+        event_id=head_commit.get("id", str(uuid4())[:8]),
+        entity_path=repo,
+        key=f"push-{branch}-{head_commit.get('id', 'latest')[:8]}",
+        action="write",
+        success=True,
+        details={
+            "event_type": "push",
+            "branch": branch,
+            "pusher": pusher,
+            "commit_count": len(commits),
+            "head_message": head_commit.get("message", ""),
+            "head_sha": head_commit.get("id", ""),
+            "compare_url": payload.get("compare", ""),
+        },
+    )]
+
+
+def _handle_pull_request(event: WebhookEvent) -> list[IngestionResult]:
+    payload = event.payload
+    repo = _repo_entity(payload)
+    action = payload.get("action", "unknown")
+    pr = payload.get("pull_request", {})
+    number = pr.get("number", 0)
+    merged = pr.get("merged", False)
+
+    effective_action = "merged" if action == "closed" and merged else action
+
+    return [IngestionResult(
+        connector_id=event.connector_id,
+        event_id=f"pr-{number}",
+        entity_path=repo,
+        key=f"pr-{number}-{effective_action}",
+        action="write",
+        success=True,
+        details={
+            "event_type": "pull_request",
+            "action": effective_action,
+            "number": number,
+            "title": pr.get("title", ""),
+            "author": pr.get("user", {}).get("login", "unknown"),
+            "base_branch": pr.get("base", {}).get("ref", ""),
+            "head_branch": pr.get("head", {}).get("ref", ""),
+            "merged": merged,
+            "html_url": pr.get("html_url", ""),
+        },
+    )]
+
+
+def _handle_issues(event: WebhookEvent) -> list[IngestionResult]:
+    payload = event.payload
+    repo = _repo_entity(payload)
+    action = payload.get("action", "unknown")
+    issue = payload.get("issue", {})
+    number = issue.get("number", 0)
+
+    return [IngestionResult(
+        connector_id=event.connector_id,
+        event_id=f"issue-{number}",
+        entity_path=repo,
+        key=f"issue-{number}-{action}",
+        action="write",
+        success=True,
+        details={
+            "event_type": "issues",
+            "action": action,
+            "number": number,
+            "title": issue.get("title", ""),
+            "author": issue.get("user", {}).get("login", "unknown"),
+            "state": issue.get("state", ""),
+            "labels": [l.get("name", "") for l in issue.get("labels", [])],
+            "html_url": issue.get("html_url", ""),
+        },
+    )]
+
+
+def _handle_deployment_status(event: WebhookEvent) -> list[IngestionResult]:
+    payload = event.payload
+    repo = _repo_entity(payload)
+    dep_status = payload.get("deployment_status", {})
+    deployment = payload.get("deployment", {})
+    status_id = dep_status.get("id", str(uuid4())[:8])
+    state = dep_status.get("state", "unknown")
+    environment = dep_status.get("environment", deployment.get("environment", "unknown"))
+
+    return [IngestionResult(
+        connector_id=event.connector_id,
+        event_id=f"deploy-{status_id}",
+        entity_path=repo,
+        key=f"deploy-{environment}-{state}",
+        action="write",
+        success=True,
+        details={
+            "event_type": "deployment_status",
+            "state": state,
+            "environment": environment,
+            "description": dep_status.get("description", ""),
+            "creator": dep_status.get("creator", {}).get("login", "unknown"),
+            "ref": deployment.get("ref", ""),
+            "sha": deployment.get("sha", ""),
+            "target_url": dep_status.get("target_url", ""),
+        },
+    )]
+
+
+_HANDLERS: dict[str, Any] = {
+    "push": _handle_push,
+    "pull_request": _handle_pull_request,
+    "issues": _handle_issues,
+    "deployment_status": _handle_deployment_status,
+}

--- a/packages/connectors/src/amfs_connectors/providers/jira.py
+++ b/packages/connectors/src/amfs_connectors/providers/jira.py
@@ -1,0 +1,248 @@
+"""Jira connector -- transforms Jira webhook events into AMFS memory.
+
+Handles issue_created, issue_updated, sprint_started, and sprint_closed
+events, transforming them into structured writes keyed by project.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from amfs_connectors.base import ConnectorABC, ConnectorConfig, IngestionResult
+from amfs_connectors.webhook import WebhookEvent
+
+
+class JiraConfig(ConnectorConfig):
+    """Jira-specific connector configuration."""
+
+    connector_type: str = "jira"
+    base_url: str | None = None
+    tracked_events: list[str] = [
+        "jira:issue_created",
+        "jira:issue_updated",
+        "sprint_started",
+        "sprint_closed",
+    ]
+
+
+class JiraConnector(ConnectorABC):
+    """Jira webhook event connector.
+
+    Registered as the ``jira`` entry point.
+    """
+
+    def __init__(self, config: ConnectorConfig | None = None) -> None:
+        super().__init__(config or ConnectorConfig(
+            name="jira",
+            connector_type="jira",
+            entity_path="jira",
+        ))
+
+    def validate_event(self, raw_event: dict[str, Any]) -> bool:
+        if "webhookEvent" in raw_event:
+            return True
+        if "sprint" in raw_event and "event" in raw_event:
+            return True
+        return False
+
+    def extract_event_id(self, raw_event: dict[str, Any]) -> str:
+        ts = raw_event.get("timestamp", "")
+        issue = raw_event.get("issue", {})
+        issue_key = issue.get("key", "")
+        if issue_key:
+            return f"jira-{issue_key}-{ts}"
+        return f"jira-{uuid4().hex[:12]}"
+
+    def transform(self, raw_event: dict[str, Any]) -> list[IngestionResult]:
+        webhook_event_type = raw_event.get("webhookEvent", "")
+        event = WebhookEvent(
+            connector_id=self._config.id,
+            source="jira",
+            event_type=_normalize_event_type(webhook_event_type, raw_event),
+            payload=raw_event,
+            headers={},
+        )
+        return _transform_jira_event(event)
+
+
+def _normalize_event_type(webhook_event: str, payload: dict[str, Any]) -> str:
+    if webhook_event in ("jira:issue_created", "jira:issue_updated"):
+        return webhook_event
+
+    sprint = payload.get("sprint", {})
+    if sprint:
+        state = sprint.get("state", "").lower()
+        if state == "active":
+            return "sprint_started"
+        if state == "closed":
+            return "sprint_closed"
+
+    return webhook_event or "unknown"
+
+
+def _transform_jira_event(event: WebhookEvent) -> list[IngestionResult]:
+    handler = _HANDLERS.get(event.event_type)
+    if handler:
+        return handler(event)
+
+    return [IngestionResult(
+        connector_id=event.connector_id,
+        event_id=str(uuid4())[:8],
+        entity_path=_project_entity(event.payload),
+        key=f"jira-event-{event.event_type}",
+        action="context",
+        success=True,
+        details={"event_type": event.event_type},
+    )]
+
+
+def _project_entity(payload: dict[str, Any]) -> str:
+    issue = payload.get("issue", {})
+    fields = issue.get("fields", {})
+    project = fields.get("project", {})
+    key = project.get("key", "")
+    if key:
+        return f"jira/{key}"
+
+    sprint = payload.get("sprint", {})
+    origin = sprint.get("originBoardId", "")
+    if origin:
+        return f"jira/board-{origin}"
+
+    return "jira/unknown"
+
+
+def _handle_issue_created(event: WebhookEvent) -> list[IngestionResult]:
+    payload = event.payload
+    issue = payload.get("issue", {})
+    fields = issue.get("fields", {})
+    issue_key = issue.get("key", "UNKNOWN-0")
+    entity = _project_entity(payload)
+
+    return [IngestionResult(
+        connector_id=event.connector_id,
+        event_id=f"issue-{issue_key}",
+        entity_path=entity,
+        key=f"issue-{issue_key}-created",
+        action="write",
+        success=True,
+        details={
+            "event_type": "jira:issue_created",
+            "issue_key": issue_key,
+            "summary": fields.get("summary", ""),
+            "issue_type": fields.get("issuetype", {}).get("name", ""),
+            "priority": fields.get("priority", {}).get("name", ""),
+            "status": fields.get("status", {}).get("name", ""),
+            "assignee": _extract_user(fields.get("assignee")),
+            "reporter": _extract_user(fields.get("reporter")),
+            "labels": fields.get("labels", []),
+        },
+    )]
+
+
+def _handle_issue_updated(event: WebhookEvent) -> list[IngestionResult]:
+    payload = event.payload
+    issue = payload.get("issue", {})
+    fields = issue.get("fields", {})
+    issue_key = issue.get("key", "UNKNOWN-0")
+    entity = _project_entity(payload)
+    changelog = payload.get("changelog", {})
+    changes = _extract_changes(changelog)
+
+    return [IngestionResult(
+        connector_id=event.connector_id,
+        event_id=f"issue-{issue_key}-update",
+        entity_path=entity,
+        key=f"issue-{issue_key}-updated",
+        action="write",
+        success=True,
+        details={
+            "event_type": "jira:issue_updated",
+            "issue_key": issue_key,
+            "summary": fields.get("summary", ""),
+            "status": fields.get("status", {}).get("name", ""),
+            "priority": fields.get("priority", {}).get("name", ""),
+            "assignee": _extract_user(fields.get("assignee")),
+            "changes": changes,
+        },
+    )]
+
+
+def _handle_sprint_started(event: WebhookEvent) -> list[IngestionResult]:
+    payload = event.payload
+    sprint = payload.get("sprint", {})
+    sprint_name = sprint.get("name", "Unknown Sprint")
+    sprint_id = sprint.get("id", str(uuid4())[:8])
+    entity = _project_entity(payload)
+
+    return [IngestionResult(
+        connector_id=event.connector_id,
+        event_id=f"sprint-{sprint_id}-started",
+        entity_path=entity,
+        key=f"sprint-{sprint_id}-started",
+        action="write",
+        success=True,
+        details={
+            "event_type": "sprint_started",
+            "sprint_id": sprint_id,
+            "sprint_name": sprint_name,
+            "state": sprint.get("state", "active"),
+            "start_date": sprint.get("startDate", ""),
+            "end_date": sprint.get("endDate", ""),
+            "goal": sprint.get("goal", ""),
+        },
+    )]
+
+
+def _handle_sprint_closed(event: WebhookEvent) -> list[IngestionResult]:
+    payload = event.payload
+    sprint = payload.get("sprint", {})
+    sprint_name = sprint.get("name", "Unknown Sprint")
+    sprint_id = sprint.get("id", str(uuid4())[:8])
+    entity = _project_entity(payload)
+
+    return [IngestionResult(
+        connector_id=event.connector_id,
+        event_id=f"sprint-{sprint_id}-closed",
+        entity_path=entity,
+        key=f"sprint-{sprint_id}-closed",
+        action="write",
+        success=True,
+        details={
+            "event_type": "sprint_closed",
+            "sprint_id": sprint_id,
+            "sprint_name": sprint_name,
+            "state": sprint.get("state", "closed"),
+            "start_date": sprint.get("startDate", ""),
+            "end_date": sprint.get("endDate", ""),
+            "complete_date": sprint.get("completeDate", ""),
+            "goal": sprint.get("goal", ""),
+        },
+    )]
+
+
+def _extract_user(user: dict[str, Any] | None) -> str:
+    if not user:
+        return "unassigned"
+    return user.get("displayName", user.get("name", user.get("emailAddress", "unknown")))
+
+
+def _extract_changes(changelog: dict[str, Any]) -> list[dict[str, str]]:
+    items = changelog.get("items", [])
+    return [
+        {
+            "field": item.get("field", ""),
+            "from": item.get("fromString", ""),
+            "to": item.get("toString", ""),
+        }
+        for item in items
+    ]
+
+
+_HANDLERS: dict[str, Any] = {
+    "jira:issue_created": _handle_issue_created,
+    "jira:issue_updated": _handle_issue_updated,
+    "sprint_started": _handle_sprint_started,
+    "sprint_closed": _handle_sprint_closed,
+}

--- a/packages/connectors/src/amfs_connectors/providers/slack.py
+++ b/packages/connectors/src/amfs_connectors/providers/slack.py
@@ -1,0 +1,190 @@
+"""Slack connector -- transforms Slack Events API payloads into AMFS context.
+
+Handles message, app_mention, and reaction_added events,
+transforming them into context records keyed by channel.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from amfs_connectors.base import ConnectorABC, ConnectorConfig, IngestionResult
+from amfs_connectors.webhook import WebhookEvent
+
+
+class SlackConfig(ConnectorConfig):
+    """Slack-specific connector configuration."""
+
+    connector_type: str = "slack"
+    signing_secret: str | None = None
+    tracked_events: list[str] = [
+        "message",
+        "app_mention",
+        "reaction_added",
+    ]
+    max_text_length: int = 500
+
+
+class SlackConnector(ConnectorABC):
+    """Slack Events API connector.
+
+    Registered as the ``slack`` entry point.
+    """
+
+    def __init__(self, config: ConnectorConfig | None = None) -> None:
+        super().__init__(config or ConnectorConfig(
+            name="slack",
+            connector_type="slack",
+            entity_path="slack",
+        ))
+
+    def validate_event(self, raw_event: dict[str, Any]) -> bool:
+        if raw_event.get("type") == "url_verification":
+            return True
+        event = raw_event.get("event", {})
+        return bool(event.get("type"))
+
+    def extract_event_id(self, raw_event: dict[str, Any]) -> str:
+        return raw_event.get("event_id", f"slack-{uuid4().hex[:12]}")
+
+    def transform(self, raw_event: dict[str, Any]) -> list[IngestionResult]:
+        if raw_event.get("type") == "url_verification":
+            return [IngestionResult(
+                connector_id=self._config.id,
+                event_id="url_verification",
+                entity_path=self._config.entity_path,
+                key="url-verification",
+                action="skip",
+                success=True,
+                details={"challenge": raw_event.get("challenge", "")},
+            )]
+
+        inner = raw_event.get("event", {})
+        event = WebhookEvent(
+            connector_id=self._config.id,
+            source="slack",
+            event_type=inner.get("type", "unknown"),
+            payload=raw_event,
+            headers={},
+        )
+        return _transform_slack_event(event)
+
+
+def _transform_slack_event(event: WebhookEvent) -> list[IngestionResult]:
+    handler = _HANDLERS.get(event.event_type)
+    if handler:
+        return handler(event)
+
+    return [IngestionResult(
+        connector_id=event.connector_id,
+        event_id=event.payload.get("event_id", str(uuid4())[:8]),
+        entity_path=_channel_entity(event.payload.get("event", {})),
+        key=f"slack-event-{event.event_type}",
+        action="context",
+        success=True,
+        details={"event_type": event.event_type},
+    )]
+
+
+def _channel_entity(inner: dict[str, Any]) -> str:
+    channel = inner.get("channel", inner.get("item", {}).get("channel", "unknown"))
+    return f"slack/{channel}"
+
+
+def _truncate(text: str, max_len: int = 500) -> str:
+    return text[:max_len] + "..." if len(text) > max_len else text
+
+
+def _handle_message(event: WebhookEvent) -> list[IngestionResult]:
+    payload = event.payload
+    inner = payload.get("event", {})
+
+    if inner.get("subtype") == "bot_message":
+        return [IngestionResult(
+            connector_id=event.connector_id,
+            event_id=payload.get("event_id", str(uuid4())[:8]),
+            entity_path=_channel_entity(inner),
+            key=f"msg-bot-{inner.get('ts', 'unknown')}",
+            action="skip",
+            success=True,
+            details={"reason": "bot_message"},
+        )]
+
+    channel = _channel_entity(inner)
+    ts = inner.get("ts", str(uuid4())[:8])
+    user = inner.get("user", "unknown")
+    text = _truncate(inner.get("text", ""))
+    thread_ts = inner.get("thread_ts")
+
+    return [IngestionResult(
+        connector_id=event.connector_id,
+        event_id=payload.get("event_id", f"slack-{ts}"),
+        entity_path=channel,
+        key=f"msg-{ts}",
+        action="context",
+        success=True,
+        details={
+            "event_type": "message",
+            "user": user,
+            "text": text,
+            "thread_ts": thread_ts,
+            "channel": inner.get("channel", ""),
+            "is_thread_reply": thread_ts is not None and thread_ts != ts,
+        },
+    )]
+
+
+def _handle_app_mention(event: WebhookEvent) -> list[IngestionResult]:
+    payload = event.payload
+    inner = payload.get("event", {})
+    channel = _channel_entity(inner)
+    ts = inner.get("ts", str(uuid4())[:8])
+
+    return [IngestionResult(
+        connector_id=event.connector_id,
+        event_id=payload.get("event_id", f"slack-mention-{ts}"),
+        entity_path=channel,
+        key=f"mention-{ts}",
+        action="write",
+        success=True,
+        details={
+            "event_type": "app_mention",
+            "user": inner.get("user", "unknown"),
+            "text": _truncate(inner.get("text", "")),
+            "thread_ts": inner.get("thread_ts"),
+            "channel": inner.get("channel", ""),
+        },
+    )]
+
+
+def _handle_reaction_added(event: WebhookEvent) -> list[IngestionResult]:
+    payload = event.payload
+    inner = payload.get("event", {})
+    item = inner.get("item", {})
+    channel = _channel_entity(inner)
+    reaction = inner.get("reaction", "unknown")
+
+    return [IngestionResult(
+        connector_id=event.connector_id,
+        event_id=payload.get("event_id", f"slack-reaction-{reaction}"),
+        entity_path=channel,
+        key=f"reaction-{reaction}-{item.get('ts', 'unknown')}",
+        action="context",
+        success=True,
+        details={
+            "event_type": "reaction_added",
+            "user": inner.get("user", "unknown"),
+            "reaction": reaction,
+            "item_type": item.get("type", ""),
+            "item_ts": item.get("ts", ""),
+            "channel": item.get("channel", ""),
+        },
+    )]
+
+
+_HANDLERS: dict[str, Any] = {
+    "message": _handle_message,
+    "app_mention": _handle_app_mention,
+    "reaction_added": _handle_reaction_added,
+}


### PR DESCRIPTION
## Summary

- GitHubConnector: push, pull_request, issues, deployment_status events
- SlackConnector: message, app_mention, reaction_added events
- JiraConnector: issue_created, issue_updated, sprint_started, sprint_closed events
- All registered as entry points for auto-discovery

## Test plan

- [ ] Verify each connector transforms sample events correctly
- [ ] Verify entry points register in ConnectorRegistry
- [ ] Test validate_event() for each connector