### PR TITLE
docs: add connector guide, CrewAI integration, update competitor comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ mem.commit_outcome(
 | HTTP/REST API | FastAPI server with 12 endpoints, SSE streaming, and API key auth. |
 | Multiple adapters | Filesystem (default), Postgres (with full-text + vector search), S3-compatible, or custom. |
 | MCP integration | First-class MCP server for Cursor, Claude Code, and any MCP client. |
+| Connector ecosystem | Ingest events from PagerDuty, GitHub, Slack, Jira, or build your own. |
+| Composite recall scoring | Rank results by relevance, recency, confidence, and outcome history. |
 | Framework integrations | CrewAI, LangGraph, LangChain, AutoGen. |
 | CLI tools | Inspect, diff, snapshot, and restore memory from the terminal. |
 | Docker & Kubernetes | Single-command deployment with Docker or Helm chart. |
@@ -167,11 +169,28 @@ Give your AI coding agents persistent, shared memory via MCP:
 
 **[Full MCP setup guide →](https://raia-live.github.io/amfs/guides/mcp/)**
 
+## Connectors
+
+AMFS connectors ingest events from external systems — PagerDuty, GitHub, Slack, Jira — and turn them into structured memory entries. Install built-in connectors or build your own:
+
+```bash
+amfs connector install pagerduty   # Install a connector
+amfs connector list                # See installed connectors
+```
+
+External systems send webhooks to `/api/v1/webhooks/{connector}`. AMFS handles HMAC verification, deduplication, and transformation into memory operations.
+
+**Built-in connectors:** PagerDuty (incident lifecycle), GitHub (PRs, deploys, issues), Slack (messages, threads), Jira (issue transitions, sprints).
+
+**Build your own:** Subclass `ConnectorABC`, define a `connector.yaml` manifest, and publish to PyPI as `amfs-connector-{name}`.
+
+**[Connector guide →](https://raia-live.github.io/amfs/guides/connectors/)**
+
 ## OSS vs Pro
 
 AMFS is available in two editions:
 
-**OSS (Apache 2.0)** — The full memory primitive: CoW versioning, confidence scoring, outcome back-propagation, session-level explainability, filesystem/Postgres/S3 adapters, HTTP API, MCP server, Python & TypeScript SDKs.
+**OSS (Apache 2.0)** — The full memory primitive: CoW versioning, confidence scoring, outcome back-propagation, session-level explainability, connector ecosystem, composite recall scoring, filesystem/Postgres/S3 adapters, HTTP API, MCP server, Python & TypeScript SDKs.
 
 **Pro (Proprietary)** — The compounding intelligence layer:
 - **Multi-Tenant SaaS** — Account isolation (Postgres RLS), RBAC, scoped API keys, OAuth/OIDC, audit logging, rate limiting, usage quotas
@@ -192,7 +211,7 @@ Visit **[raia-live.github.io/amfs](https://raia-live.github.io/amfs/)** for the 
 - [Core Concepts](https://raia-live.github.io/amfs/concepts/) — memory entries, CoW, confidence, provenance
 - [OSS vs Pro](https://raia-live.github.io/amfs/editions/) — feature comparison and when to use which
 - [AMFS vs Vector Databases](https://raia-live.github.io/amfs/vs-vector-databases/) — when to use which, and how they complement each other
-- [AMFS vs Competitors](https://raia-live.github.io/amfs/vs-competitors/) — comparison with Mem0, Cognee, Zep/Graphiti, LangMem
+- [AMFS vs Competitors](https://raia-live.github.io/amfs/vs-competitors/) — comparison with Mem0, Cognee, Zep/Graphiti, CrewAI Memory, LangMem
 - [Guides](https://raia-live.github.io/amfs/guides/) — Python SDK, TypeScript SDK, CLI, MCP, HTTP API, Docker & Kubernetes
 - [Adapters](https://raia-live.github.io/amfs/adapters/) — filesystem, Postgres, S3-compatible, custom adapters
 - [Integrations](https://raia-live.github.io/amfs/integrations/) — CrewAI, LangGraph, LangChain, AutoGen

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -62,8 +62,10 @@ AMFS is split into two layers: a fully open-source core and a proprietary Pro la
 │                                                          │
 │  CoW Engine · Memory Types · Provenance Tiers             │
 │  Temporal Queries · Session-Level Causal Explainability   │
-│  Adapters (Filesystem, Postgres, S3) · HTTP/REST API      │
-│  MCP Server · Python SDK · TypeScript SDK · CLI           │
+│  Composite Recall Scoring · Multi-Scope Search            │
+│  Connector Framework · CLI · Built-in Connectors          │
+│  Webhook Receiver · Adapters (FS, Postgres, S3)           │
+│  HTTP/REST API · MCP Server · Python SDK · TS SDK · CLI   │
 │  Docker + Helm Charts                                     │
 └──────────────────────────────────────────────────────────┘
 ```
@@ -82,6 +84,13 @@ AMFS is split into two layers: a fully open-source core and a proprietary Pro la
 | Provenance tiers (production-validated → manual) | Yes | Yes |
 | Temporal queries (`history`) | Yes | Yes |
 | Session-level causal explainability (`explain`) | Yes | Yes |
+| Composite recall scoring | Yes | Yes |
+| Multi-scope search | Yes | Yes |
+| **Connectors** | | |
+| Connector framework (`ConnectorABC`) | Yes | Yes |
+| Connector CLI (`amfs connector install/list/remove`) | Yes | Yes |
+| Built-in connectors (PagerDuty, GitHub, Slack, Jira) | Yes | Yes |
+| Webhook receiver (`/api/v1/webhooks/{name}`) | Yes | Yes |
 | **Adapters & Infrastructure** | | |
 | Filesystem adapter | Yes | Yes |
 | Postgres adapter (triggers, LISTEN/NOTIFY) | Yes | Yes |
@@ -108,12 +117,12 @@ AMFS is split into two layers: a fully open-source core and a proprietary Pro la
 | Historical `explain(outcome_ref)` | — | Yes |
 | `search_traces` / precedent search API | — | Yes |
 | Cross-agent, cross-session trace queries | — | Yes |
-| **Cross-System Ingestion (Pro)** | | |
-| Generic webhook endpoint with HMAC verification | — | Yes |
-| Payload deduplication (idempotency) | — | Yes |
-| Pluggable transform pipeline with pattern matching | — | Yes |
-| PagerDuty incident connector | — | Yes |
-| Extensible connector framework (`ConnectorABC`) | — | Yes |
+| **Cross-System Ingestion** | | |
+| Generic webhook endpoint with HMAC verification | Yes | Yes |
+| Payload deduplication (idempotency) | Yes | Yes |
+| Pluggable transform pipeline with pattern matching | Yes | Yes |
+| PagerDuty incident connector | Yes | Yes |
+| Extensible connector framework (`ConnectorABC`) | Yes | Yes |
 | **Automated Pattern Detection (Pro)** | | |
 | Recurring failure detection across causal chains | — | Yes |
 | Hot entity detection (disproportionate activity) | — | Yes |
@@ -144,7 +153,7 @@ AMFS is split into two layers: a fully open-source core and a proprietary Pro la
 
 ## OSS Layer — What's Included
 
-The open-source layer ([github.com/raia-live/amfs](https://github.com/raia-live/amfs)) provides the full memory primitive: read, write, version, search, and learn from outcomes.
+The open-source layer ([github.com/raia-live/amfs](https://github.com/raia-live/amfs)) provides the full memory primitive: read, write, version, search, and learn from outcomes. It also includes a connector framework for ingesting events from external systems, composite recall scoring, and multi-scope search.
 
 ### Packages
 

--- a/docs/guides/connectors.md
+++ b/docs/guides/connectors.md
@@ -1,0 +1,497 @@
+---
+title: Connectors
+layout: default
+parent: Guides
+nav_order: 7
+description: "Connect external systems to AMFS — install built-in connectors or build your own."
+---
+
+# Connectors
+{: .no_toc }
+
+Connectors let AMFS ingest events from external systems — PagerDuty incidents, GitHub PRs, Slack messages, Jira tickets — and turn them into structured memory entries that agents can query and learn from.
+{: .fs-6 .fw-300 }
+
+## Table of Contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## What Are Connectors?
+
+A connector is a plugin that bridges an external system and AMFS. It receives raw events (typically via webhooks), transforms them into `write()` or `record_context()` operations, and feeds them into the memory store.
+
+```
+External System          AMFS
+┌──────────┐      ┌──────────────────────────────────┐
+│ PagerDuty│─────▶│  Webhook Endpoint                │
+│ GitHub   │─────▶│  /api/v1/webhooks/{connector}    │
+│ Slack    │─────▶│                                  │
+│ Jira     │─────▶│  ┌────────────┐  ┌────────────┐ │
+│ Custom   │─────▶│  │ Connector  │──▶│ AgentMemory│ │
+└──────────┘      │  │ Transform  │  │  write()   │ │
+                  │  └────────────┘  │  record()  │ │
+                  │                  └────────────┘ │
+                  └──────────────────────────────────┘
+```
+
+Each connector:
+- Validates incoming payloads (HMAC signature verification)
+- Deduplicates events (idempotency keys)
+- Transforms raw JSON into AMFS memory operations
+- Writes structured entries with proper entity paths, confidence scores, and memory types
+
+---
+
+## Installing a Connector
+
+Install connectors from PyPI using the `amfs` CLI:
+
+```bash
+amfs connector install pagerduty
+```
+
+This installs the `amfs-connector-pagerduty` package and registers it with AMFS. You can also install directly via pip:
+
+```bash
+pip install amfs-connector-pagerduty
+```
+
+List installed connectors:
+
+```bash
+amfs connector list
+```
+
+Remove a connector:
+
+```bash
+amfs connector remove pagerduty
+```
+
+---
+
+## Connecting External Systems
+
+Once a connector is installed, external systems send events to AMFS via a webhook URL.
+
+### Webhook URL
+
+Each connector exposes a webhook endpoint:
+
+```
+POST /api/v1/webhooks/{name}
+```
+
+For example, after installing the PagerDuty connector:
+
+```
+POST https://your-amfs-host/api/v1/webhooks/pagerduty
+```
+
+### Authentication
+
+Connectors use HMAC signature verification to validate incoming payloads. Configure the shared secret as an environment variable:
+
+```bash
+export AMFS_CONNECTOR_PAGERDUTY_SECRET=whsec_your_secret_here
+export AMFS_CONNECTOR_GITHUB_SECRET=whsec_your_secret_here
+export AMFS_CONNECTOR_SLACK_SECRET=whsec_your_secret_here
+export AMFS_CONNECTOR_JIRA_SECRET=whsec_your_secret_here
+```
+
+The naming convention is `AMFS_CONNECTOR_{NAME}_SECRET` where `{NAME}` is the uppercased connector name.
+
+### Headers
+
+Connectors expect standard webhook headers from the source system. For example, PagerDuty sends `X-PagerDuty-Signature`, GitHub sends `X-Hub-Signature-256`. Each connector knows how to validate its own system's signature format.
+
+---
+
+## Built-in Connectors
+
+### PagerDuty
+
+Ingests incident lifecycle events: triggered, acknowledged, resolved.
+
+```bash
+amfs connector install pagerduty
+```
+
+**What it captures:**
+- Incident title, severity, and status
+- Assigned responders
+- Service and escalation policy
+- Resolution notes
+
+**Entity path:** `incidents/pagerduty/{service_name}`
+
+**Example entry:**
+
+```python
+{
+    "incident_id": "P1234ABC",
+    "title": "High error rate on checkout-service",
+    "severity": "critical",
+    "status": "triggered",
+    "service": "checkout-service",
+    "assignees": ["oncall-team"],
+}
+```
+
+---
+
+### GitHub
+
+Ingests pull request events, deployment statuses, and issue updates.
+
+```bash
+amfs connector install github
+```
+
+**What it captures:**
+- PR opened/merged/closed events with diff stats
+- Deployment success/failure with environment info
+- Issue state changes and label updates
+
+**Entity path:** `repos/{owner}/{repo}`
+
+---
+
+### Slack
+
+Ingests channel messages and thread context relevant to incidents or decisions.
+
+```bash
+amfs connector install slack
+```
+
+**What it captures:**
+- Messages from monitored channels
+- Thread context around incident discussions
+- Bot interaction logs
+
+**Entity path:** `comms/slack/{channel}`
+
+---
+
+### Jira
+
+Ingests issue transitions, sprint events, and release notes.
+
+```bash
+amfs connector install jira
+```
+
+**What it captures:**
+- Issue status transitions (e.g., In Progress → Done)
+- Sprint start/complete events
+- Release creation and deployment tracking
+
+**Entity path:** `projects/jira/{project_key}`
+
+---
+
+## Building Your Own Connector
+
+You can build a connector for any system that sends webhooks or has an API.
+
+### Step 1: Create the Package
+
+```bash
+mkdir amfs-connector-myservice
+cd amfs-connector-myservice
+```
+
+### Step 2: Write the Connector Manifest
+
+Create a `connector.yaml` at the package root:
+
+```yaml
+name: myservice
+version: "1.0.0"
+description: "Ingest events from MyService into AMFS"
+author: "Your Name"
+license: "Apache-2.0"
+
+entry_point: amfs_connector_myservice.connector:MyServiceConnector
+
+webhook:
+  signature_header: "X-MyService-Signature"
+  signature_algorithm: "hmac-sha256"
+
+default_entity_path: "integrations/myservice"
+
+event_types:
+  - "event.created"
+  - "event.updated"
+  - "event.deleted"
+
+env_vars:
+  - name: AMFS_CONNECTOR_MYSERVICE_SECRET
+    description: "HMAC secret for webhook signature verification"
+    required: true
+  - name: AMFS_CONNECTOR_MYSERVICE_API_KEY
+    description: "API key for pulling historical data"
+    required: false
+```
+
+### Step 3: Implement the Connector
+
+Subclass `ConnectorABC` and implement the `transform` method:
+
+```python
+from amfs_connectors import ConnectorABC, ConnectorEvent, ConnectorResult
+from amfs import MemoryType
+
+
+class MyServiceConnector(ConnectorABC):
+    """Transforms MyService webhook events into AMFS memory operations."""
+
+    name = "myservice"
+
+    def transform(self, event: ConnectorEvent) -> list[ConnectorResult]:
+        payload = event.payload
+        event_type = event.event_type
+
+        results = []
+
+        if event_type == "event.created":
+            results.append(ConnectorResult(
+                operation="write",
+                entity_path=f"integrations/myservice/{payload['project']}",
+                key=f"event-{payload['id']}",
+                value={
+                    "type": payload["type"],
+                    "summary": payload["summary"],
+                    "severity": payload.get("severity", "info"),
+                },
+                confidence=0.7,
+                memory_type=MemoryType.FACT,
+            ))
+
+        elif event_type == "event.deleted":
+            results.append(ConnectorResult(
+                operation="record_context",
+                label=f"myservice-deletion-{payload['id']}",
+                summary=f"Event {payload['id']} deleted from MyService",
+                source="myservice",
+            ))
+
+        return results
+
+    def validate_signature(self, payload: bytes, signature: str, secret: str) -> bool:
+        import hashlib
+        import hmac
+        expected = hmac.new(
+            secret.encode(), payload, hashlib.sha256
+        ).hexdigest()
+        return hmac.compare_digest(expected, signature)
+```
+
+### Step 4: Add Package Metadata
+
+Create `pyproject.toml`:
+
+```toml
+[project]
+name = "amfs-connector-myservice"
+version = "1.0.0"
+description = "MyService connector for AMFS"
+requires-python = ">=3.10"
+dependencies = ["amfs>=0.1.0"]
+
+[project.entry-points."amfs.connectors"]
+myservice = "amfs_connector_myservice.connector:MyServiceConnector"
+```
+
+### Step 5: Test with MockAMFS
+
+Use `MockAMFS` to test your connector without a running AMFS instance:
+
+```python
+from amfs.testing import MockAMFS
+from amfs_connector_myservice.connector import MyServiceConnector
+
+
+def test_event_created():
+    mock = MockAMFS()
+    connector = MyServiceConnector(memory=mock)
+
+    event = ConnectorEvent(
+        event_type="event.created",
+        payload={
+            "id": "evt-123",
+            "project": "my-project",
+            "type": "alert",
+            "summary": "CPU spike detected",
+            "severity": "warning",
+        },
+        headers={"X-MyService-Signature": "abc123"},
+    )
+
+    results = connector.transform(event)
+
+    assert len(results) == 1
+    assert results[0].operation == "write"
+    assert results[0].entity_path == "integrations/myservice/my-project"
+    assert results[0].key == "event-evt-123"
+
+
+def test_signature_validation():
+    connector = MyServiceConnector(memory=MockAMFS())
+    payload = b'{"test": true}'
+    import hashlib, hmac
+    secret = "test-secret"
+    sig = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    assert connector.validate_signature(payload, sig, secret)
+```
+
+Run tests:
+
+```bash
+pytest tests/ -v
+```
+
+---
+
+## Publishing Your Connector
+
+### PyPI Naming Convention
+
+Connector packages should follow the naming convention:
+
+```
+amfs-connector-{name}
+```
+
+Examples:
+- `amfs-connector-pagerduty`
+- `amfs-connector-github`
+- `amfs-connector-datadog`
+- `amfs-connector-opsgenie`
+
+### GitHub Topic
+
+Tag your repository with the `amfs-connector` topic on GitHub so it appears in connector searches:
+
+```
+https://github.com/topics/amfs-connector
+```
+
+### Publishing to PyPI
+
+```bash
+pip install build twine
+python -m build
+twine upload dist/*
+```
+
+Once published, users can install your connector with:
+
+```bash
+amfs connector install {name}
+# or
+pip install amfs-connector-{name}
+```
+
+---
+
+## connector.yaml Reference
+
+The `connector.yaml` manifest describes your connector to AMFS. Here is the full specification:
+
+```yaml
+# Required: unique connector name (lowercase, alphanumeric, hyphens)
+name: myservice
+
+# Required: semantic version
+version: "1.0.0"
+
+# Required: human-readable description
+description: "Ingest events from MyService into AMFS"
+
+# Optional: author name or organization
+author: "Your Name <you@example.com>"
+
+# Optional: license identifier (SPDX)
+license: "Apache-2.0"
+
+# Required: Python import path to the ConnectorABC subclass
+entry_point: amfs_connector_myservice.connector:MyServiceConnector
+
+# Webhook configuration
+webhook:
+  # Header name containing the HMAC signature
+  signature_header: "X-MyService-Signature"
+
+  # HMAC algorithm: hmac-sha256 | hmac-sha1 | hmac-sha512
+  signature_algorithm: "hmac-sha256"
+
+  # Optional: prefix stripped from signature header value before validation
+  # e.g., PagerDuty uses "v1=" prefix
+  signature_prefix: ""
+
+  # Optional: maximum payload size in bytes (default: 1048576 = 1MB)
+  max_payload_bytes: 1048576
+
+# Default entity path for entries created by this connector
+# Can be overridden per-event in the transform method
+default_entity_path: "integrations/myservice"
+
+# List of event types this connector handles
+# Used for documentation and routing; the transform method receives the event_type
+event_types:
+  - "event.created"
+  - "event.updated"
+  - "event.deleted"
+
+# Environment variables the connector expects
+env_vars:
+  - name: AMFS_CONNECTOR_MYSERVICE_SECRET
+    description: "HMAC secret for webhook signature verification"
+    required: true
+
+  - name: AMFS_CONNECTOR_MYSERVICE_API_KEY
+    description: "API key for pulling historical data (optional)"
+    required: false
+
+  - name: AMFS_CONNECTOR_MYSERVICE_ENTITY_PREFIX
+    description: "Custom entity path prefix (overrides default_entity_path)"
+    required: false
+
+# Optional: minimum AMFS version required
+min_amfs_version: "0.1.0"
+
+# Optional: additional Python dependencies beyond amfs
+dependencies:
+  - "requests>=2.28.0"
+
+# Optional: connector-specific configuration defaults
+config:
+  batch_size: 100
+  retry_attempts: 3
+  retry_delay_seconds: 5
+```
+
+| Field | Required | Description |
+|:------|:--------:|:------------|
+| `name` | Yes | Unique connector name. Lowercase, alphanumeric, hyphens only. |
+| `version` | Yes | Semantic version string. |
+| `description` | Yes | Human-readable description. |
+| `author` | No | Author name or email. |
+| `license` | No | SPDX license identifier. |
+| `entry_point` | Yes | Python import path to the `ConnectorABC` subclass (`module.path:ClassName`). |
+| `webhook.signature_header` | Yes | HTTP header containing the HMAC signature. |
+| `webhook.signature_algorithm` | Yes | Algorithm for HMAC verification. |
+| `webhook.signature_prefix` | No | Prefix to strip from the signature header value. |
+| `webhook.max_payload_bytes` | No | Maximum payload size (default 1 MB). |
+| `default_entity_path` | Yes | Default entity path for created entries. |
+| `event_types` | Yes | List of event types the connector handles. |
+| `env_vars` | No | Environment variables with name, description, and required flag. |
+| `min_amfs_version` | No | Minimum compatible AMFS version. |
+| `dependencies` | No | Additional Python dependencies. |
+| `config` | No | Connector-specific configuration defaults. |

--- a/docs/guides/crewai.md
+++ b/docs/guides/crewai.md
@@ -1,0 +1,236 @@
+---
+title: CrewAI Integration
+layout: default
+parent: Guides
+nav_order: 8
+description: "Use AMFS as the storage backend for CrewAI memory — get versioning, provenance, and outcome tracking on top of CrewAI's agent orchestration."
+---
+
+# CrewAI Integration
+{: .no_toc }
+
+AMFS plugs into CrewAI as a storage backend, giving your crews versioned, outcome-aware memory that persists across runs and survives restarts.
+{: .fs-6 .fw-300 }
+
+## Table of Contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Overview
+
+[CrewAI](https://crewai.com) provides a powerful framework for orchestrating multi-agent workflows with built-in memory support. By default, CrewAI stores memories in local files or vector databases. AMFS replaces that storage layer while preserving CrewAI's full API — you get CrewAI's agent orchestration **plus** AMFS's versioning, confidence scoring, and outcome back-propagation.
+
+```
+┌────────────────────────────────────────┐
+│              CrewAI Crew               │
+│                                        │
+│  ┌──────────┐  ┌──────────┐            │
+│  │ Agent A  │  │ Agent B  │  ...       │
+│  └────┬─────┘  └────┬─────┘            │
+│       │              │                 │
+│       └──────┬───────┘                 │
+│              ▼                         │
+│     ┌──────────────┐                   │
+│     │ CrewAI Memory│                   │
+│     │   (API)      │                   │
+│     └──────┬───────┘                   │
+│            │                           │
+│            ▼                           │
+│   ┌────────────────┐                   │
+│   │ AMFSStorage    │  ← storage=...    │
+│   │ Backend        │                   │
+│   └────────┬───────┘                   │
+└────────────┼───────────────────────────┘
+             │
+             ▼
+    ┌────────────────┐
+    │  AgentMemory   │  CoW · Provenance · Outcomes
+    │  (AMFS)        │
+    └────────┬───────┘
+             │
+       Filesystem / Postgres / S3
+```
+
+---
+
+## Installation
+
+```bash
+pip install amfs crewai
+```
+
+---
+
+## Basic Setup
+
+Use `AMFSStorageBackend` as the storage layer for CrewAI's `Memory`:
+
+```python
+from crewai import Agent, Crew, Task, Process
+from crewai.memory import Memory
+from amfs.integrations.crewai import AMFSStorageBackend
+
+backend = AMFSStorageBackend(
+    agent_id="my-crew",
+    entity_path="my-project",
+)
+
+crew = Crew(
+    agents=[...],
+    tasks=[...],
+    process=Process.sequential,
+    memory=Memory(storage=backend),
+)
+
+result = crew.kickoff()
+```
+
+Every memory operation CrewAI performs — short-term, long-term, and entity memory — flows through AMFS and benefits from CoW versioning, provenance tracking, and confidence scoring.
+
+---
+
+## What You Get
+
+### Versioning
+
+CrewAI overwrites memories in place. With AMFS as the backend, every update creates a new CoW version. You can inspect how agent knowledge evolved across crew runs:
+
+```python
+from amfs import AgentMemory
+
+mem = AgentMemory(agent_id="my-crew")
+versions = mem.history("my-project", "agent-a-learnings")
+for v in versions:
+    print(f"v{v.version}  confidence={v.confidence}  at={v.updated_at}")
+```
+
+### Provenance
+
+AMFS tracks which agent wrote each memory entry, in which session, and from which crew run. This is critical when multiple crews or agents share the same memory store:
+
+```python
+entry = mem.read("my-project", "research-findings")
+print(entry.agent_id)       # "researcher-agent"
+print(entry.session_id)     # "crew-run-2024-03-15-001"
+print(entry.provenance_tier) # ProvenanceTier.OBSERVED
+```
+
+### Outcome Back-Propagation
+
+After a crew run, record whether the result was successful. AMFS adjusts confidence on all entries that were read during the decision process:
+
+```python
+from amfs import OutcomeType
+
+mem.commit_outcome(
+    outcome_ref="crew-run-042",
+    outcome_type=OutcomeType.CLEAN_DEPLOY,
+)
+```
+
+Entries that contributed to successful outcomes gain confidence. Entries involved in failures lose confidence. Over time, your crew's memory becomes self-curating.
+
+### Decision Traces
+
+Use `explain()` to see the full causal chain — which memories were read, which external contexts were gathered, and what outcome occurred:
+
+```python
+chain = mem.explain()
+print(chain.reads)     # entries read during this session
+print(chain.contexts)  # external context recorded
+```
+
+---
+
+## Multi-Crew Setup
+
+When running multiple crews that share knowledge, use separate `agent_id` values but the same storage backend configuration:
+
+```python
+research_backend = AMFSStorageBackend(
+    agent_id="research-crew",
+    entity_path="shared-project",
+)
+
+execution_backend = AMFSStorageBackend(
+    agent_id="execution-crew",
+    entity_path="shared-project",
+)
+```
+
+Both crews read from and write to the same entity path. AMFS handles provenance automatically — you always know which crew produced which insight.
+
+---
+
+## Using with Postgres
+
+For production deployments, point AMFS at Postgres for durable storage with full-text and vector search:
+
+```python
+from amfs import AgentMemory
+from amfs_adapter_postgres import PostgresAdapter
+
+adapter = PostgresAdapter(dsn="postgresql://user:pass@host:5432/amfs")
+
+backend = AMFSStorageBackend(
+    agent_id="my-crew",
+    entity_path="my-project",
+    adapter=adapter,
+)
+```
+
+---
+
+## Example: Research Crew with Persistent Memory
+
+```python
+from crewai import Agent, Crew, Task, Process
+from crewai.memory import Memory
+from amfs.integrations.crewai import AMFSStorageBackend
+from amfs import OutcomeType
+
+backend = AMFSStorageBackend(
+    agent_id="research-crew",
+    entity_path="market-analysis",
+)
+
+researcher = Agent(
+    role="Market Researcher",
+    goal="Find emerging trends in AI infrastructure",
+    backstory="Senior analyst with deep knowledge of the AI market.",
+)
+
+writer = Agent(
+    role="Report Writer",
+    goal="Synthesize research into actionable reports",
+    backstory="Technical writer specializing in market analysis.",
+)
+
+research_task = Task(
+    description="Research the latest trends in AI agent memory systems",
+    agent=researcher,
+)
+
+write_task = Task(
+    description="Write a summary report based on the research findings",
+    agent=writer,
+)
+
+crew = Crew(
+    agents=[researcher, writer],
+    tasks=[research_task, write_task],
+    process=Process.sequential,
+    memory=Memory(storage=backend),
+)
+
+result = crew.kickoff()
+
+# Record success so future runs benefit from higher-confidence memories
+backend.memory.commit_outcome("research-run-001", OutcomeType.CLEAN_DEPLOY)
+```
+
+On subsequent runs, the crew starts with all prior research findings — versioned, confidence-scored, and ranked by outcome history.

--- a/docs/vs-competitors.md
+++ b/docs/vs-competitors.md
@@ -2,14 +2,14 @@
 title: AMFS vs Competitors
 layout: default
 nav_order: 6
-description: "How AMFS compares to Mem0, Cognee, Zep/Graphiti, LangMem, and other AI memory systems."
+description: "How AMFS compares to Mem0, Cognee, Zep/Graphiti, LangMem, CrewAI Memory, and other AI memory systems."
 permalink: /vs-competitors/
 ---
 
 # AMFS vs Competitors
 {: .no_toc }
 
-The AI memory space is evolving fast. Here's how AMFS compares to the leading alternatives and where each excels.
+The AI memory space is evolving fast. Here's how AMFS compares to the leading alternatives — Mem0, Cognee, Zep/Graphiti, CrewAI Memory, and LangMem — and where each excels.
 {: .fs-6 .fw-300 }
 
 ## Table of Contents
@@ -22,32 +22,37 @@ The AI memory space is evolving fast. Here's how AMFS compares to the leading al
 
 ## Feature Matrix
 
-| Feature | AMFS | Mem0 | Cognee | Zep / Graphiti | LangMem |
-|:--------|:----:|:----:|:------:|:--------------:|:-------:|
-| Persistent memory across sessions | Yes | Yes | Yes | Yes | Yes |
-| Versioning (full history) | CoW | No | No | Temporal | No |
-| Provenance (who wrote, when) | Yes | No | No | Partial | No |
-| Confidence scoring | Yes | No | No | No | No |
-| Outcome back-propagation | Yes | No | No | No | No |
-| Memory types (fact/belief/experience) | Yes | No | No | No | No |
-| Provenance tiers | Yes | No | No | No | No |
-| Causal explainability | Yes | No | No | No | No |
-| Persistent decision traces | Pro | No | No | No | No |
-| Cross-system ingestion (webhooks) | Pro | No | No | No | No |
-| Automated pattern detection | Pro | No | No | No | No |
-| Knowledge graph | Via pattern_refs | No | Yes | Yes | No |
-| Semantic search | Yes | Yes | Yes | Yes | Yes |
-| Multi-agent support | Native | Partial | No | No | No |
-| Conflict detection | Yes | No | No | No | No |
-| Multi-tenant with RLS | Pro | Cloud-only | Cloud-only | Cloud-only | Cloud-only |
-| Scoped API keys per agent | Pro | No | No | No | No |
-| MCP server | Yes | Yes | No | No | No |
-| Framework integrations | Yes | Yes | Yes | Yes | Yes |
-| Self-hosted / OSS | Apache 2.0 | OSS + Cloud | OSS + Cloud | OSS + Cloud | OSS |
-| Pluggable storage backends | Yes | No | No | No | No |
-| Enterprise dashboard | Pro | Cloud | Cloud | Cloud | Cloud |
-| Learned ranking from outcomes | Pro | No | No | No | No |
-| Training data export (SFT/DPO) | Pro | No | No | No | No |
+| Feature | AMFS | Mem0 | Cognee | Zep / Graphiti | LangMem | CrewAI Memory |
+|:--------|:----:|:----:|:------:|:--------------:|:-------:|:-------------:|
+| Persistent memory across sessions | Yes | Yes | Yes | Yes | Yes | Yes |
+| Versioning (full history) | CoW | No | No | Temporal | No | No |
+| Provenance (who wrote, when) | Yes | No | No | Partial | No | No |
+| Confidence scoring | Yes | No | No | No | No | Composite |
+| Outcome back-propagation | Yes | No | No | No | No | No |
+| Memory types (fact/belief/experience) | Yes | No | No | No | No | Short/Long/Entity |
+| Provenance tiers | Yes | No | No | No | No | No |
+| Causal explainability | Yes | No | No | No | No | No |
+| LLM-powered organization | No | No | Yes | No | No | Yes |
+| Composite scoring (relevance+recency+importance) | Yes | No | No | No | No | Yes |
+| Scope tree (hierarchical scoping) | Pro | No | No | No | No | Yes |
+| Deep recall (multi-step retrieval) | Pro | No | No | No | No | Yes |
+| Persistent decision traces | Pro | No | No | No | No | No |
+| Cross-system ingestion (webhooks) | Yes | No | No | No | No | No |
+| Connector ecosystem | Yes | No | No | No | No | No |
+| Automated pattern detection | Pro | No | No | No | No | No |
+| Knowledge graph | Via pattern_refs | No | Yes | Yes | No | No |
+| Semantic search | Yes | Yes | Yes | Yes | Yes | Yes |
+| Multi-agent support | Native | Partial | No | No | No | Native |
+| Conflict detection | Yes | No | No | No | No | No |
+| Multi-tenant with RLS | Pro | Cloud-only | Cloud-only | Cloud-only | Cloud-only | No |
+| Scoped API keys per agent | Pro | No | No | No | No | No |
+| MCP server | Yes | Yes | No | No | No | No |
+| Framework integrations | Yes | Yes | Yes | Yes | Yes | CrewAI only |
+| Self-hosted / OSS | Apache 2.0 | OSS + Cloud | OSS + Cloud | OSS + Cloud | OSS | OSS |
+| Pluggable storage backends | Yes | No | No | No | No | Yes |
+| Enterprise dashboard | Pro | Cloud | Cloud | Cloud | Cloud | No |
+| Learned ranking from outcomes | Pro | No | No | No | No | No |
+| Training data export (SFT/DPO) | Pro | No | No | No | No | No |
 
 ---
 
@@ -117,6 +122,53 @@ The AI memory space is evolving fast. Here's how AMFS compares to the leading al
 - **Decision traces** — AMFS captures the full causal chain including external tool context. Pro persists traces durably with precedent search across all historical decisions. Zep focuses on conversation-derived knowledge.
 - **Cross-system context** — AMFS Pro's webhook ingester and connectors automatically pull context from PagerDuty, Slack, GitHub into the memory store. Zep only processes conversations.
 - **Pattern intelligence** — AMFS Pro detects recurring failures, stale knowledge, and confidence anomalies automatically. Zep doesn't analyze memory quality.
+
+---
+
+## AMFS vs CrewAI Memory
+
+[CrewAI](https://crewai.com) includes a built-in memory system designed for multi-agent crews, with short-term, long-term, and entity memory backed by a pluggable storage layer.
+
+### Where CrewAI Memory Excels
+
+- **LLM-powered auto-organization** — CrewAI uses LLMs to automatically categorize and organize memories, reducing manual overhead.
+- **Composite scoring** — Memories are scored by a composite of relevance, recency, and importance, enabling nuanced retrieval.
+- **Deep recall (RecallFlow)** — Multi-step retrieval pipeline that refines and enriches results through iterative LLM passes.
+- **Scope tree** — Hierarchical scoping lets you define memory boundaries at crew, agent, task, or custom levels.
+- **Native multi-agent** — Memory is shared across agents within a crew by default, with scoping for isolation when needed.
+- **Short/Long/Entity memory types** — Purpose-built memory categories for different retention needs.
+
+### Where AMFS Differs
+
+- **Outcome back-propagation** — AMFS adjusts confidence scores based on real-world outcomes (deploys, incidents, regressions). CrewAI's composite scoring doesn't incorporate production feedback.
+- **Copy-on-Write versioning** — Every AMFS write creates an immutable version. You can reconstruct the state of knowledge at any point in time. CrewAI overwrites memories in place.
+- **Provenance tiers** — AMFS automatically ranks entries by how they were created: production-validated, observed, dev, or manual. CrewAI doesn't distinguish provenance quality.
+- **Persistent decision traces** — AMFS captures the full causal chain (what was read, what external context was gathered, what decision was made) and can persist it indefinitely. CrewAI doesn't track decision provenance.
+- **Connector ecosystem** — AMFS ingests events from PagerDuty, GitHub, Slack, Jira, and custom systems via webhooks. CrewAI memory only captures agent-generated knowledge.
+- **Multi-tenant isolation** — AMFS Pro provides hard tenant isolation via Postgres RLS, RBAC, scoped API keys, and audit logging. CrewAI memory is single-tenant.
+- **Framework agnostic** — AMFS works with any framework (CrewAI, LangGraph, AutoGen, standalone). CrewAI memory is tightly coupled to the CrewAI framework.
+- **MCP server** — AMFS exposes memory to IDE agents (Cursor, Claude Code) via MCP. CrewAI memory is only accessible from within CrewAI crews.
+
+### Better Together
+
+AMFS can serve as the storage backend for CrewAI's memory system via `AMFSStorageBackend`. This gives you the best of both worlds:
+
+- **CrewAI's UX** — LLM-powered organization, composite scoring, scope trees, RecallFlow — all the features that make CrewAI's memory ergonomic for crew orchestration.
+- **AMFS's durability** — CoW versioning, outcome feedback, provenance tracking, connector ingestion, and persistent decision traces underneath.
+
+```python
+from crewai.memory import Memory
+from amfs.integrations.crewai import AMFSStorageBackend
+
+backend = AMFSStorageBackend(agent_id="my-crew", entity_path="my-project")
+crew = Crew(
+    agents=[...],
+    tasks=[...],
+    memory=Memory(storage=backend),
+)
+```
+
+See the [CrewAI Integration guide](/amfs/guides/crewai/) for full setup instructions.
 
 ---
 


### PR DESCRIPTION
## Summary

- New docs/guides/connectors.md: full connector guide (install, build, publish, webhook URLs, connector.yaml reference)
- New docs/guides/crewai.md: CrewAI integration guide with AMFSStorageBackend
- Updated docs/vs-competitors.md: added CrewAI Memory as competitor with full comparison section
- Updated docs/editions.md: reflect connectors, composite scoring, multi-scope as OSS features
- Updated README.md: added connectors section and new feature rows

## Test plan

- [ ] Verify docs build with Jekyll (no broken links)
- [ ] Review connector guide for accuracy and completeness
- [ ] Review CrewAI competitor comparison for balanced coverage