### PR TITLE
feat: agent-brain SDK methods (recall, my_entries, read_from)

### DIFF
--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -756,6 +756,65 @@ async def agent_cross_reads(
     }
 
 
+@app.get("/api/v1/agents/{agent_id}/recall/{entity_path:path}/{key}")
+async def agent_recall(
+    agent_id: str,
+    entity_path: str,
+    key: str,
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    """Recall an agent's own memory for a key (agent-scoped read).
+
+    Unlike the generic read endpoint, this returns only entries written
+    by the specified agent — what that agent's brain actually knows.
+    """
+    mem = _get_memory()
+    original_agent = mem._tagger.agent_id
+    mem._tagger.agent_id = agent_id
+    try:
+        entry = mem.recall(entity_path, key)
+    finally:
+        mem._tagger.agent_id = original_agent
+    if entry is None:
+        return {"status": "not_found", "agentId": agent_id,
+                "entityPath": entity_path, "key": key}
+    return _entry_to_response(entry)
+
+
+@app.get("/api/v1/agents/{agent_id}/entries")
+async def agent_entries(
+    agent_id: str,
+    entity_path: str | None = Query(None),
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    """List all entries written by a specific agent."""
+    mem = _get_memory()
+    entries = mem.search(entity_path=entity_path, agent_id=agent_id)
+    return {
+        "agentId": agent_id,
+        "count": len(entries),
+        "entries": [_entry_to_response(e) for e in entries],
+    }
+
+
+@app.get("/api/v1/agents/{agent_id}/read-from/{source_agent_id}/{entity_path:path}/{key}")
+async def agent_read_from(
+    agent_id: str,
+    source_agent_id: str,
+    entity_path: str,
+    key: str,
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    """Read a specific key from another agent's memory (cross-agent read)."""
+    mem = _get_memory()
+    entries = mem.search(entity_path=entity_path, agent_id=source_agent_id)
+    matching = [e for e in entries if e.key == key]
+    if not matching:
+        return {"status": "not_found", "sourceAgentId": source_agent_id,
+                "entityPath": entity_path, "key": key}
+    return _entry_to_response(matching[0])
+
+
 @app.get("/api/v1/agents/{agent_id}/activity")
 async def agent_activity(
     agent_id: str,

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -391,6 +391,71 @@ def amfs_record_context(
 
 
 @mcp.tool
+def amfs_recall(entity_path: str, key: str) -> str:
+    """Recall YOUR OWN memory for a key — what do I know about this?
+
+    Unlike amfs_read (which returns the latest version by any agent),
+    amfs_recall returns only entries written by you. Use this to check
+    your own knowledge before acting.
+
+    Args:
+        entity_path: Entity path (e.g. "checkout-service")
+        key: Memory key (e.g. "retry-pattern")
+
+    Example: amfs_recall("checkout-service", "retry-pattern")
+    """
+    mem = _get_memory()
+    entry = mem.recall(entity_path, key)
+    if entry is None:
+        return json.dumps({"status": "not_found", "entity_path": entity_path, "key": key,
+                           "hint": "You have not written this key. Try amfs_read() for shared knowledge."})
+    return json.dumps(_serialize_entry(entry), default=str)
+
+
+@mcp.tool
+def amfs_my_entries(entity_path: str | None = None) -> str:
+    """List all entries written by YOU — what's in my brain?
+
+    Returns only entries authored by this agent. Optionally filter to
+    a specific entity path.
+
+    Args:
+        entity_path: Optional entity path filter
+
+    Example: amfs_my_entries("checkout-service")
+    """
+    mem = _get_memory()
+    entries = mem.my_entries(entity_path)
+    return json.dumps({
+        "agent_id": mem.agent_id,
+        "count": len(entries),
+        "entries": [_serialize_entry(e) for e in entries],
+    }, default=str)
+
+
+@mcp.tool
+def amfs_read_from(agent_id: str, entity_path: str, key: str) -> str:
+    """Read a specific key from ANOTHER agent's memory.
+
+    Use this when you want to explicitly learn from another agent's
+    experience. The read is tracked for causal tracing.
+
+    Args:
+        agent_id: The agent whose memory to read from
+        entity_path: Entity path (e.g. "checkout-service")
+        key: Memory key (e.g. "retry-pattern")
+
+    Example: amfs_read_from("deploy-agent", "checkout-service", "deploy-config")
+    """
+    mem = _get_memory()
+    entry = mem.read_from(agent_id, entity_path, key)
+    if entry is None:
+        return json.dumps({"status": "not_found", "agent_id": agent_id,
+                           "entity_path": entity_path, "key": key})
+    return json.dumps(_serialize_entry(entry), default=str)
+
+
+@mcp.tool
 def amfs_cross_agent_reads() -> str:
     """Show which other agents' memory this agent has read.
 

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -568,6 +568,61 @@ class AgentMemory:
         }
 
     # ------------------------------------------------------------------
+    # Agent brain — scoped recall & cross-agent reads
+    # ------------------------------------------------------------------
+
+    def recall(
+        self,
+        entity_path: str,
+        key: str,
+        *,
+        min_confidence: float = 0.0,
+    ) -> MemoryEntry | None:
+        """Recall this agent's own memory for a key.
+
+        Unlike ``read()``, which returns the latest version by any agent,
+        ``recall()`` returns only entries written by this agent — what this
+        brain actually knows from direct experience.  Falls back through
+        history to find the most recent version authored by this agent.
+        """
+        entry = self._engine.read(entity_path, key, min_confidence=0.0)
+        if entry is None:
+            return None
+        if entry.provenance.agent_id == self.agent_id:
+            return entry if entry.confidence >= min_confidence else None
+        versions = self._engine.history(entity_path, key)
+        for v in reversed(versions):
+            if v.provenance.agent_id == self.agent_id:
+                return v if v.confidence >= min_confidence else None
+        return None
+
+    def my_entries(
+        self,
+        entity_path: str | None = None,
+    ) -> list[MemoryEntry]:
+        """List entries written by this agent — the contents of this brain."""
+        return self.search(entity_path=entity_path, agent_id=self.agent_id)
+
+    def read_from(
+        self,
+        agent_id: str,
+        entity_path: str,
+        key: str,
+    ) -> MemoryEntry | None:
+        """Read a specific key from another agent's memory.
+
+        Makes cross-agent knowledge transfer explicit and trackable.
+        The read is logged in the causal chain for decision tracing.
+        """
+        entries = self.search(entity_path=entity_path, agent_id=agent_id)
+        matching = [e for e in entries if e.key == key]
+        if not matching:
+            return None
+        entry = matching[0]
+        self._read_tracker.record(entry)
+        return entry
+
+    # ------------------------------------------------------------------
     # Cross-agent relationships
     # ------------------------------------------------------------------
 

--- a/packages/sdk-typescript/src/memory.ts
+++ b/packages/sdk-typescript/src/memory.ts
@@ -295,6 +295,56 @@ export class AgentMemory {
     return this.propagator.propagate(record);
   }
 
+  // ------------------------------------------------------------------
+  // Agent brain — scoped recall & cross-agent reads
+  // ------------------------------------------------------------------
+
+  /**
+   * Recall this agent's own memory for a key.
+   * Unlike read(), returns only entries written by this agent.
+   */
+  recall(
+    entityPath: string,
+    key: string,
+    options?: { minConfidence?: number }
+  ): MemoryEntry | null {
+    const entry = this.engine.read(entityPath, key);
+    if (!entry) return null;
+    const minConf = options?.minConfidence ?? 0;
+    if (entry.provenance.agentId === this.agentId) {
+      return entry.confidence >= minConf ? entry : null;
+    }
+    const versions = this.engine.history(entityPath, key);
+    for (let i = versions.length - 1; i >= 0; i--) {
+      const v = versions[i];
+      if (v.provenance.agentId === this.agentId) {
+        return v.confidence >= minConf ? v : null;
+      }
+    }
+    return null;
+  }
+
+  /** List entries written by this agent — the contents of this brain. */
+  myEntries(entityPath?: string): MemoryEntry[] {
+    return this.search({ entityPath, agentId: this.agentId });
+  }
+
+  /**
+   * Read a specific key from another agent's memory.
+   * Makes cross-agent knowledge transfer explicit and trackable.
+   */
+  readFrom(
+    agentId: string,
+    entityPath: string,
+    key: string,
+  ): MemoryEntry | null {
+    const entries = this.search({ entityPath, agentId });
+    const match = entries.find((e) => e.key === key);
+    if (!match) return null;
+    this.readTracker.record(match);
+    return match;
+  }
+
   /** Return a MemoryScope bound to the given entity path. */
   scope(entityPath: string, options?: { readonly?: boolean }): MemoryScope {
     return new MemoryScope(this, entityPath, options?.readonly ?? false);


### PR DESCRIPTION
## Summary
- Adds `recall()`, `my_entries()`, `read_from()` to Python SDK, TypeScript SDK, MCP tools, and HTTP API
- Implements the "agent brain" mental model where each agent has its own memory scope
- All new methods are backward compatible — `read()` and `write()` behavior unchanged

## Test plan
- [ ] Verify `recall()` returns only entries written by the calling agent
- [ ] Verify `my_entries()` filters by agent_id
- [ ] Verify `read_from()` tracks the cross-agent read in the causal chain
- [ ] Verify MCP tools work via stdio transport
- [ ] Verify HTTP endpoints return correct responses

Closes #69