### PR TITLE
feat: fork agent memory and branch-aware Cortex (Pro)

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -164,6 +164,13 @@ class PostgresAdapter(AdapterABC):
             ADD COLUMN IF NOT EXISTS branch TEXT NOT NULL DEFAULT 'main'
         """)
         cur.execute("""
+            ALTER TABLE amfs_digests DROP CONSTRAINT IF EXISTS uq_digest
+        """)
+        cur.execute("""
+            ALTER TABLE amfs_digests
+            ADD CONSTRAINT uq_digest UNIQUE (namespace, branch, digest_type, scope)
+        """)
+        cur.execute("""
             ALTER TABLE amfs_api_keys
             ADD COLUMN IF NOT EXISTS default_branch TEXT
         """)
@@ -176,7 +183,8 @@ class PostgresAdapter(AdapterABC):
                         'entity_path', NEW.entity_path,
                         'key', NEW.key,
                         'version', NEW.version,
-                        'agent_id', NEW.agent_id
+                        'agent_id', NEW.agent_id,
+                        'branch', NEW.branch
                     )::TEXT);
                 END IF;
                 RETURN NEW;
@@ -974,12 +982,13 @@ class PostgresAdapter(AdapterABC):
 
     def upsert_digest(self, digest: Digest) -> None:
         """Insert or update a compiled digest."""
+        branch = digest.branch or "main"
         with self._pool.connection() as conn:
             conn.execute(
                 """INSERT INTO amfs_digests
-                   (namespace, digest_type, scope, summary, entry_count,
+                   (namespace, branch, digest_type, scope, summary, entry_count,
                     source_agents, anticipation_score, compiled_at)
-                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
                    ON CONFLICT ON CONSTRAINT uq_digest
                    DO UPDATE SET summary = EXCLUDED.summary,
                                  entry_count = EXCLUDED.entry_count,
@@ -988,6 +997,7 @@ class PostgresAdapter(AdapterABC):
                                  compiled_at = EXCLUDED.compiled_at""",
                 (
                     digest.namespace,
+                    branch,
                     digest.digest_type.value,
                     digest.scope,
                     json.dumps(digest.summary),
@@ -1003,14 +1013,16 @@ class PostgresAdapter(AdapterABC):
         digest_type: DigestType,
         scope: str,
         namespace: str = "default",
+        branch: str = "main",
     ) -> Digest | None:
         """Read a single digest by type and scope."""
         with self._pool.connection() as conn:
             with conn.cursor(row_factory=dict_row) as cur:
                 row = cur.execute(
                     """SELECT * FROM amfs_digests
-                       WHERE namespace = %s AND digest_type = %s AND scope = %s""",
-                    (namespace, digest_type.value, scope),
+                       WHERE namespace = %s AND branch = %s
+                         AND digest_type = %s AND scope = %s""",
+                    (namespace, branch, digest_type.value, scope),
                 ).fetchone()
         return self._row_to_digest(row) if row else None
 
@@ -1018,22 +1030,24 @@ class PostgresAdapter(AdapterABC):
         self,
         digest_type: DigestType | None = None,
         namespace: str = "default",
+        branch: str = "main",
     ) -> list[Digest]:
-        """List digests, optionally filtered by type."""
+        """List digests, optionally filtered by type and branch."""
         with self._pool.connection() as conn:
             with conn.cursor(row_factory=dict_row) as cur:
                 if digest_type:
                     rows = cur.execute(
                         """SELECT * FROM amfs_digests
-                           WHERE namespace = %s AND digest_type = %s
+                           WHERE namespace = %s AND branch = %s AND digest_type = %s
                            ORDER BY compiled_at DESC""",
-                        (namespace, digest_type.value),
+                        (namespace, branch, digest_type.value),
                     ).fetchall()
                 else:
                     rows = cur.execute(
                         """SELECT * FROM amfs_digests
-                           WHERE namespace = %s ORDER BY compiled_at DESC""",
-                        (namespace,),
+                           WHERE namespace = %s AND branch = %s
+                           ORDER BY compiled_at DESC""",
+                        (namespace, branch),
                     ).fetchall()
         return [self._row_to_digest(r) for r in rows]
 
@@ -1050,6 +1064,7 @@ class PostgresAdapter(AdapterABC):
             source_agents=row.get("source_agents") or [],
             compiled_at=row["compiled_at"],
             anticipation_score=float(row.get("anticipation_score", 0.0)),
+            branch=row.get("branch", "main"),
             namespace=row.get("namespace", "default"),
         )
 
@@ -1897,6 +1912,69 @@ class PostgresAdapter(AdapterABC):
                             )
                             restored += 1
         return restored
+
+    # ── Fork (Pro) ────────────────────────────────────────────────────
+
+    def fork_agent(
+        self,
+        source_agent_id: str,
+        target_agent_id: str,
+        *,
+        namespace: str = "default",
+        branch: str = "main",
+    ) -> int:
+        """Copy all live entries from source agent's branch into target agent's main."""
+        self.ensure_agent(target_agent_id, namespace)
+        copied = 0
+        with self._pool.connection() as conn:
+            with conn.transaction():
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT * FROM amfs_memory_entries
+                        WHERE namespace = %s AND branch = %s
+                          AND superseded_at IS NULL
+                        """,
+                        (namespace, branch),
+                    )
+                    rows = cur.fetchall()
+
+                    for row in rows:
+                        cur.execute(
+                            """
+                            INSERT INTO amfs_memory_entries
+                            (namespace, entity_path, key, version, value,
+                             agent_id, session_id, tool_context, pattern_refs,
+                             written_at, confidence, outcome_count,
+                             ttl_at, artifact_refs, memory_type, shared,
+                             branch, embedding)
+                            VALUES
+                            (%s, %s, %s, 1, %s,
+                             %s, %s, %s, %s,
+                             NOW(), %s, 0,
+                             %s, %s, %s, %s,
+                             'main', %s)
+                            ON CONFLICT ON CONSTRAINT uq_entry_version DO NOTHING
+                            """,
+                            (
+                                namespace,
+                                row["entity_path"],
+                                row["key"],
+                                json.dumps(row["value"]) if not isinstance(row["value"], str) else row["value"],
+                                target_agent_id,
+                                row.get("session_id", ""),
+                                row.get("tool_context", ""),
+                                row.get("pattern_refs", []),
+                                row["confidence"],
+                                row.get("ttl_at"),
+                                row.get("artifact_refs", []),
+                                row.get("memory_type", "fact"),
+                                row.get("shared", False),
+                                row.get("embedding"),
+                            ),
+                        )
+                        copied += cur.rowcount
+        return copied
 
     def close(self) -> None:
         """Stop listener and close connection pool."""

--- a/packages/adapters/postgres/src/amfs_postgres/schema.sql
+++ b/packages/adapters/postgres/src/amfs_postgres/schema.sql
@@ -414,7 +414,8 @@ BEGIN
             'entity_path', NEW.entity_path,
             'key', NEW.key,
             'version', NEW.version,
-            'agent_id', NEW.agent_id
+            'agent_id', NEW.agent_id,
+            'branch', NEW.branch
         )::TEXT);
     END IF;
     RETURN NEW;
@@ -438,7 +439,8 @@ CREATE TABLE IF NOT EXISTS amfs_digests (
     source_agents TEXT[] DEFAULT '{}',
     anticipation_score NUMERIC(6,4) DEFAULT 0.0,
     compiled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    CONSTRAINT uq_digest UNIQUE (namespace, digest_type, scope)
+    branch TEXT NOT NULL DEFAULT 'main',
+    CONSTRAINT uq_digest UNIQUE (namespace, branch, digest_type, scope)
 );
 
 CREATE INDEX IF NOT EXISTS idx_digests_type ON amfs_digests(digest_type);

--- a/packages/core/src/amfs_core/abc.py
+++ b/packages/core/src/amfs_core/abc.py
@@ -390,6 +390,22 @@ class AdapterABC(ABC):
         """Rollback memory to a point in time. Returns count of restored entries."""
         raise NotImplementedError("Rollback requires the Postgres adapter")
 
+    # ── Fork (Pro) ────────────────────────────────────────────────────
+
+    def fork_agent(
+        self,
+        source_agent_id: str,
+        target_agent_id: str,
+        *,
+        namespace: str = "default",
+        branch: str = "main",
+    ) -> int:
+        """Copy all entries from source_agent's branch into target_agent's main.
+
+        Returns the number of entries copied.
+        """
+        raise NotImplementedError("Fork requires the Postgres adapter")
+
     def semantic_search(
         self, query: SemanticQuery, embedder: EmbedderABC
     ) -> list[tuple[MemoryEntry, float]]:

--- a/packages/core/src/amfs_core/models.py
+++ b/packages/core/src/amfs_core/models.py
@@ -348,6 +348,7 @@ class Digest(BaseModel):
     staleness_ms: int = 0
     anticipation_score: float = 0.0
     namespace: str = "default"
+    branch: str = "main"
 
 
 # ── Git-like memory models (Pro) ──────────────────────────────────────

--- a/packages/cortex/src/amfs_cortex/briefing.py
+++ b/packages/cortex/src/amfs_cortex/briefing.py
@@ -23,6 +23,7 @@ class BriefingService:
         entity_path: str | None = None,
         agent_id: str | None = None,
         limit: int = 10,
+        branch: str = "main",
     ) -> list[Digest]:
         """Get a ranked list of relevant digests for the given context.
 
@@ -33,7 +34,7 @@ class BriefingService:
         4. Recency-weighted
         5. Entry count weighted
         """
-        all_digests = self._adapter.list_digests(namespace=self._namespace)
+        all_digests = self._adapter.list_digests(namespace=self._namespace, branch=branch)
         if not all_digests:
             return []
 

--- a/packages/cortex/src/amfs_cortex/compiler.py
+++ b/packages/cortex/src/amfs_cortex/compiler.py
@@ -20,9 +20,9 @@ class CompilationStrategy(Protocol):
     OutcomeCalibratedStrategy, etc.
     """
 
-    def compile_entity(self, entity_path: str, adapter: PostgresAdapter, namespace: str) -> Digest | None: ...
-    def compile_agent_brief(self, agent_id: str, adapter: PostgresAdapter, namespace: str) -> Digest | None: ...
-    def compile_source(self, source_id: str, adapter: PostgresAdapter, namespace: str) -> Digest | None: ...
+    def compile_entity(self, entity_path: str, adapter: PostgresAdapter, namespace: str, branch: str = "main") -> Digest | None: ...
+    def compile_agent_brief(self, agent_id: str, adapter: PostgresAdapter, namespace: str, branch: str = "main") -> Digest | None: ...
+    def compile_source(self, source_id: str, adapter: PostgresAdapter, namespace: str, branch: str = "main") -> Digest | None: ...
 
 
 class DigestCompiler:
@@ -33,44 +33,57 @@ class DigestCompiler:
         adapter: PostgresAdapter,
         strategies: list[CompilationStrategy] | None = None,
         namespace: str = "default",
+        branch: str = "main",
     ) -> None:
         self._adapter = adapter
         self._namespace = namespace
+        self._branch = branch
         if strategies:
             self._strategy = strategies[0]
         else:
             from amfs_cortex.strategies import RuleBasedStrategy
             self._strategy = RuleBasedStrategy()
 
-    def compile(self, scope_key: str) -> Digest | None:
+    @property
+    def branch(self) -> str:
+        return self._branch
+
+    @branch.setter
+    def branch(self, value: str) -> None:
+        self._branch = value
+
+    def compile(self, scope_key: str, *, branch: str | None = None) -> Digest | None:
         """Compile a digest for the given scope key.
 
         Scope keys are prefixed: 'entity:path', 'agent:id', 'source:id'.
         """
+        b = branch or self._branch
         kind, _, scope = scope_key.partition(":")
         if not scope:
             return None
 
         digest: Digest | None = None
         if kind == "entity":
-            digest = self._strategy.compile_entity(scope, self._adapter, self._namespace)
+            digest = self._strategy.compile_entity(scope, self._adapter, self._namespace, b)
         elif kind == "agent":
-            digest = self._strategy.compile_agent_brief(scope, self._adapter, self._namespace)
+            digest = self._strategy.compile_agent_brief(scope, self._adapter, self._namespace, b)
         elif kind == "source":
-            digest = self._strategy.compile_source(scope, self._adapter, self._namespace)
+            digest = self._strategy.compile_source(scope, self._adapter, self._namespace, b)
         else:
             logger.warning("Unknown scope kind: %s", kind)
             return None
 
         if digest:
+            digest.branch = b
             self._adapter.upsert_digest(digest)
-            logger.debug("Compiled %s digest for %s", kind, scope)
+            logger.debug("Compiled %s digest for %s (branch=%s)", kind, scope, b)
 
         return digest
 
-    def recompile_all(self) -> int:
+    def recompile_all(self, *, branch: str | None = None) -> int:
         """Recompile all digests from scratch. Returns count of digests compiled."""
-        entries = self._adapter.list()
+        b = branch or self._branch
+        entries = self._adapter.list(branch=b)
         entity_paths: set[str] = set()
         agent_ids: set[str] = set()
         source_ids: set[str] = set()
@@ -87,15 +100,15 @@ class DigestCompiler:
 
         count = 0
         for ep in entity_paths:
-            if self.compile(f"entity:{ep}"):
+            if self.compile(f"entity:{ep}", branch=b):
                 count += 1
         for aid in agent_ids:
-            if self.compile(f"agent:{aid}"):
+            if self.compile(f"agent:{aid}", branch=b):
                 count += 1
         for sid in source_ids:
-            if self.compile(f"source:{sid}"):
+            if self.compile(f"source:{sid}", branch=b):
                 count += 1
 
-        logger.info("Recompiled %d digests (%d entities, %d agents, %d sources)",
-                     count, len(entity_paths), len(agent_ids), len(source_ids))
+        logger.info("Recompiled %d digests (%d entities, %d agents, %d sources) branch=%s",
+                     count, len(entity_paths), len(agent_ids), len(source_ids), b)
         return count

--- a/packages/cortex/src/amfs_cortex/strategies.py
+++ b/packages/cortex/src/amfs_cortex/strategies.py
@@ -39,7 +39,7 @@ class RuleBasedStrategy:
     """Compiles digests from structured aggregation of memory entries."""
 
     def compile_entity(
-        self, entity_path: str, adapter: PostgresAdapter, namespace: str
+        self, entity_path: str, adapter: PostgresAdapter, namespace: str, branch: str = "main",
     ) -> Digest | None:
         from amfs_core.models import SearchQuery
 
@@ -47,7 +47,7 @@ class RuleBasedStrategy:
             entity_path=entity_path,
             limit=1000,
             sort_by="confidence",
-        ))
+        ), branch=branch)
         if not entries:
             return None
 
@@ -151,7 +151,7 @@ class RuleBasedStrategy:
         return " ".join(parts)
 
     def compile_agent_brief(
-        self, agent_id: str, adapter: PostgresAdapter, namespace: str
+        self, agent_id: str, adapter: PostgresAdapter, namespace: str, branch: str = "main",
     ) -> Digest | None:
         from amfs_core.models import SearchQuery
 
@@ -159,7 +159,7 @@ class RuleBasedStrategy:
             agent_id=agent_id,
             limit=1000,
             sort_by="recency",
-        ))
+        ), branch=branch)
         if not entries:
             return None
 
@@ -243,7 +243,7 @@ class RuleBasedStrategy:
         return " ".join(parts)
 
     def compile_source(
-        self, source_id: str, adapter: PostgresAdapter, namespace: str
+        self, source_id: str, adapter: PostgresAdapter, namespace: str, branch: str = "main",
     ) -> Digest | None:
         from amfs_core.models import SearchQuery
 
@@ -251,12 +251,12 @@ class RuleBasedStrategy:
             agent_id=f"webhook/{source_id}",
             limit=1000,
             sort_by="recency",
-        ))
+        ), branch=branch)
         external_entries = adapter.search(SearchQuery(
             agent_id=f"external/{source_id}",
             limit=1000,
             sort_by="recency",
-        ))
+        ), branch=branch)
         entries = webhook_entries + external_entries
         if not entries:
             return None

--- a/packages/cortex/src/amfs_cortex/worker.py
+++ b/packages/cortex/src/amfs_cortex/worker.py
@@ -168,16 +168,17 @@ class CortexWorker:
         if channel == "amfs_write":
             entity_path = payload.get("entity_path", "")
             agent_id = payload.get("agent_id", "")
+            branch = payload.get("branch", "main")
             if entity_path:
                 with self._lock:
-                    self._pending[f"entity:{entity_path}"] = time.monotonic()
+                    self._pending[f"entity:{entity_path}@{branch}"] = time.monotonic()
             if agent_id:
                 with self._lock:
                     if agent_id.startswith(("webhook/", "external/")):
                         source = agent_id.split("/", 1)[1]
-                        self._pending[f"source:{source}"] = time.monotonic()
+                        self._pending[f"source:{source}@{branch}"] = time.monotonic()
                     else:
-                        self._pending[f"agent:{agent_id}"] = time.monotonic()
+                        self._pending[f"agent:{agent_id}@{branch}"] = time.monotonic()
 
                 if self._hot_tracker:
                     self._hot_tracker.record_activity(agent_id, entity_path, "write")
@@ -187,6 +188,7 @@ class CortexWorker:
                 "channel": channel,
                 "entity_path": entity_path,
                 "agent_id": agent_id,
+                "branch": branch,
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             })
 
@@ -222,26 +224,32 @@ class CortexWorker:
             for scope in ready:
                 del self._pending[scope]
 
-        for scope in ready:
+        for scope_with_branch in ready:
+            if "@" in scope_with_branch:
+                scope, branch = scope_with_branch.rsplit("@", 1)
+            else:
+                scope, branch = scope_with_branch, "main"
             try:
                 t0 = time.monotonic()
-                result = self._compiler.compile(scope)
+                result = self._compiler.compile(scope, branch=branch)
                 elapsed_ms = round((time.monotonic() - t0) * 1000)
                 if result:
                     self._digests_compiled += 1
                     self._activity_log.append({
                         "type": "digest_compiled",
                         "scope": scope,
+                        "branch": branch,
                         "digest_type": result.digest_type.value,
                         "entry_count": result.entry_count,
                         "elapsed_ms": elapsed_ms,
                         "timestamp": datetime.now(timezone.utc).isoformat(),
                     })
             except Exception:
-                logger.exception("Failed to compile digest for %s", scope)
+                logger.exception("Failed to compile digest for %s (branch=%s)", scope, branch)
                 self._activity_log.append({
                     "type": "compilation_error",
                     "scope": scope,
+                    "branch": branch,
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                 })
 

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -1226,6 +1226,25 @@ async def rollback_to_tag(
 
 
 # ──────────────────────────────────────────────────────────────────────
+# Fork (Pro)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@app.post("/api/v1/fork")
+async def fork_agent(
+    target_agent_id: str = Query(...),
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    mem = _get_memory()
+    count = mem.fork(target_agent_id)
+    return {
+        "source_agent": mem.agent_id,
+        "target_agent": target_agent_id,
+        "entries_copied": count,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
 # Admin — API Keys
 # ──────────────────────────────────────────────────────────────────────
 
@@ -2021,6 +2040,7 @@ async def list_connectors(
 async def get_briefing(
     entity_path: str | None = Query(None),
     agent_id: str | None = Query(None),
+    branch: str = Query("main"),
     limit: int = Query(10, ge=1, le=100),
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
@@ -2030,6 +2050,7 @@ async def get_briefing(
         entity_path=entity_path,
         agent_id=agent_id,
         limit=limit,
+        branch=branch,
     )
     return {
         "digests": [d.model_dump(mode="json") for d in digests],

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -762,6 +762,58 @@ def amfs_cherry_pick(branch_name: str, entries: list[dict[str, str]]) -> str:
     return json.dumps({"picked": picked, "source_branch": branch_name})
 
 
+@mcp.tool()
+def amfs_fork(target_agent_id: str) -> str:
+    """Fork this agent's current branch memory into a new agent's main branch.
+
+    All live entries on the current branch are copied to the target agent.
+    """
+    mem = _get_memory()
+    count = mem.fork(target_agent_id)
+    return json.dumps({
+        "source_agent": mem.agent_id,
+        "target_agent": target_agent_id,
+        "entries_copied": count,
+    })
+
+
+@mcp.tool()
+def amfs_create_pull_request(
+    title: str,
+    source_branch: str,
+    target_branch: str = "main",
+    description: str = "",
+) -> str:
+    """Create a pull request to merge a branch into another."""
+    mem = _get_memory()
+    pr = mem.create_pull_request(
+        title, source_branch, target_branch=target_branch,
+        description=description or None,
+    )
+    return json.dumps(pr.model_dump(mode="json"), default=str)
+
+
+@mcp.tool()
+def amfs_list_pull_requests(status: str = "") -> str:
+    """List pull requests, optionally filtered by status (open/merged/closed)."""
+    mem = _get_memory()
+    prs = mem.list_pull_requests(status=status or None)
+    return json.dumps([p.model_dump(mode="json") for p in prs], default=str)
+
+
+@mcp.tool()
+def amfs_rollback(timestamp: str = "", tag_name: str = "") -> str:
+    """Rollback memory to a point in time or a named tag.
+
+    Provide either timestamp (ISO 8601) or tag_name.
+    """
+    mem = _get_memory()
+    from datetime import datetime as dt
+    ts = dt.fromisoformat(timestamp) if timestamp else None
+    count = mem.rollback(timestamp=ts, tag_name=tag_name or None)
+    return json.dumps({"entries_restored": count, "rolled_back_to": timestamp or tag_name})
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Entry point
 # ──────────────────────────────────────────────────────────────────────

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -729,6 +729,7 @@ class AgentMemory:
         entity_path: str | None = None,
         agent_id: str | None = None,
         limit: int = 10,
+        branch: str | None = None,
     ) -> list:
         """Get a ranked briefing of compiled knowledge digests.
 
@@ -740,6 +741,7 @@ class AgentMemory:
             entity_path: Focus on digests relevant to this entity.
             agent_id: Focus on digests relevant to this agent.
             limit: Maximum number of digests to return.
+            branch: Branch to read digests from (defaults to active branch).
 
         Returns:
             List of Digest objects ranked by relevance.
@@ -757,6 +759,7 @@ class AgentMemory:
             entity_path=entity_path,
             agent_id=agent_id or self.agent_id,
             limit=limit,
+            branch=branch or self._branch,
         )
 
     # ------------------------------------------------------------------
@@ -1060,6 +1063,36 @@ class AgentMemory:
             since=since,
             limit=limit,
         )
+
+    # ------------------------------------------------------------------
+    # Fork (Pro)
+    # ------------------------------------------------------------------
+
+    def fork(self, target_agent_id: str) -> int:
+        """Fork this agent's current branch memory into a new agent's main.
+
+        All live entries on the current branch are copied to ``target_agent_id``'s
+        ``main`` branch.  Returns the number of entries copied.
+        """
+        count = self._adapter.fork_agent(
+            self.agent_id,
+            target_agent_id,
+            namespace=self.namespace,
+            branch=self._branch,
+        )
+        self._adapter.log_event(Event(
+            namespace=self.namespace,
+            agent_id=self.agent_id,
+            branch=self._branch,
+            event_type=EventType.FORK,
+            summary=f"Forked {count} entries to agent '{target_agent_id}'",
+            details={
+                "target_agent_id": target_agent_id,
+                "source_branch": self._branch,
+                "entries_copied": count,
+            },
+        ))
+        return count
 
     # ------------------------------------------------------------------
     # Scoped access


### PR DESCRIPTION
## Summary

- **Fork**: Copy an entire agent's memory branch into a new independent agent (abc, adapter, SDK, HTTP, MCP)
- **Cortex branch awareness**: Digest compilation, briefing, and the CortexWorker are now scoped per-branch — digests are keyed by `(namespace, branch, digest_type, scope)` and the NOTIFY payload includes `branch`
- **MCP tools**: `amfs_fork`, `amfs_create_pull_request`, `amfs_list_pull_requests`, `amfs_rollback`

Builds on PR #92.

## Test plan

- [x] All 85 existing unit tests pass
- [ ] Integration test for fork (create agent, write entries, fork, verify target has entries)
- [ ] Integration test for branch-scoped digest compilation
- [ ] Verify NOTIFY payload includes branch field