### PR TITLE
docs: adjusting documentation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,32 @@
 [![TypeScript Tests](https://github.com/raia-live/amfs/actions/workflows/test-typescript.yml/badge.svg)](https://github.com/raia-live/amfs/actions/workflows/test-typescript.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
-A shared, causally-linked memory layer for multi-agent AI systems. Agents write versioned findings with confidence scores, read each other's knowledge, and learn from real-world outcomes — turning isolated LLM calls into compounding institutional intelligence.
+**GitHub for agent memory.** Every agent gets a brain — its own repo of what it knows. Branch it, diff it, open a PR, review the changes, merge. Roll back to any point. The mental model is already in every developer's head.
 
 **[Documentation](https://raia-live.github.io/amfs/)** · **[Roadmap](https://github.com/orgs/raia-live/projects/2)** · **[Contributing](https://raia-live.github.io/amfs/contributing/)**
 
-## Why AMFS
+## The Problem
 
-Most agent memory is a vector store with a `save()` and `query()`. AMFS is different:
+When agents share memory today, it's chaos — last write wins, no branching, no review, no rollback. It's like coding without Git. Every team that tried that eventually hit a wall. Agent teams are hitting that wall right now.
 
-- **Versioned** — Every write creates an immutable CoW snapshot. See how knowledge evolved.
-- **Outcome-aware** — Confidence scores adjust automatically when deploys succeed or incidents happen.
-- **Causal** — Every read is tracked. `explain()` shows exactly which memories drove a decision.
-- **Knowledge graph** — Relationships between entities, agents, and outcomes are auto-materialized from normal operations and queryable via `graph_neighbors()`.
-- **Hybrid search** — Combine full-text (Postgres tsvector), semantic (cosine similarity), recency, and confidence into a single ranked result set.
-- **Multi-agent** — Agents share a single memory layer. One agent's finding is another's context.
-- **Pluggable** — Filesystem for dev, Postgres for production, S3 for cloud. Swap without code changes.
+The solution isn't "better permissions" or "smarter retrieval." It's giving agents the same collaboration model developers already live in: **version control for knowledge**.
+
+## How AMFS Works
+
+```
+Every developer knows this:          AMFS does the same for agent memory:
+
+  repo                                 agent brain
+  ├── main branch                      ├── main (what the agent knows)
+  ├── feature branch                   ├── experiment branch (isolated changes)
+  ├── pull request                     ├── pull request (review before merge)
+  ├── code review                      ├── diff (what changed in the branch)
+  ├── merge                            ├── merge (accept changes into main)
+  ├── git log                          ├── timeline (every operation logged)
+  └── git revert                       └── rollback (restore to any point)
+```
+
+Every write is a versioned commit. Every agent has provenance (who wrote what, when). Changes stay isolated on branches until the owner reviews the diff and merges. You can roll back to any point. You can fork an agent's entire brain to a new agent.
 
 ## Quick Start
 
@@ -31,12 +42,15 @@ from amfs import AgentMemory, OutcomeType
 
 mem = AgentMemory(agent_id="review-agent")
 
+# Agent discovers a pattern and commits it to memory
 mem.write("checkout-service", "retry-pattern",
           {"max_retries": 3, "strategy": "exponential-backoff"},
           confidence=0.85)
 
+# Another agent reads it — the read is tracked automatically
 entry = mem.read("checkout-service", "retry-pattern")
 
+# When the deploy fails, confidence on related entries adjusts
 mem.commit_outcome("INC-1042", OutcomeType.CRITICAL_FAILURE)
 ```
 
@@ -59,17 +73,36 @@ Or run with Docker:
 docker run -p 8080:8080 -v amfs-data:/data ghcr.io/raia-live/amfs
 ```
 
+## What You Get
+
+| | |
+|:--|:--|
+| **Git-like Timeline** | Every write, outcome, and cross-agent read is logged as an event. Full history, always. |
+| **Branching & PRs** | Create branches, diff changes, open pull requests, merge or discard. Pro feature — [details →](https://raia-live.github.io/amfs/editions/) |
+| **Rollback & Tags** | Create named snapshots. Roll back to any tag or event. Pro feature. |
+| **Access Control** | Grant read or read/write access per branch, per user, team, or API key. Pro feature. |
+| **Versioned Knowledge** | Copy-on-Write — every write creates a new version. Nothing is lost. `history()` to replay. |
+| **Confidence & Outcomes** | Entries carry trust scores that evolve when deploys succeed or incidents happen. |
+| **Causal Explainability** | `explain()` shows exactly which memories and external contexts drove a decision. |
+| **Knowledge Graph** | Relationships between entities, agents, and outcomes auto-materialize from normal operations. |
+| **Hybrid Search** | Full-text + semantic + recency + confidence in a single ranked result set. |
+| **MCP Server** | First-class support for Cursor, Claude Code, and any MCP client. [Setup →](https://raia-live.github.io/amfs/guides/mcp/) · [Cursor plugin](https://github.com/raia-live/cursor-plugin) |
+| **Connectors** | Ingest events from PagerDuty, GitHub, Slack, Jira — or [build your own](https://raia-live.github.io/amfs/guides/connectors/). |
+| **Python & TypeScript** | Same API in both languages. Plus [CrewAI](https://raia-live.github.io/amfs/guides/crewai/), LangGraph, LangChain, AutoGen. |
+
 ## Architecture
 
 ```
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│ Review Agent│     │Release Agent│     │  Other Agent │
+│ Agent A      │     │ Agent B      │     │ Agent C      │
+│ (its brain)  │     │ (its brain)  │     │ (its brain)  │
 └──────┬──────┘     └──────┬──────┘     └──────┬──────┘
        │                   │                   │
        └───────────┬───────┴───────────────────┘
                    │
        ┌───────────┴───────────┐
-       │ AgentMemory (CoW)     │  ← Python / TypeScript SDK
+       │ AgentMemory           │  ← Python / TypeScript SDK
+       │ (versioned, branched) │
        └───────────┬───────────┘
                    │
        ┌───────────┴───────────┐
@@ -82,25 +115,13 @@ docker run -p 8080:8080 -v amfs-data:/data ghcr.io/raia-live/amfs
   Adapter    Adapter  Adapter   Adapter
 ```
 
-## Highlights
-
-| | |
-|:--|:--|
-| **CoW Versioning** | Full version history for every entry. `history()` to replay changes. |
-| **Confidence & Outcomes** | Scores adjust when real-world outcomes (deploys, incidents) are recorded. |
-| **Causal Explainability** | `explain()` returns the full decision trace: what was read, by whom, and when. |
-| **Connectors** | Ingest events from PagerDuty, GitHub, Slack, Jira — or [build your own](https://raia-live.github.io/amfs/guides/connectors/). |
-| **Composite Scoring** | Rank results by weighted blend of relevance, recency, and confidence. |
-| **Multi-Scope** | Query across scopes with `search(entity_paths=[...])` and visualize with `tree()`. |
-| **MCP Server** | First-class support for Cursor, Claude Code, and any MCP client. [Setup →](https://raia-live.github.io/amfs/guides/mcp/) · **Cursor:** [cursor-plugin](https://github.com/raia-live/cursor-plugin) (Sense Lab dashboard MCP) |
-| **Integrations** | [CrewAI](https://raia-live.github.io/amfs/guides/crewai/), LangGraph, LangChain, AutoGen. |
-| **Python & TypeScript** | Same API in both languages. |
-
 ## OSS vs Pro
 
-AMFS is open source under [Apache 2.0](LICENSE). The OSS edition includes the full memory engine, SDKs, adapters, connectors, HTTP API, MCP server, and CLI.
+AMFS is open source under [Apache 2.0](LICENSE). The OSS edition gives you the full memory engine — versioned writes, confidence scoring, outcome feedback, causal traces, knowledge graph, hybrid search, git-like timeline on `main`, SDKs, adapters, HTTP API, MCP server, and CLI.
 
-**[AMFS Pro](https://raia-live.github.io/amfs/editions/)** adds enterprise capabilities: multi-tenant isolation (Postgres RLS + RBAC), persistent decision traces, automated pattern detection, an intelligence layer (LLM extraction, memory critic), and a web dashboard.
+**[AMFS Pro](https://raia-live.github.io/amfs/editions/)** unlocks the full Git model: branching, merge, pull requests, access control, tags, rollback, cherry-pick, and fork. Plus multi-tenant SaaS isolation, immutable decision traces, automated pattern detection, an intelligence layer, and a web dashboard.
+
+Think of it this way: OSS gives you a single-branch repo with full history. Pro gives you GitHub.
 
 **[Full comparison →](https://raia-live.github.io/amfs/editions/)**
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -12,7 +12,9 @@ permalink: /concepts/
 Understanding the building blocks of AMFS.
 {: .fs-6 .fw-300 }
 
-AMFS is built around a few core ideas that work together: **memory entries** store knowledge with a **memory type** (fact, belief, or experience), **copy-on-write** preserves history, **provenance** tracks authorship and **provenance tiers** rank quality, **confidence** scores reflect trust with type-specific decay, **outcomes** close the feedback loop, a **knowledge graph** auto-materializes relationships between entities, agents, and outcomes, **hybrid search** blends full-text, semantic, and confidence signals, and a **git-like timeline** records every operation as an event on the agent's history.
+AMFS treats each agent's knowledge as a **Git repository**. Every write is a versioned commit. Every operation is logged on a timeline. Branches isolate experiments. Pull requests let you review changes before merging. You can roll back to any point.
+
+On top of this Git-like foundation, AMFS adds memory intelligence: **memory entries** store knowledge with a **memory type** (fact, belief, or experience), **copy-on-write** preserves full history, **provenance** tracks authorship, **confidence** scores evolve based on real-world **outcomes**, a **knowledge graph** auto-materializes relationships, and **hybrid search** blends full-text, semantic, and confidence signals.
 {: .fs-6 .fw-300 }
 
 ---

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -9,7 +9,7 @@ permalink: /editions/
 # OSS vs Pro
 {: .no_toc }
 
-AMFS is split into two layers: a fully open-source core and a proprietary Pro layer. The OSS layer gives you everything you need to build production-ready agent memory. Pro adds multi-tenant SaaS infrastructure, persistent decision traces, cross-system ingestion, automated pattern detection, LLM-powered intelligence, and an enterprise dashboard.
+AMFS is GitHub for agent memory, split into two layers. The open-source core gives you the full memory engine with a single-branch repo model — versioning, confidence, outcomes, causal traces, knowledge graph, and a git-like timeline. Pro unlocks the full Git model: branching, merge, pull requests, access control, tags, rollback, cherry-pick, fork — plus multi-tenant SaaS, immutable traces, pattern detection, intelligence, and a dashboard.
 {: .fs-6 .fw-300 }
 
 ## Table of Contents

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,14 +2,14 @@
 title: Home
 layout: home
 nav_order: 1
-description: "AMFS — Agent Memory File System. Shared, versioned memory for multi-agent AI systems."
+description: "AMFS — Agent Memory File System. GitHub for agent memory."
 permalink: /
 ---
 
 # Agent Memory File System
 {: .fs-9 }
 
-A shared, causally-linked memory layer so AI agents can read each other's findings, track confidence over time, and learn from outcomes.
+GitHub for agent memory. Every agent gets a brain — its own repo of what it knows. Branch it, diff it, review changes, merge them. Roll back to any point. Collaborate the way developers already do.
 {: .fs-6 .fw-300 }
 
 [Get Started](/amfs/getting-started/){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
@@ -17,44 +17,30 @@ A shared, causally-linked memory layer so AI agents can read each other's findin
 
 ---
 
+## The Problem
+
+When agents share memory today, it's chaos — last write wins, no branching, no review, no rollback. It's like coding without Git. Every team that tried that eventually hit a wall. Agent teams are hitting that wall right now.
+
+The problem isn't "agents need permissions." The problem is agents have no way to collaborate on knowledge the way developers collaborate on code.
+
 ## What is AMFS?
 
-AMFS is a filesystem-modeled protocol and SDK that gives multi-agent AI systems a standard way to **share**, **persist**, and **version** memory. It works like a version-controlled knowledge base that agents can read from and write to — across sessions, machines, and frameworks.
+AMFS applies the Git model to agent memory. The mental model is already in every developer's head — you're not learning something new, you're getting the tool you've been waiting for.
 
 ```
-┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│ Review Agent│     │Release Agent│     │  Other Agent │
-└──────┬──────┘     └──────┬──────┘     └──────┬──────┘
-       │                   │                   │
-       └───────────┬───────┴───────────────────┘
-                   │
-       ┌───────────┴───────────┐
-       │ AgentMemory (CoW)     │  ← Python / TypeScript SDK
-       └───────────┬───────────┘
-                   │
-       ┌───────────┴───────────┐
-       │ HTTP API / MCP Server │  ← REST + SSE / stdio + HTTP
-       └───────────┬───────────┘
-                   │
-     ┌─────────┬───┴────┬─────────┐
-     ▼         ▼        ▼         ▼
- Filesystem  Postgres   S3      Custom
-  Adapter    Adapter  Adapter   Adapter
+Every developer knows this:          AMFS does the same for agent memory:
+
+  repo                                 agent brain
+  ├── main branch                      ├── main (what the agent knows)
+  ├── feature branch                   ├── experiment branch (isolated changes)
+  ├── pull request                     ├── pull request (review before merge)
+  ├── code review                      ├── diff (what changed in the branch)
+  ├── merge                            ├── merge (accept changes into main)
+  ├── git log                          ├── timeline (every operation logged)
+  └── git revert                       └── rollback (restore to any point)
 ```
 
-### Why AMFS?
-
-AI agents today are stateless. Each session starts from scratch — no memory of past decisions, patterns, or mistakes. When multiple agents work on the same codebase, they duplicate work and repeat errors.
-
-AMFS solves this by giving agents a **shared memory layer** with:
-
-- **Versioned knowledge** — Every write creates a new version. Nothing is lost.
-- **Provenance tracking** — Know which agent wrote what, and when.
-- **Confidence scoring** — Entries carry a confidence score that evolves over time based on real-world outcomes.
-- **Outcome back-propagation** — Incidents increase confidence on risky patterns. Clean deploys decay it.
-- **Pluggable storage** — Filesystem, Postgres (with full-text + vector search), S3-compatible, or custom.
-- **HTTP API** — Access AMFS from any language or service over REST. Real-time streaming via SSE.
-- **Artifact references** — Link memory entries to external blobs (model weights, datasets, logs) in S3 or elsewhere.
+Other agents can be granted read or write access to branches of that brain. Changes stay isolated until the owner reviews the diff and merges. Every change is logged. You can roll back to any point. You can back up and restore the entire brain.
 
 ### Quick Example
 
@@ -63,7 +49,7 @@ from amfs import AgentMemory
 
 mem = AgentMemory(agent_id="review-agent")
 
-# Agent discovers a risk and records it
+# Agent discovers a risk and commits it to memory
 mem.write(
     "checkout-service",
     "risk-race-condition",
@@ -71,36 +57,50 @@ mem.write(
     confidence=0.85,
 )
 
-# Later, another agent reads it before working on the same code
+# Another agent reads it — the read is tracked automatically
 entry = mem.read("checkout-service", "risk-race-condition")
-# → "Race condition in order processing under concurrent load"
-# → confidence: 0.85
+# → confidence: 0.85, written_by: review-agent
 ```
 
 ---
 
 ## Key Features
 
+### Git-like Collaboration
+
 | Feature | Description |
 |:--------|:------------|
-| **Copy-on-Write versioning** | Every write creates a new version. Full history is preserved. |
-| **Confidence scores** | Each entry carries a confidence score that evolves based on outcomes. |
-| **Outcome back-propagation** | Link deploys and incidents to memory entries. Confidence adjusts automatically. |
-| **Memory types** | Classify entries as `fact`, `belief`, or `experience` with type-specific decay rates. |
-| **Provenance tiers** | Automatically tier entries by quality: production-validated, observed, dev, or manual. |
-| **Temporal queries** | Retrieve the full version history of any entry, filtered by time range. |
-| **Causal explainability** | Inspect which entries were read and how they connect to outcomes. |
-| **Enriched decision traces** | Traces capture full entry snapshots, query/error events, session timing, and state diffs. |
-| **Per-agent memory graph** | View any agent's complete knowledge footprint across entities. |
-| **Provenance tracking** | Every entry records which agent wrote it, when, and from which session. |
-| **Artifact references** | Link entries to external blobs in S3, local files, or URLs. |
-| **HTTP/REST API** | FastAPI server with 12 endpoints, SSE streaming, and API key auth. |
-| **Multiple adapters** | Filesystem (default), Postgres (with full-text + vector search), S3-compatible, or custom. |
-| **MCP integration** | First-class MCP server for Cursor, Claude Code, and any MCP-compatible client. |
-| **Framework integrations** | Works with CrewAI, LangGraph, LangChain, and AutoGen. |
+| **Git-like timeline** | Every write, outcome, and cross-agent read is logged as an event. Full history, always. |
+| **Branching & PRs** | Create branches, diff changes, open pull requests, review, merge or discard. (Pro) |
+| **Tags & rollback** | Create named snapshots. Roll back to any tag or event. (Pro) |
+| **Access control** | Grant read or read/write access per branch, per user, team, or API key. (Pro) |
+| **Fork** | Clone an agent's entire brain to a new agent. (Pro) |
+
+### Memory Intelligence
+
+| Feature | Description |
+|:--------|:------------|
+| **Versioned knowledge** | Copy-on-Write — every write creates a new version. Nothing is ever lost. |
+| **Confidence & outcomes** | Trust scores evolve when deploys succeed or incidents happen. |
+| **Causal explainability** | `explain()` shows exactly which memories and external contexts drove a decision. |
+| **Decision traces** | Full trace capture — reads, writes, query events, errors, timing, and state diffs. |
+| **Knowledge graph** | Relationships between entities, agents, and outcomes auto-materialize from normal operations. |
+| **Hybrid search** | Full-text + semantic + recency + confidence in a single ranked result set. |
+| **Memory types** | Classify as `fact`, `belief`, or `experience` — each with its own decay rate. |
+| **Tiered memory** | Hot / Warm / Archive with progressive retrieval and frequency-modulated decay. |
+
+### Platform
+
+| Feature | Description |
+|:--------|:------------|
+| **MCP server** | First-class support for Cursor, Claude Code, and any MCP client. [Setup →](/amfs/guides/mcp/) |
+| **HTTP/REST API** | FastAPI server with SSE streaming and API key auth. |
+| **Multiple adapters** | Filesystem (dev), Postgres (production), S3 (cloud). Swap without code changes. |
+| **Python & TypeScript** | Same API in both languages. |
+| **Framework integrations** | CrewAI, LangGraph, LangChain, AutoGen. |
+| **Connectors** | Ingest events from PagerDuty, GitHub, Slack, Jira — or build your own. |
 | **CLI tools** | Inspect, diff, snapshot, and restore memory from the command line. |
 | **Docker & Kubernetes** | One-command deployment with Docker or Helm chart. |
-| **Python & TypeScript** | SDKs for both languages with the same conceptual API. |
 
 ---
 
@@ -151,7 +151,11 @@ curl http://localhost:8080/api/v1/entries/checkout-service/retry-pattern
 
 ## OSS vs Pro
 
-AMFS is available in two editions. The open-source layer provides the full memory primitive — versioning, confidence, outcomes, enriched decision traces, per-agent memory graphs, adapters, and MCP. The Pro layer adds a multi-tenant SaaS foundation (RBAC, scoped API keys, Postgres RLS), immutable decision trace store with cryptographic integrity and LLM call tracking, OpenTelemetry export, auto entity extraction, cross-system ingestion (PagerDuty, Slack, GitHub webhooks), automated pattern detection and alerting, LLM-powered intelligence, and an interactive dashboard with causal graph visualization.
+AMFS is open source under [Apache 2.0](https://github.com/raia-live/amfs/blob/main/LICENSE). The OSS edition gives you the full memory engine with a single-branch repo model — versioned writes, confidence scoring, outcome feedback, causal traces, knowledge graph, hybrid search, tiered memory, git-like timeline on `main`, SDKs, adapters, HTTP API, MCP server, and CLI.
+
+**[AMFS Pro](https://raia-live.github.io/amfs/editions/)** unlocks the full Git model: branching, merge, pull requests, access control, tags, rollback, cherry-pick, and fork. Plus multi-tenant SaaS isolation, immutable decision traces, automated pattern detection, an intelligence layer, and a web dashboard.
+
+OSS gives you a repo with full history. Pro gives you GitHub.
 
 [Compare editions](/amfs/editions/){: .btn .btn-outline .fs-5 .mb-4 .mb-md-0 }
 [AMFS vs Vector DBs](/amfs/vs-vector-databases/){: .btn .btn-outline .fs-5 .mb-4 .mb-md-0 }
@@ -162,15 +166,17 @@ AMFS is available in two editions. The open-source layer provides the full memor
 ## How Agents Use AMFS
 
 ```
-1. Get a briefing           →  amfs_briefing(entity_path="checkout-service")
-2. Search for specifics     →  amfs_search("checkout-service")
-3. Read relevant entries    →  amfs_read("checkout-service", "retry-pattern")
-4. Do the work              →  (agent performs its task)
-5. Write findings           →  amfs_write("checkout-service", "new-pattern", ...)
-6. Record outcomes          →  amfs_commit_outcome("DEP-287", "success")
+1. Identify yourself         →  amfs_set_identity("checkout-agent", "Fixing retry logic")
+2. Get a briefing            →  amfs_briefing(entity_path="checkout-service")
+3. Search for specifics      →  amfs_search("checkout-service")
+4. Read relevant entries     →  amfs_read("checkout-service", "retry-pattern")
+5. Do the work               →  (agent performs its task)
+6. Write findings            →  amfs_write("checkout-service", "new-pattern", ...)
+7. Record outcomes           →  amfs_commit_outcome("DEP-287", "success")
+8. Next agent starts at #2   →  Knowledge compounds across agents and sessions
 ```
 
-Knowledge compounds over time. The Memory Cortex compiles raw entries into ranked digests, so the next agent — on any machine — starts with a pre-compiled briefing of what matters, instead of searching from scratch.
+The Memory Cortex compiles raw entries into ranked digests, so the next agent — on any machine — starts with a pre-compiled briefing of what matters, instead of searching from scratch.
 
 ---
 

--- a/docs/vs-competitors.md
+++ b/docs/vs-competitors.md
@@ -9,7 +9,7 @@ permalink: /vs-competitors/
 # AMFS vs Competitors
 {: .no_toc }
 
-How AMFS compares to every serious memory system in the 2026 landscape.
+Every other memory system is a smarter store. AMFS is the only one that treats agent memory like code — with version control, branching, pull requests, and rollback.
 {: .fs-6 .fw-300 }
 
 ## Table of Contents
@@ -24,6 +24,15 @@ How AMFS compares to every serious memory system in the 2026 landscape.
 
 | Feature | AMFS | Mem0 | Zep / Graphiti | Hindsight | Letta | Cognee | LangMem |
 |:--------|:----:|:----:|:--------------:|:---------:|:-----:|:------:|:-------:|
+| **Git-like collaboration** | | | | | | | |
+| Branching (isolated experiments) | Pro | No | No | No | No | No | No |
+| Pull requests (review before merge) | Pro | No | No | No | No | No | No |
+| Diff, merge, rollback | Pro | No | No | No | No | No | No |
+| Tags / named snapshots | Pro | No | No | No | No | No | No |
+| Branch-level access control | Pro | No | No | No | No | No | No |
+| Fork (clone brain to new agent) | Pro | No | No | No | No | No | No |
+| Git-like timeline (event log) | Yes | No | No | No | No | No | No |
+| **Memory fundamentals** | | | | | | | |
 | Persistent memory | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | Versioning (full history) | CoW | No | Temporal | No | No | No | No |
 | Provenance (who wrote, when) | Yes | No | Partial | No | No | No | No |
@@ -55,12 +64,12 @@ How AMFS compares to every serious memory system in the 2026 landscape.
 **Where Mem0 excels:** Simple API, automatic fact extraction from chat, optional graph memory, wide framework integrations (CrewAI, LangGraph, Flowise).
 
 **Where AMFS differs:**
+- **Git model for collaboration** -- Branching, PRs, diff, merge, rollback, access control. Mem0 has no collaboration model — it's a single-writer store.
 - **Outcome feedback loop** -- AMFS confidence evolves from production events. Mem0 stores facts without trust signals.
 - **CoW versioning** -- Every write is immutable and replayable. Mem0 overwrites.
 - **Multi-agent provenance** -- AMFS tracks authorship, detects conflicts, and auto-links causality. Mem0 is single-user oriented.
 - **Four-signal decay** -- Time + type + outcomes + access frequency. Mem0 has no decay model.
 - **Tiered memory** -- Hot/Warm/Archive with progressive retrieval. Mem0 searches everything.
-- **Cross-system ingestion** -- Webhooks from PagerDuty, Slack, GitHub, Jira. Mem0 only ingests from conversations.
 
 ---
 
@@ -71,6 +80,7 @@ How AMFS compares to every serious memory system in the 2026 landscape.
 **Where Zep excels:** Temporal knowledge graphs with time-bounded edges, entity resolution across conversations, strong on multi-hop temporal queries.
 
 **Where AMFS differs:**
+- **Git model for collaboration** -- Branching, PRs, diff, merge, rollback. Zep has no collaboration or version control model.
 - **Outcome back-propagation** -- AMFS learns from production events. Zep tracks temporal validity but doesn't learn from what happens after retrieval.
 - **CoW vs temporal graph** -- Different models. AMFS versions individual entries; Graphiti maintains a graph with time-bounded edges. AMFS is simpler; Graphiti captures richer temporal relationships.
 - **Multi-agent** -- AMFS has conflict detection and per-agent provenance. Zep targets single-assistant use.
@@ -153,11 +163,11 @@ Memvid is the right choice for single-user, offline, or edge scenarios where inf
 
 ## What Makes AMFS Unique
 
-1. **Memory that learns from production** -- Confidence scoring evolves from incidents, deployments, and regressions. No other system connects memory to real-world outcomes.
+1. **GitHub for agent memory** -- No other system treats agent knowledge like code. AMFS gives every agent a brain (repo), with branching, pull requests, diff, merge, rollback, access control, and fork. The mental model is already in every developer's head. No competitor has any of this.
 
-2. **Memory as cognitive substrate** -- Tiered memory (Hot/Warm/Archive), frequency-modulated decay, multi-dimensional importance scoring, and progressive retrieval make AMFS a self-organizing memory system -- not just a retrieval layer. This is the "new wave" the industry is moving toward.
+2. **Memory that learns from production** -- Confidence scoring evolves from incidents, deployments, and regressions. No other system connects memory to real-world outcomes.
 
-3. **Four-signal decay** -- Time, memory type, outcome validation, and access frequency all modulate how fast entries fade. Frequently recalled, outcome-validated entries resist decay; cold, unvalidated beliefs decay quickly.
+3. **Self-organizing memory** -- Tiered memory (Hot/Warm/Archive), frequency-modulated decay, multi-dimensional importance scoring, and progressive retrieval. Not just a retrieval layer — a memory system that reorganizes itself based on what matters.
 
 4. **Copy-on-Write versioning** -- Every write is immutable. Replay history, compare versions, audit decisions. Most competitors overwrite.
 

--- a/docs/vs-vector-databases.md
+++ b/docs/vs-vector-databases.md
@@ -24,9 +24,9 @@ Vector databases and AMFS solve different problems. Understanding the distinctio
 
 **Vector databases** store embeddings and retrieve them by similarity. They answer: *"what is most relevant to this query?"*
 
-**AMFS** stores versioned, provenanced knowledge and evolves it based on outcomes. It answers: *"what does this agent know, who wrote it, how confident are we, and what happened when we acted on it?"*
+**AMFS** is version control for what agents know. It answers: *"what does this agent know, who wrote it, how confident are we, what happened when we acted on it, and how do we collaborate on changing it?"*
 
-A vector database is a **retrieval engine**. AMFS is a **memory system**.
+A vector database is a **search index**. AMFS is **GitHub for agent memory** — versioning, branching, pull requests, rollback, and a collaboration model developers already understand.
 
 ---
 
@@ -35,6 +35,7 @@ A vector database is a **retrieval engine**. AMFS is a **memory system**.
 | Dimension | Vector Database | AMFS |
 |:----------|:----------------|:-----|
 | **Primary operation** | Similarity search over embeddings | Read/write versioned knowledge with provenance |
+| **Collaboration model** | Shared index — last write wins | Git model — branch, diff, PR, merge, rollback, access control |
 | **Data model** | Vectors + metadata | Structured entries with entity/key scoping, confidence, memory type, provenance |
 | **Versioning** | Overwrite or append | Copy-on-Write — every write creates a new version, full history preserved |
 | **Who wrote it?** | Not tracked | Provenance: agent ID, session ID, timestamp, pattern refs |
@@ -71,6 +72,7 @@ Vector databases are **stateless retrieval indexes**. They don't track:
 - **What happened when you used it** — No outcome tracking. If an agent retrieves a vector and acts on it, and that action causes an incident, the vector database has no way to learn from that.
 - **How data changed over time** — Vectors are overwritten or appended. You can't ask "what did this entry say last week?"
 - **Why a decision was made** — No causal chain linking retrieved data to actions and outcomes.
+- **How to collaborate on changes** — No branching, no review process, no way for one agent to propose a change and another to approve it. It's like coding without Git.
 
 ---
 
@@ -174,8 +176,9 @@ No vector database provides this lifecycle. They are a retrieval layer. AMFS is 
 
 | | Vector Database | AMFS |
 |:--|:----------------|:-----|
-| **Think of it as** | A search index for embeddings | A version-controlled knowledge base for agents |
-| **Best for** | Finding relevant data | Remembering, learning, and explaining decisions |
+| **Think of it as** | A search index for embeddings | GitHub for agent memory |
+| **Best for** | Finding relevant data | Collaborating on knowledge the way developers collaborate on code |
+| **Collaboration** | None — shared index, last write wins | Branch, diff, PR, review, merge, rollback, access control |
 | **Data lifecycle** | Write once, query many | Write, version, track outcomes, decay, explain |
 | **Multi-agent** | Shared index | Shared memory with provenance, conflicts, and causal chains |
 | **Cross-system context** | Manual ingestion | Pro: auto-ingest from PagerDuty, Slack, GitHub, Jira |


### PR DESCRIPTION
## Summary

Repositions all key documentation around the core pitch: **AMFS is GitHub for agent memory.**

The problem isn't "agents need permissions" or "agents need smarter retrieval." The problem is that agents have no way to collaborate on knowledge the way developers collaborate on code. Right now, agent memory is chaos — last write wins, no branching, no review, no rollback. It's like coding without Git.

AMFS applies the Git mental model (branch, diff, PR, merge, rollback) to agent knowledge. The mental model is already in every developer's head.

### Changes by file

- **README.md** — New tagline ("GitHub for agent memory"), problem statement, side-by-side Git-model comparison diagram, highlights table reordered to lead with collaboration features, OSS-vs-Pro reframed as "single-branch repo vs full GitHub"
- **docs/index.md** — New homepage pitch, feature tables reorganized into three groups (Git-like Collaboration / Memory Intelligence / Platform), agent workflow updated with identity step
- **docs/vs-competitors.md** — Feature matrix now leads with 7 Git collaboration rows (branching, PRs, rollback, tags, access control, fork, timeline) where AMFS is the only "Yes." Per-competitor sections add Git model as first differentiator. "What Makes AMFS Unique" leads with point #1: "GitHub for agent memory"
- **docs/vs-vector-databases.md** — Adds "Collaboration model" row to comparison table, reframes "The Short Version" around version control, adds collaboration bullet to "What Vector Databases Don't Do", updates summary table
- **docs/editions.md** — Opening paragraph reframed: OSS = single-branch repo with full history, Pro = full GitHub model
- **docs/concepts/index.md** — Intro paragraph now frames all concepts around the Git mental model before diving into memory intelligence