### PR TITLE
fix: add read/snapshot event types to chk_event_type

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/schema.sql
+++ b/packages/adapters/postgres/src/amfs_postgres/schema.sql
@@ -224,10 +224,11 @@ CREATE TABLE IF NOT EXISTS amfs_events (
     actor_agent_id TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT chk_event_type CHECK (event_type IN (
-        'write', 'outcome', 'webhook', 'brief_compiled', 'cross_agent_read',
+        'write', 'read', 'outcome', 'webhook', 'brief_compiled', 'cross_agent_read',
         'branch_created', 'branch_merged', 'branch_closed',
         'access_granted', 'access_revoked',
-        'rollback', 'tag_created', 'cherry_pick', 'fork'
+        'rollback', 'tag_created', 'cherry_pick', 'fork',
+        'snapshot_taken', 'snapshot_recovered'
     ))
 );
 


### PR DESCRIPTION
## Summary
- Adds `read`, `snapshot_taken`, `snapshot_recovered` to the `chk_event_type` CHECK constraint on `amfs_events`
- The new `READ` event type (from PR #141 independent read tracking) was missing from the constraint, causing `CheckViolation` 500 errors when persisting read events
- Already applied to production DB directly; this aligns the schema file