### PR TITLE
feat: add single trace retrieval endpoint

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -622,6 +622,44 @@ class PostgresAdapter(AdapterABC):
     # decision traces
     # ------------------------------------------------------------------
 
+    def get_trace(self, trace_id: str) -> "DecisionTrace | None":
+        from amfs_core.models import DecisionTrace, TraceEntry, ExternalContext
+
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT id, agent_id, session_id, outcome_ref, outcome_type,
+                           decision_summary, causal_entries, external_contexts, created_at
+                    FROM amfs_decision_traces
+                    WHERE id = %s AND namespace = %s
+                    """,
+                    (trace_id, self._namespace),
+                )
+                row = cur.fetchone()
+
+        if row is None:
+            return None
+
+        ce_raw = row["causal_entries"] or []
+        ec_raw = row["external_contexts"] or []
+        if isinstance(ce_raw, str):
+            ce_raw = json.loads(ce_raw)
+        if isinstance(ec_raw, str):
+            ec_raw = json.loads(ec_raw)
+        return DecisionTrace(
+            id=str(row["id"]),
+            agent_id=row["agent_id"],
+            session_id=row["session_id"],
+            outcome_ref=row.get("outcome_ref"),
+            outcome_type=row.get("outcome_type"),
+            decision_summary=row.get("decision_summary"),
+            causal_entries=[TraceEntry(**e) for e in ce_raw],
+            external_contexts=[ExternalContext(**c) for c in ec_raw],
+            created_at=row["created_at"],
+            namespace=self._namespace,
+        )
+
     def save_trace(self, trace: "DecisionTrace") -> "DecisionTrace":
         from amfs_core.models import DecisionTrace, TraceEntry, ExternalContext
 

--- a/packages/core/src/amfs_core/abc.py
+++ b/packages/core/src/amfs_core/abc.py
@@ -128,6 +128,17 @@ class AdapterABC(ABC):
                 return entry
         return None
 
+    def get_trace(self, trace_id: str) -> DecisionTrace | None:
+        """Return a single trace by ID, or None if not found.
+
+        Default implementation scans ``list_traces()``; adapters with
+        indexed storage (e.g. Postgres) should override for O(1) lookup.
+        """
+        for t in self.list_traces(limit=10_000):
+            if t.id == trace_id:
+                return t
+        return None
+
     def save_trace(self, trace: DecisionTrace) -> DecisionTrace:
         """Persist a decision trace. Default is a no-op; adapters with
         persistent storage (e.g. Postgres) should override."""

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -400,6 +400,19 @@ async def list_traces(
     return {"traces": [t.model_dump(mode="json") for t in traces]}
 
 
+@app.get("/api/v1/traces/{trace_id}")
+async def get_trace(
+    trace_id: str,
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    mem = _get_memory()
+    trace = mem._adapter.get_trace(trace_id)
+    if trace is None:
+        from fastapi.responses import JSONResponse
+        return JSONResponse({"error": "Trace not found"}, status_code=404)
+    return trace.model_dump(mode="json")
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Admin — Usage
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `get_trace(trace_id)` method to `AdapterABC` with a default fallback scan implementation
- Implement efficient O(1) `get_trace()` in `PostgresAdapter` using direct `SELECT ... WHERE id = %s`
- Add `GET /api/v1/traces/{trace_id}` HTTP endpoint to the server, returning 404 when not found

This enables the dashboard to fetch individual trace details using the OSS layer, removing the dependency on the Pro trace endpoints.

## Test plan
- [ ] Verify `GET /api/v1/traces/{valid-uuid}` returns the full trace JSON
- [ ] Verify `GET /api/v1/traces/{unknown-uuid}` returns 404
- [ ] Confirm the endpoint works with API key auth when enabled