### PR TITLE
fix: thread agent_id from MCP → HTTP adapter → database

### DIFF
--- a/packages/adapters/http/pyproject.toml
+++ b/packages/adapters/http/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-adapter-http"
-version = "0.1.1"
+version = "0.1.2"
 description = "AMFS HTTP adapter — routes memory operations through the authenticated REST API"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -100,6 +100,7 @@ class HttpAdapter(AdapterABC):
             "memory_type": entry.memory_type.value if hasattr(entry.memory_type, "value") else str(entry.memory_type),
             "shared": entry.shared,
             "branch": entry.branch,
+            "agent_id": entry.provenance.agent_id,
         }
         data = self._post("/api/v1/entries", body)
         return _parse_entry(data)
@@ -133,6 +134,7 @@ class HttpAdapter(AdapterABC):
             "outcome_type": record.outcome_type.value if hasattr(record.outcome_type, "value") else str(record.outcome_type),
             "causal_entry_keys": record.causal_entry_keys,
             "causal_confidence": record.causal_confidence,
+            "agent_id": record.agent_id,
         }
         data = self._post("/api/v1/outcomes", body)
         return [_parse_entry(e) for e in data.get("entries", [])]

--- a/packages/http-server/pyproject.toml
+++ b/packages/http-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-http-server"
-version = "0.1.0"
+version = "0.1.1"
 description = "AMFS HTTP/REST API server with SSE support"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/http-server/src/amfs_http/models.py
+++ b/packages/http-server/src/amfs_http/models.py
@@ -16,6 +16,7 @@ class WriteRequest(BaseModel):
     memory_type: str = "fact"
     shared: bool = True
     branch: str = "main"
+    agent_id: str | None = None
 
 
 class OutcomeRequest(BaseModel):
@@ -23,6 +24,7 @@ class OutcomeRequest(BaseModel):
     outcome_type: str
     causal_entry_keys: list[str] | None = None
     causal_confidence: float = 1.0
+    agent_id: str | None = None
 
 
 class SearchRequest(BaseModel):
@@ -42,6 +44,7 @@ class ContextRequest(BaseModel):
     label: str
     summary: str
     source: str | None = None
+    agent_id: str | None = None
 
 
 class CreateAPIKeyRequest(BaseModel):

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -292,16 +292,27 @@ async def write_entry(
     }
     mt = type_map.get(req.memory_type.lower(), MemoryType.FACT)
 
-    entry = mem.write(
-        req.entity_path,
-        req.key,
-        req.value,
-        confidence=req.confidence,
-        pattern_refs=req.pattern_refs or None,
-        memory_type=mt,
-        shared=req.shared,
-        branch=req.branch,
-    )
+    original_agent = mem._tagger.agent_id if req.agent_id else None
+    if req.agent_id:
+        mem._tagger.agent_id = req.agent_id
+        try:
+            mem._adapter.ensure_agent(req.agent_id, mem.namespace)
+        except Exception:
+            pass
+    try:
+        entry = mem.write(
+            req.entity_path,
+            req.key,
+            req.value,
+            confidence=req.confidence,
+            pattern_refs=req.pattern_refs or None,
+            memory_type=mt,
+            shared=req.shared,
+            branch=req.branch,
+        )
+    finally:
+        if original_agent is not None:
+            mem._tagger.agent_id = original_agent
     _sse_manager.broadcast(entry)
     _audit_log(
         "memory.write",
@@ -525,12 +536,23 @@ async def commit_outcome(
         valid = ", ".join(_OUTCOME_TYPE_MAP.keys())
         return {"error": f"Invalid outcome_type '{req.outcome_type}'. Must be one of: {valid}"}
 
-    entries = mem.commit_outcome(
-        req.outcome_ref,
-        otype,
-        causal_entry_keys=req.causal_entry_keys,
-        causal_confidence=req.causal_confidence,
-    )
+    original_agent = mem._tagger.agent_id if req.agent_id else None
+    if req.agent_id:
+        mem._tagger.agent_id = req.agent_id
+        try:
+            mem._adapter.ensure_agent(req.agent_id, mem.namespace)
+        except Exception:
+            pass
+    try:
+        entries = mem.commit_outcome(
+            req.outcome_ref,
+            otype,
+            causal_entry_keys=req.causal_entry_keys,
+            causal_confidence=req.causal_confidence,
+        )
+    finally:
+        if original_agent is not None:
+            mem._tagger.agent_id = original_agent
     _audit_log(
         "outcome.commit",
         resource=req.outcome_ref,

--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-mcp-server"
-version = "0.2.1"
+version = "0.2.2"
 description = "AMFS MCP Server — expose Agent Memory as MCP tools for Cursor and Claude Code"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -167,8 +167,7 @@ def amfs_set_identity(name: str, description: str | None = None) -> str:
     """
     mem = _get_memory()
     old_id = mem.agent_id
-    mem._agent_id = name
-    mem._read_tracker._agent_id = name
+    mem._tagger.agent_id = name
     result: dict[str, Any] = {
         "previous_identity": old_id,
         "new_identity": name,


### PR DESCRIPTION
## Summary

- **MCP server**: `amfs_set_identity` now correctly updates `mem._tagger.agent_id` instead of the wrong attribute `mem._agent_id`
- **HTTP adapter**: `write()` and `commit_outcome()` include `agent_id` in the request body
- **HTTP server**: `write_entry` and `commit_outcome` endpoints honor client-provided `agent_id`, temporarily swapping the tagger's identity and calling `ensure_agent()` so new agents appear in the dashboard

Version bumps: `amfs-mcp-server` 0.2.2, `amfs-http-server` 0.1.1, `amfs-adapter-http` 0.1.2

## Test plan

- [ ] Call `amfs_set_identity("my-agent-name")` via MCP
- [ ] Write a memory entry — verify provenance shows the custom agent name
- [ ] Check dashboard agents page — new agent should appear