### PR TITLE
feat: persist read events independently of commit_outcome

### DIFF
--- a/packages/core/src/amfs_core/models.py
+++ b/packages/core/src/amfs_core/models.py
@@ -456,13 +456,14 @@ class Digest(BaseModel):
 class EventType(str, Enum):
     """Types of events on the agent timeline (git commit log).
 
-    Core event types (OSS): WRITE, OUTCOME, WEBHOOK, BRIEF_COMPILED,
-    CROSS_AGENT_READ. Branching event types (Pro): BRANCH_CREATED,
-    BRANCH_MERGED, BRANCH_CLOSED, ACCESS_GRANTED, ACCESS_REVOKED,
-    ROLLBACK, TAG_CREATED, CHERRY_PICK, FORK.
+    Core event types (OSS): WRITE, READ, OUTCOME, WEBHOOK,
+    BRIEF_COMPILED, CROSS_AGENT_READ. Branching event types (Pro):
+    BRANCH_CREATED, BRANCH_MERGED, BRANCH_CLOSED, ACCESS_GRANTED,
+    ACCESS_REVOKED, ROLLBACK, TAG_CREATED, CHERRY_PICK, FORK.
     """
 
     WRITE = "write"
+    READ = "read"
     OUTCOME = "outcome"
     WEBHOOK = "webhook"
     BRIEF_COMPILED = "brief_compiled"

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -1001,6 +1001,7 @@ async def agent_memory_graph(
             "writtenAt": e.provenance.written_at.isoformat(),
         })
 
+    # Build read counts from both traces (causal_entries) and timeline events.
     read_entities: dict[str, dict[str, int]] = {}
     for t in traces:
         for ce in t.causal_entries:
@@ -1009,6 +1010,26 @@ async def agent_memory_graph(
             if ep not in read_entities:
                 read_entities[ep] = {}
             read_entities[ep][key] = read_entities[ep].get(key, 0) + 1
+
+    # Supplement with READ events from the timeline (persisted independently).
+    total_read_events = 0
+    try:
+        read_events = mem._adapter.list_events(
+            agent_id, mem.namespace, event_type="read", limit=10000,
+        )
+        cross_read_events = mem._adapter.list_events(
+            agent_id, mem.namespace, event_type="cross_agent_read", limit=10000,
+        )
+        for ev in read_events + cross_read_events:
+            ep = ev.details.get("entity_path", "")
+            key = ev.details.get("key", "")
+            if ep and key:
+                if ep not in read_entities:
+                    read_entities[ep] = {}
+                read_entities[ep][key] = read_entities[ep].get(key, 0) + 1
+        total_read_events = len(read_events) + len(cross_read_events)
+    except Exception:
+        pass
 
     entry_authors: dict[str, str] = {}
     for e in entries:
@@ -1040,6 +1061,7 @@ async def agent_memory_graph(
         "nodes": nodes,
         "traceCount": len(traces),
         "totalWritten": len(written_by_agent),
+        "totalReads": total_read_events,
         "crossAgentReads": cross_agent_reads,
     }
 

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -165,10 +165,13 @@ class AgentMemory:
                 )
                 if effective < min_confidence:
                     return None
+                self._log_read_event(entry, effective_branch)
                 return entry
             entry = self._engine.read(entity_path, key, min_confidence=min_confidence, branch=effective_branch)
             if entry is not None and not entry.shared and entry.provenance.agent_id != self.agent_id:
                 return None
+            if entry is not None:
+                self._log_read_event(entry, effective_branch)
             return entry
         except Exception as exc:
             self._read_tracker.record_error(
@@ -796,6 +799,25 @@ class AgentMemory:
     # Agent brain — scoped recall & cross-agent reads
     # ------------------------------------------------------------------
 
+    def _log_read_event(self, entry: MemoryEntry, branch: str | None = None) -> None:
+        """Log a READ event to the timeline (fire-and-forget)."""
+        try:
+            self._adapter.log_event(Event(
+                namespace=self.namespace,
+                agent_id=self.agent_id,
+                branch=branch or self._branch,
+                event_type=EventType.READ,
+                summary=f"Read {entry.entity_path}/{entry.key}",
+                details={
+                    "entity_path": entry.entity_path,
+                    "key": entry.key,
+                    "version": entry.version,
+                    "author_agent_id": entry.provenance.agent_id,
+                },
+            ))
+        except Exception:
+            logger.debug("Failed to log read event", exc_info=True)
+
     def recall(
         self,
         entity_path: str,
@@ -814,11 +836,17 @@ class AgentMemory:
         if entry is None:
             return None
         if entry.provenance.agent_id == self.agent_id:
-            return entry if entry.confidence >= min_confidence else None
+            if entry.confidence >= min_confidence:
+                self._log_read_event(entry)
+                return entry
+            return None
         versions = self._engine.history(entity_path, key)
         for v in reversed(versions):
             if v.provenance.agent_id == self.agent_id:
-                return v if v.confidence >= min_confidence else None
+                if v.confidence >= min_confidence:
+                    self._log_read_event(v)
+                    return v
+                return None
         return None
 
     def my_entries(


### PR DESCRIPTION
## Summary
- Reads were only tracked inside DecisionTraces (created by `commit_outcome`). Most sessions never call `commit_outcome`, so reads were silently lost.
- Adds `READ` EventType — `Memory.read()` and `recall()` now log a timeline event on every successful read
- `memory-graph` endpoint counts reads from both traces AND timeline events, returning a `totalReads` field
- Existing `CROSS_AGENT_READ` events (from `read_from()`) continue to work as before