### PR TITLE
feat: expose cross-agent memory reads in OSS SDK, MCP, and HTTP API

### DIFF
--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -710,6 +710,52 @@ async def agent_memory_graph(
     }
 
 
+@app.get("/api/v1/agents/{agent_id}/cross-agent-reads")
+async def agent_cross_reads(
+    agent_id: str,
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    """Which other agents' memory this agent has read."""
+    mem = _get_memory()
+    entries = mem.list()
+    traces = mem._adapter.list_traces(agent_id=agent_id, limit=10000)
+
+    entry_authors: dict[str, str] = {}
+    for e in entries:
+        entry_authors[f"{e.entity_path}/{e.key}"] = e.provenance.agent_id
+
+    read_entities: dict[str, dict[str, int]] = {}
+    for t in traces:
+        for ce in t.causal_entries:
+            ep = ce.entity_path
+            key = ce.key
+            if ep not in read_entities:
+                read_entities[ep] = {}
+            read_entities[ep][key] = read_entities[ep].get(key, 0) + 1
+
+    cross_reads: dict[str, list[dict[str, Any]]] = {}
+    for ep, keys in read_entities.items():
+        for key, count in keys.items():
+            author = entry_authors.get(f"{ep}/{key}")
+            if author and author != agent_id:
+                if author not in cross_reads:
+                    cross_reads[author] = []
+                cross_reads[author].append({
+                    "entityPath": ep,
+                    "key": key,
+                    "readCount": count,
+                })
+
+    return {
+        "agentId": agent_id,
+        "readsFrom": cross_reads,
+        "agentsReadFrom": list(cross_reads.keys()),
+        "totalCrossAgentReads": sum(
+            r["readCount"] for reads in cross_reads.values() for r in reads
+        ),
+    }
+
+
 @app.get("/api/v1/agents/{agent_id}/activity")
 async def agent_activity(
     agent_id: str,

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -391,6 +391,42 @@ def amfs_record_context(
 
 
 @mcp.tool
+def amfs_cross_agent_reads() -> str:
+    """Show which other agents' memory this agent has read.
+
+    Returns a mapping of other agent IDs to the specific entity/key pairs
+    read from them, with read counts. Use this to understand inter-agent
+    communication and memory sharing relationships.
+
+    Answers questions like:
+    - "Which agents have I talked to?"
+    - "What memory did I get from agent X?"
+    - "Who wrote the knowledge I'm relying on?"
+
+    Example response:
+    {
+      "agent_id": "review-agent",
+      "reads_from": {
+        "deploy-agent": [
+          {"entity_path": "checkout-service", "key": "retry-pattern", "read_count": 3}
+        ]
+      },
+      "agents_read_from": ["deploy-agent"]
+    }
+    """
+    mem = _get_memory()
+    cross_reads = mem.cross_agent_reads()
+    return json.dumps({
+        "agent_id": mem.agent_id,
+        "reads_from": cross_reads,
+        "agents_read_from": list(cross_reads.keys()),
+        "total_cross_agent_reads": sum(
+            r["read_count"] for reads in cross_reads.values() for r in reads
+        ),
+    }, default=str)
+
+
+@mcp.tool
 def amfs_explain(outcome_ref: str | None = None) -> str:
     """Explain the causal chain — which memories influenced this session's decisions.
 

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -568,6 +568,67 @@ class AgentMemory:
         }
 
     # ------------------------------------------------------------------
+    # Cross-agent relationships
+    # ------------------------------------------------------------------
+
+    def cross_agent_reads(self) -> dict[str, list[dict[str, Any]]]:
+        """Return which other agents' memory this agent has read.
+
+        Examines the decision traces to find all entries read by this agent,
+        then identifies which of those were written by other agents.
+
+        Returns a dict mapping ``other_agent_id`` to a list of dicts with
+        ``entity_path``, ``key``, and ``read_count``.
+
+        Use this to answer questions like:
+        - "Which agents have I talked to?"
+        - "What memory did I get from agent X?"
+
+        Example::
+
+            reads = mem.cross_agent_reads()
+            # {'deploy-agent': [{'entity_path': 'checkout-service', 'key': 'retry-pattern', 'read_count': 3}]}
+        """
+        entries = self.list()
+        traces = self._adapter.list_traces(agent_id=self.agent_id, limit=10000)
+
+        entry_authors: dict[str, str] = {}
+        for e in entries:
+            entry_authors[f"{e.entity_path}/{e.key}"] = e.provenance.agent_id
+
+        read_entities: dict[str, dict[str, int]] = {}
+        for t in traces:
+            for ce in t.causal_entries:
+                ep = ce.entity_path
+                key = ce.key
+                if ep not in read_entities:
+                    read_entities[ep] = {}
+                read_entities[ep][key] = read_entities[ep].get(key, 0) + 1
+
+        cross_reads: dict[str, list[dict[str, Any]]] = {}
+        for ep, keys in read_entities.items():
+            for key, count in keys.items():
+                author = entry_authors.get(f"{ep}/{key}")
+                if author and author != self.agent_id:
+                    if author not in cross_reads:
+                        cross_reads[author] = []
+                    cross_reads[author].append({
+                        "entity_path": ep,
+                        "key": key,
+                        "read_count": count,
+                    })
+
+        return cross_reads
+
+    def agents_i_read_from(self) -> list[str]:
+        """Return a list of other agent IDs whose memory this agent has read.
+
+        A convenience wrapper around :meth:`cross_agent_reads` that returns
+        just the agent IDs.
+        """
+        return list(self.cross_agent_reads().keys())
+
+    # ------------------------------------------------------------------
     # Scoped access
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **SDK**: Added `AgentMemory.cross_agent_reads()` and `agents_i_read_from()` methods so agents can programmatically discover which other agents' memory they've consumed
- **MCP**: Added `amfs_cross_agent_reads` tool so Cursor/Claude Code agents can query inter-agent relationships directly
- **HTTP API**: Added `GET /api/v1/agents/{agent_id}/cross-agent-reads` endpoint for lightweight cross-agent relationship queries without needing the full memory graph

## Test plan

- [ ] Call `cross_agent_reads()` on an agent that has read entries written by other agents — verify the returned dict maps author agent IDs to entity/key/count
- [ ] Call `agents_i_read_from()` — verify it returns a flat list of agent IDs
- [ ] Invoke `amfs_cross_agent_reads` MCP tool — verify JSON response includes `reads_from`, `agents_read_from`, and `total_cross_agent_reads`
- [ ] Hit `GET /api/v1/agents/{agent_id}/cross-agent-reads` — verify response includes `readsFrom`, `agentsReadFrom`, `totalCrossAgentReads`
- [ ] Verify an agent with no cross-agent reads returns empty results