### PR TITLE
fix: CortexWorker auto-reconnect and manual recompile endpoint

### DIFF
--- a/packages/cortex/src/amfs_cortex/worker.py
+++ b/packages/cortex/src/amfs_cortex/worker.py
@@ -84,12 +84,41 @@ class CortexWorker:
         }
 
     def run(self) -> None:
-        """Main event loop. Blocks until stop() is called."""
-        import psycopg
+        """Main event loop. Blocks until stop() is called.
 
+        Automatically reconnects on connection loss with exponential backoff.
+        """
         self._started_at = time.monotonic()
         logger.info("Cortex worker starting (debounce=%dms, advisory_lock=%s)",
                      self._debounce_ms, self._use_advisory_lock)
+
+        backoff = 1.0
+        max_backoff = 60.0
+
+        while not self._stop.is_set():
+            try:
+                self._run_once()
+                # Clean exit (stop() was called)
+                break
+            except Exception:
+                if self._stop.is_set():
+                    break
+                logger.exception(
+                    "Cortex worker connection lost — reconnecting in %.0fs", backoff
+                )
+                self._activity_log.append({
+                    "type": "connection_lost",
+                    "backoff_s": backoff,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                })
+                self._stop.wait(backoff)
+                backoff = min(backoff * 2, max_backoff)
+
+        logger.info("Cortex worker stopped")
+
+    def _run_once(self) -> None:
+        """Single connection lifecycle. Raises on connection loss."""
+        import psycopg
 
         conn = psycopg.connect(self._dsn, autocommit=True)
         try:
@@ -116,11 +145,8 @@ class CortexWorker:
                         break
                     self._handle_notify(notify)
 
-        except Exception:
-            logger.exception("Cortex worker error")
         finally:
             conn.close()
-            logger.info("Cortex worker stopped")
 
     def stop(self) -> None:
         """Signal the worker to stop."""

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -2950,6 +2950,17 @@ async def cortex_activity(
     return {"events": [], "total": 0, "throughput": [], "stats": None}
 
 
+@app.post("/api/v1/cortex/recompile")
+async def cortex_recompile(
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    """Trigger a full digest recompilation."""
+    if not _cortex_worker:
+        raise HTTPException(status_code=503, detail="Cortex worker not running")
+    count = _cortex_worker._compiler.recompile_all()
+    return {"recompiled": count}
+
+
 @app.post("/api/v1/webhooks/{connector_name}")
 async def ingest_webhook(
     connector_name: str,


### PR DESCRIPTION
## Summary
- CortexWorker now automatically reconnects with exponential backoff (1s → 60s) when the Postgres NOTIFY listener disconnects — this was the root cause of brain briefs not being compiled for new agents
- Adds `POST /api/v1/cortex/recompile` endpoint to manually trigger a full digest recompilation without restarting the service

## Context
In Cloud Run, the connection between the embedded Cortex worker and Cloud SQL can drop silently (idle timeout, instance scaling). Previously, the worker thread would die and never restart and brain briefs would stop being compiled permanently until the next deploy.