### PR TITLE
feat: add composite recall scoring to search (Python + TypeScript)

### DIFF
--- a/packages/core/src/amfs_core/models.py
+++ b/packages/core/src/amfs_core/models.py
@@ -156,6 +156,23 @@ class OutcomeRecord(BaseModel):
     agent_id: str
 
 
+class RecallConfig(BaseModel):
+    """Weights for composite recall scoring."""
+
+    semantic_weight: float = 0.5
+    recency_weight: float = 0.3
+    confidence_weight: float = 0.2
+    recency_half_life_days: float = 30.0
+
+
+class ScoredEntry(BaseModel):
+    """A memory entry with composite recall score."""
+
+    entry: MemoryEntry
+    score: float
+    breakdown: dict[str, float] = Field(default_factory=dict)
+
+
 class SearchQuery(BaseModel):
     """Filters for searching across memory entries."""
 
@@ -168,6 +185,7 @@ class SearchQuery(BaseModel):
     pattern_ref: str | None = None
     limit: int = 100
     sort_by: str = "confidence"  # "confidence", "recency", "version"
+    recall_config: RecallConfig | None = None
 
 
 class MemoryStats(BaseModel):

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import logging
+import math
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
@@ -19,7 +20,9 @@ from amfs_core.models import (
     MemoryStats,
     MemoryType,
     OutcomeType,
+    RecallConfig,
     ScopeInfo,
+    ScoredEntry,
     SearchQuery,
     SemanticQuery,
 )
@@ -241,12 +244,16 @@ class AgentMemory:
         pattern_ref: str | None = None,
         limit: int = 100,
         sort_by: str = "confidence",
-    ) -> list[MemoryEntry]:
+        recall_config: RecallConfig | None = None,
+    ) -> list[MemoryEntry] | list[ScoredEntry]:
         """Search across all entities with rich filters.
 
         When *entity_paths* is provided, runs a search for each path and merges
         the results.  *entity_path* (singular) is still supported for backwards
         compatibility; if both are given, *entity_paths* takes precedence.
+
+        When *recall_config* is provided, returns ``ScoredEntry`` objects
+        sorted by composite recall score instead.
         """
         paths = entity_paths or ([entity_path] if entity_path else [None])
 
@@ -262,6 +269,7 @@ class AgentMemory:
                 pattern_ref=pattern_ref,
                 limit=limit,
                 sort_by=sort_by,
+                recall_config=recall_config,
             )
             for entry in self._adapter.search(query):
                 if entry.entry_key not in seen_keys:
@@ -276,7 +284,38 @@ class AgentMemory:
         else:
             sort_key = lambda e: e.confidence
         merged.sort(key=sort_key, reverse=True)
-        return merged[:limit]
+        entries = merged[:limit]
+
+        if recall_config is None:
+            return entries
+
+        now = datetime.now(timezone.utc)
+        scored: list[ScoredEntry] = []
+        for entry in entries:
+            age = now - entry.provenance.written_at
+            age_days = age.total_seconds() / 86400.0
+            half_life = recall_config.recency_half_life_days
+
+            recency_score = math.exp(-math.log(2) * age_days / half_life) if half_life > 0 else 0.0
+            confidence_score = max(0.0, min(1.0, entry.confidence))
+
+            composite = (
+                recall_config.semantic_weight * 1.0
+                + recall_config.recency_weight * recency_score
+                + recall_config.confidence_weight * confidence_score
+            )
+            scored.append(ScoredEntry(
+                entry=entry,
+                score=composite,
+                breakdown={
+                    "semantic": recall_config.semantic_weight * 1.0,
+                    "recency": recall_config.recency_weight * recency_score,
+                    "confidence": recall_config.confidence_weight * confidence_score,
+                },
+            ))
+
+        scored.sort(key=lambda s: s.score, reverse=True)
+        return scored
 
     def semantic_search(
         self,

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -23,5 +23,7 @@ export type {
   ArtifactRef,
   AMFSConfig,
   LayerConfig,
+  RecallConfig,
   ScopeInfo,
+  ScoredEntry,
 } from "./models.js";

--- a/packages/sdk-typescript/src/memory.ts
+++ b/packages/sdk-typescript/src/memory.ts
@@ -6,7 +6,7 @@ import type { AmfsAdapter, WatchHandle } from "./adapter.js";
 import { InMemoryAdapter } from "./adapters/filesystem.js";
 import { defaultConfig } from "./config.js";
 import { CausalTagger, CoWEngine } from "./engine.js";
-import type { AMFSConfig, MemoryEntry, ScopeInfo } from "./models.js";
+import type { AMFSConfig, MemoryEntry, RecallConfig, ScopeInfo, ScoredEntry } from "./models.js";
 import { OutcomeType } from "./models.js";
 import { OutcomeBackPropagator } from "./outcome.js";
 import { ReadTracker } from "./tracker.js";
@@ -24,6 +24,7 @@ export interface SearchOptions {
   agentId?: string;
   limit?: number;
   sortBy?: "confidence" | "recency" | "version";
+  recallConfig?: RecallConfig;
 }
 
 export interface MemoryStats {
@@ -103,8 +104,10 @@ export class AgentMemory {
     return this.engine.history(entityPath, key, options);
   }
 
-  /** Search entries with filters. Supports multi-scope via entityPaths. */
-  search(options?: SearchOptions): MemoryEntry[] {
+  /** Search entries with filters. Supports multi-scope via entityPaths and composite scoring via recallConfig. */
+  search(options: SearchOptions & { recallConfig: RecallConfig }): ScoredEntry[];
+  search(options?: SearchOptions): MemoryEntry[];
+  search(options?: SearchOptions): MemoryEntry[] | ScoredEntry[] {
     const paths =
       options?.entityPaths ??
       (options?.entityPath ? [options.entityPath] : [undefined]);
@@ -144,7 +147,45 @@ export class AgentMemory {
       merged.sort((a, b) => b.version - a.version);
     }
 
-    return merged.slice(0, options?.limit ?? 100);
+    const limited = merged.slice(0, options?.limit ?? 100);
+
+    if (!options?.recallConfig) {
+      return limited;
+    }
+
+    const rc = options.recallConfig;
+    const semanticWeight = rc.semanticWeight ?? 0.5;
+    const recencyWeight = rc.recencyWeight ?? 0.3;
+    const confidenceWeight = rc.confidenceWeight ?? 0.2;
+    const halfLife = rc.recencyHalfLifeDays ?? 30.0;
+    const now = Date.now();
+    const LN2 = Math.LN2;
+
+    const scored: ScoredEntry[] = limited.map((entry) => {
+      const writtenMs = new Date(entry.provenance.writtenAt).getTime();
+      const ageDays = (now - writtenMs) / 86_400_000;
+
+      const recencyScore =
+        halfLife > 0 ? Math.exp(-LN2 * ageDays / halfLife) : 0;
+      const confidenceScore = Math.max(0, Math.min(1, entry.confidence));
+
+      const semanticComponent = semanticWeight * 1.0;
+      const recencyComponent = recencyWeight * recencyScore;
+      const confidenceComponent = confidenceWeight * confidenceScore;
+
+      return {
+        entry,
+        score: semanticComponent + recencyComponent + confidenceComponent,
+        breakdown: {
+          semantic: semanticComponent,
+          recency: recencyComponent,
+          confidence: confidenceComponent,
+        },
+      };
+    });
+
+    scored.sort((a, b) => b.score - a.score);
+    return scored;
   }
 
   /** Aggregate statistics about current memory state. */

--- a/packages/sdk-typescript/src/models.ts
+++ b/packages/sdk-typescript/src/models.ts
@@ -70,3 +70,16 @@ export interface AMFSConfig {
   namespace: string;
   layers: Record<string, LayerConfig>;
 }
+
+export interface RecallConfig {
+  semanticWeight?: number;
+  recencyWeight?: number;
+  confidenceWeight?: number;
+  recencyHalfLifeDays?: number;
+}
+
+export interface ScoredEntry {
+  entry: MemoryEntry;
+  score: number;
+  breakdown: Record<string, number>;
+}


### PR DESCRIPTION
## Summary

- Add RecallConfig (semantic/recency/confidence weights) and ScoredEntry models
- Extend search() with optional recall_config for weighted composite scoring
- Recency score uses exponential decay with configurable half-life
- Fully backward-compatible -- recall_config defaults to None
- Implemented in both Python and TypeScript SDKs

## Test plan

- [ ] search() without recall_config behaves identically to before
- [ ] search() with recall_config returns ScoredEntry list sorted by composite score
- [ ] Verify recency decay: older entries score lower on recency axis