### PR TITLE
fix: proxy briefing through HttpAdapter so MCP server gets Cortex digests

### DIFF
--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -17,6 +17,7 @@ import httpx
 from amfs_core.abc import AdapterABC, WatchHandle
 from amfs_core.models import (
     DecisionTrace,
+    Digest,
     Event,
     EventType,
     GraphEdge,
@@ -267,3 +268,30 @@ class HttpAdapter(AdapterABC):
             "branch": branch,
         }
         self._post("/api/v1/graph/edges", body)
+
+    def list_digests(
+        self,
+        digest_type: Any = None,
+        namespace: str = "default",
+        branch: str = "main",
+    ) -> list[Digest]:
+        params: dict[str, Any] = {}
+        if digest_type is not None:
+            params["digest_type"] = digest_type.value if hasattr(digest_type, "value") else str(digest_type)
+        data = self._get("/api/v1/cortex/digests", **params)
+        return [Digest.model_validate(d) for d in data.get("digests", [])]
+
+    def briefing(
+        self,
+        entity_path: str | None = None,
+        agent_id: str | None = None,
+        limit: int = 10,
+    ) -> list[Digest]:
+        """Proxy briefing to the HTTP server which has full Cortex access."""
+        params: dict[str, Any] = {"limit": limit}
+        if entity_path:
+            params["entity_path"] = entity_path
+        if agent_id:
+            params["agent_id"] = agent_id
+        data = self._get("/api/v1/briefing", **params)
+        return [Digest.model_validate(d) for d in data.get("digests", [])]

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -903,6 +903,13 @@ def amfs_briefing(
         agent_id=agent_id,
         limit=limit,
     )
+    if not digests:
+        hint = (
+            "No compiled briefings yet. "
+            "Use amfs_search() or amfs_recall() to find existing memories, "
+            "or amfs_write() to start building knowledge."
+        )
+        return json.dumps({"status": "empty", "message": hint})
     return json.dumps(
         [d.model_dump(mode="json") for d in digests],
         default=str,

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -1044,6 +1044,16 @@ class AgentMemory:
         Returns:
             List of Digest objects ranked by relevance.
         """
+        # Prefer the adapter's native briefing when available (e.g. HttpAdapter
+        # proxies to the server which has full Cortex + Postgres access).
+        adapter_briefing = getattr(self._adapter, "briefing", None)
+        if callable(adapter_briefing):
+            return adapter_briefing(
+                entity_path=entity_path,
+                agent_id=agent_id or self.agent_id,
+                limit=limit,
+            )
+
         try:
             from amfs_cortex.briefing import BriefingService
         except ImportError:


### PR DESCRIPTION
## Summary

- **HttpAdapter** was missing `briefing()` and `list_digests()` methods, so when the MCP server ran in HTTP mode (`AMFS_HTTP_URL`), `Memory.briefing()` tried to import `amfs_cortex` locally — which isn't installed in the MCP environment — and silently returned `[]`. The briefings existed server-side (visible on the dashboard) but were never fetched.
- Added `briefing()` and `list_digests()` to `HttpAdapter`, proxying to the HTTP server's `/api/v1/briefing` and `/api/v1/cortex/digests` endpoints
- Updated `Memory.briefing()` to prefer the adapter's native `briefing()` when available, falling back to local `BriefingService`
- Return a structured `{"status": "empty", "message": "..."}` instead of bare `[]` when no briefings exist, so Cursor shows a helpful hint instead of confusing empty brackets