### PR TITLE
fix: make all MCP tools work end-to-end over HTTP adapter

### DIFF
--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -14,13 +14,14 @@ from typing import Any, Callable
 
 import httpx
 
-from amfs_core.abc import AdapterABC, WatchHandle
+from amfs_core.abc import AdapterABC, Agent, WatchHandle
 from amfs_core.models import (
     DecisionTrace,
     Digest,
     Event,
     EventType,
     GraphEdge,
+    GraphNeighborQuery,
     MemoryEntry,
     MemoryStats,
     OutcomeRecord,
@@ -121,6 +122,8 @@ class HttpAdapter(AdapterABC):
             params["entity_path"] = entity_path
         if branch and branch != "main":
             params["branch"] = branch
+        if include_superseded:
+            params["include_superseded"] = "true"
         data = self._get("/api/v1/entries", **params)
         return [_parse_entry(e) for e in data.get("entries", [])]
 
@@ -145,12 +148,13 @@ class HttpAdapter(AdapterABC):
 
     # ── optional overrides ────────────────────────────────────────────
 
-    def search(self, query: SearchQuery) -> list[MemoryEntry]:
+    def search(self, query: SearchQuery, **kwargs: Any) -> list[MemoryEntry]:
         body: dict[str, Any] = {
             "entity_path": query.entity_path,
             "min_confidence": query.min_confidence,
             "limit": query.limit,
             "sort_by": query.sort_by or "confidence",
+            "depth": query.depth,
         }
         if query.query:
             body["query"] = query.query
@@ -162,6 +166,9 @@ class HttpAdapter(AdapterABC):
             body["since"] = query.since.isoformat()
         if query.pattern_ref:
             body["pattern_ref"] = query.pattern_ref
+        branch = kwargs.get("branch")
+        if branch:
+            body["branch"] = branch
         data = self._post("/api/v1/search", body)
         if isinstance(data, list):
             return [_parse_entry(e) for e in data]
@@ -268,6 +275,29 @@ class HttpAdapter(AdapterABC):
             "branch": branch,
         }
         self._post("/api/v1/graph/edges", body)
+
+    def graph_neighbors(
+        self,
+        query: GraphNeighborQuery,
+        *,
+        namespace: str = "default",
+        branch: str = "main",
+    ) -> list[GraphEdge]:
+        data = self._get(
+            "/api/v1/pro/graph/neighbors",
+            entity=query.entity,
+            relation=query.relation,
+            direction=query.direction,
+            min_confidence=query.min_confidence,
+            depth=query.depth,
+            limit=query.limit,
+        )
+        return [GraphEdge.model_validate(e) for e in data.get("edges", [])]
+
+    def ensure_agent(self, agent_id: str, namespace: str = "default") -> Agent:
+        # Server-side ensure_agent runs automatically during writes.
+        # Return a stub so AgentMemory.__init__ doesn't hit the ABC no-op.
+        return Agent(agent_id=agent_id, namespace=namespace)
 
     def list_digests(
         self,

--- a/packages/http-server/src/amfs_http/models.py
+++ b/packages/http-server/src/amfs_http/models.py
@@ -38,6 +38,7 @@ class SearchRequest(BaseModel):
     limit: int = 100
     sort_by: str = "confidence"
     branch: str = "main"
+    depth: int = 3
 
 
 class ContextRequest(BaseModel):

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -401,10 +401,11 @@ async def write_entry(
 async def list_entries(
     entity_path: str | None = Query(None),
     branch: str = Query("main"),
+    include_superseded: bool = Query(False),
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
     mem = _get_memory()
-    entries = mem.list(entity_path, branch=branch)
+    entries = mem.list(entity_path, branch=branch, include_superseded=include_superseded)
     return {"entries": [_entry_to_response(e) for e in entries]}
 
 
@@ -430,6 +431,7 @@ async def search_entries(
         pattern_ref=req.pattern_ref,
         sort_by=req.sort_by,
         limit=req.limit,
+        depth=req.depth,
     )
     try:
         results = mem._adapter.search(sq, branch=branch)

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -445,7 +445,22 @@ def amfs_search(
             or query_lower in e.entity_path.lower()
         ]
 
-    return json.dumps([_serialize_entry(e) for e in results], default=str)
+    if not results:
+        return json.dumps({
+            "status": "empty",
+            "count": 0,
+            "message": "No entries matched your search filters.",
+            "filters": {
+                "query": query,
+                "entity_path": entity_path,
+                "agent_id": agent_id,
+                "min_confidence": min_confidence,
+            },
+        })
+    return json.dumps({
+        "count": len(results),
+        "entries": [_serialize_entry(e) for e in results],
+    }, default=str)
 
 
 def _adapter_supports_fts(mem) -> bool:
@@ -509,7 +524,18 @@ def amfs_retrieve(
         data["_breakdown"] = {k: round(v, 4) for k, v in scored.breakdown.items()}
         serialized.append(data)
 
-    return json.dumps(serialized, default=str)
+    if not serialized:
+        return json.dumps({
+            "status": "empty",
+            "count": 0,
+            "message": "No entries matched your query.",
+            "query": query,
+            "entity_path": entity_path,
+        })
+    return json.dumps({
+        "count": len(serialized),
+        "entries": serialized,
+    }, default=str)
 
 
 @mcp.tool
@@ -525,7 +551,20 @@ def amfs_list(entity_path: str | None = None) -> str:
     """
     mem = _get_memory()
     entries = mem.list(entity_path)
-    return json.dumps([_serialize_entry(e) for e in entries], default=str)
+    if not entries:
+        return json.dumps({
+            "status": "empty",
+            "count": 0,
+            "entity_path": entity_path,
+            "message": "No entries found." + (
+                " Try without an entity_path filter to see all entries."
+                if entity_path else ""
+            ),
+        })
+    return json.dumps({
+        "count": len(entries),
+        "entries": [_serialize_entry(e) for e in entries],
+    }, default=str)
 
 
 @mcp.tool
@@ -560,7 +599,17 @@ def amfs_graph_neighbors(
         depth=depth,
         limit=limit,
     )
-    return json.dumps([e.model_dump(mode="json") for e in edges], default=str)
+    if not edges:
+        return json.dumps({
+            "status": "empty",
+            "count": 0,
+            "entity": entity,
+            "message": "No graph edges found for this entity.",
+        })
+    return json.dumps({
+        "count": len(edges),
+        "edges": [e.model_dump(mode="json") for e in edges],
+    }, default=str)
 
 
 @mcp.tool

--- a/tests/unit/test_http_adapter.py
+++ b/tests/unit/test_http_adapter.py
@@ -1,0 +1,175 @@
+"""Unit tests for HttpAdapter — verifies correct HTTP calls are made.
+
+Uses httpx mock transport so no real server is needed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from amfs_core.models import (
+    GraphNeighborQuery,
+    SearchQuery,
+)
+
+
+def _make_adapter(responses: dict[str, Any] | None = None):
+    """Create an HttpAdapter with a mock transport that returns canned responses."""
+    from amfs_adapter_http.adapter import HttpAdapter
+
+    canned = responses or {}
+    call_log: list[dict[str, Any]] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        method = request.method
+        key = f"{method} {path}"
+
+        body = None
+        if request.content:
+            try:
+                body = json.loads(request.content)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                pass
+
+        call_log.append({
+            "method": method,
+            "path": path,
+            "params": dict(request.url.params),
+            "body": body,
+        })
+
+        resp_data = canned.get(key, canned.get(path, {}))
+        return httpx.Response(200, json=resp_data)
+
+    adapter = HttpAdapter.__new__(HttpAdapter)
+    adapter._base = "http://test"
+    adapter._api_key = "test-key"
+    adapter._client = httpx.Client(
+        base_url="http://test",
+        headers={"X-AMFS-API-Key": "test-key"},
+        transport=httpx.MockTransport(_handler),
+    )
+    return adapter, call_log
+
+
+class TestSearchForwardsDepth:
+    def test_depth_included_in_body(self) -> None:
+        adapter, calls = _make_adapter({
+            "POST /api/v1/search": {"entries": []},
+        })
+        sq = SearchQuery(entity_path="svc", depth=2, limit=10)
+        adapter.search(sq)
+
+        assert len(calls) == 1
+        assert calls[0]["body"]["depth"] == 2
+
+    def test_depth_defaults_to_3(self) -> None:
+        adapter, calls = _make_adapter({
+            "POST /api/v1/search": {"entries": []},
+        })
+        sq = SearchQuery(entity_path="svc")
+        adapter.search(sq)
+
+        assert calls[0]["body"]["depth"] == 3
+
+    def test_branch_forwarded_via_kwargs(self) -> None:
+        adapter, calls = _make_adapter({
+            "POST /api/v1/search": {"entries": []},
+        })
+        sq = SearchQuery(entity_path="svc")
+        adapter.search(sq, branch="feature-x")
+
+        assert calls[0]["body"]["branch"] == "feature-x"
+
+
+class TestGraphNeighbors:
+    def test_proxies_to_server(self) -> None:
+        adapter, calls = _make_adapter({
+            "/api/v1/pro/graph/neighbors": {
+                "entity": "checkout",
+                "edges": [
+                    {
+                        "source_entity": "checkout",
+                        "source_type": "service",
+                        "relation": "calls",
+                        "target_entity": "payment",
+                        "target_type": "service",
+                        "confidence": 0.9,
+                    }
+                ],
+                "count": 1,
+            },
+        })
+        query = GraphNeighborQuery(
+            entity="checkout",
+            relation="calls",
+            direction="outgoing",
+            depth=2,
+            limit=20,
+        )
+        edges = adapter.graph_neighbors(query)
+
+        assert len(edges) == 1
+        assert edges[0].target_entity == "payment"
+        assert calls[0]["params"]["entity"] == "checkout"
+        assert calls[0]["params"]["relation"] == "calls"
+        assert calls[0]["params"]["direction"] == "outgoing"
+        assert calls[0]["params"]["depth"] == "2"
+        assert calls[0]["params"]["limit"] == "20"
+
+
+class TestListForwardsSuperseded:
+    def test_include_superseded_sent(self) -> None:
+        adapter, calls = _make_adapter({
+            "/api/v1/entries": {"entries": []},
+        })
+        adapter.list("svc", include_superseded=True)
+
+        assert calls[0]["params"]["include_superseded"] == "true"
+
+    def test_superseded_not_sent_by_default(self) -> None:
+        adapter, calls = _make_adapter({
+            "/api/v1/entries": {"entries": []},
+        })
+        adapter.list("svc")
+
+        assert "include_superseded" not in calls[0]["params"]
+
+
+class TestBriefingProxy:
+    def test_proxies_to_server_endpoint(self) -> None:
+        adapter, calls = _make_adapter({
+            "/api/v1/briefing": {
+                "digests": [
+                    {
+                        "digest_type": "entity",
+                        "scope": "checkout-service",
+                        "summary": {"key_facts": ["uses Stripe"]},
+                        "entry_count": 5,
+                        "compiled_at": "2026-04-12T00:00:00Z",
+                    }
+                ],
+                "total": 1,
+            },
+        })
+        digests = adapter.briefing(entity_path="checkout-service", agent_id="test-agent")
+
+        assert len(digests) == 1
+        assert digests[0].scope == "checkout-service"
+        assert calls[0]["params"]["entity_path"] == "checkout-service"
+        assert calls[0]["params"]["agent_id"] == "test-agent"
+
+
+class TestEnsureAgent:
+    def test_returns_stub_without_http_call(self) -> None:
+        adapter, calls = _make_adapter()
+        agent = adapter.ensure_agent("my-agent", "default")
+
+        assert agent.agent_id == "my-agent"
+        assert len(calls) == 0

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -129,7 +129,8 @@ class TestMCPTools:
         from amfs_mcp.server import amfs_list
 
         result = json.loads(amfs_list())
-        assert result == []
+        assert result["status"] == "empty"
+        assert result["count"] == 0
 
     def test_amfs_list_filtered(self) -> None:
         from amfs_mcp.server import amfs_list, amfs_write
@@ -139,8 +140,8 @@ class TestMCPTools:
         amfs_write("svc-b", "k3", "v3")
 
         result = json.loads(amfs_list("svc-a"))
-        assert len(result) == 2
-        assert all(e["entity_path"] == "svc-a" for e in result)
+        assert result["count"] == 2
+        assert all(e["entity_path"] == "svc-a" for e in result["entries"])
 
     def test_amfs_list_all(self) -> None:
         from amfs_mcp.server import amfs_list, amfs_write
@@ -149,7 +150,7 @@ class TestMCPTools:
         amfs_write("svc-b", "k2", "v2")
 
         result = json.loads(amfs_list())
-        assert len(result) == 2
+        assert result["count"] == 2
 
     def test_amfs_search_all(self) -> None:
         from amfs_mcp.server import amfs_search, amfs_write
@@ -158,7 +159,7 @@ class TestMCPTools:
         amfs_write("svc-b", "k2", "v2")
 
         result = json.loads(amfs_search())
-        assert len(result) == 2
+        assert result["count"] == 2
 
     def test_amfs_search_by_entity(self) -> None:
         from amfs_mcp.server import amfs_search, amfs_write
@@ -167,8 +168,8 @@ class TestMCPTools:
         amfs_write("svc-b", "k2", "v2")
 
         result = json.loads(amfs_search(entity_path="svc-a"))
-        assert len(result) == 1
-        assert result[0]["entity_path"] == "svc-a"
+        assert result["count"] == 1
+        assert result["entries"][0]["entity_path"] == "svc-a"
 
     def test_amfs_search_by_min_confidence(self) -> None:
         from amfs_mcp.server import amfs_search, amfs_write
@@ -177,8 +178,8 @@ class TestMCPTools:
         amfs_write("svc", "low", "v2", confidence=0.2)
 
         result = json.loads(amfs_search(min_confidence=0.5))
-        assert len(result) == 1
-        assert result[0]["key"] == "high"
+        assert result["count"] == 1
+        assert result["entries"][0]["key"] == "high"
 
     def test_amfs_search_with_text_query(self) -> None:
         from amfs_mcp.server import amfs_search, amfs_write
@@ -187,8 +188,8 @@ class TestMCPTools:
         amfs_write("svc", "auth-flow", "JWT token validation")
 
         result = json.loads(amfs_search(query="retry"))
-        assert len(result) == 1
-        assert result[0]["key"] == "retry-logic"
+        assert result["count"] == 1
+        assert result["entries"][0]["key"] == "retry-logic"
 
     def test_amfs_search_text_query_in_value(self) -> None:
         from amfs_mcp.server import amfs_search, amfs_write
@@ -197,8 +198,8 @@ class TestMCPTools:
         amfs_write("svc", "k2", "something else entirely")
 
         result = json.loads(amfs_search(query="backoff"))
-        assert len(result) == 1
-        assert result[0]["key"] == "k1"
+        assert result["count"] == 1
+        assert result["entries"][0]["key"] == "k1"
 
     def test_amfs_stats_empty(self) -> None:
         from amfs_mcp.server import amfs_stats


### PR DESCRIPTION
## Summary

The HttpAdapter (used when MCP server connects to the AMFS HTTP API) was missing some methods, causing tools to silently return empty results even when data existed on the server.

### What was broken

| MCP Tool | Problem |
|----------|---------|
| `amfs_briefing` | Returned `[]` — cortex not installed locally, adapter had no proxy (**fixed in #144**) |
| `amfs_graph_neighbors` | Always returned `[]` — HttpAdapter had no `graph_neighbors()` |
| `amfs_search` / `amfs_retrieve` | Tier depth filtering lost — `depth` not forwarded through HTTP pipeline |
| `amfs_history` | Returned only current version — `include_superseded` not forwarded to HTTP server |
| `amfs_search`, `amfs_list`, etc. | Bare `[]` display in Cursor when empty — no structured message |

### Fixes

**HttpAdapter** (`packages/adapters/http`):
- Add `graph_neighbors()` — proxies to `GET /api/v1/pro/graph/neighbors`
- Add `ensure_agent()` — returns stub (server handles registration on write)
- Forward `depth` parameter in `search()` body
- Forward `include_superseded` in `list()` for history to work
- Add `briefing()` and `list_digests()` (**from #144**)

**HTTP Server** (`packages/http-server`):
- Add `include_superseded` query param to `GET /api/v1/entries`
- Add `depth` field to `SearchRequest` model and pass it to `SearchQuery`

**MCP Server** (`packages/mcp-server`):
- All list-returning tools (`amfs_search`, `amfs_list`, `amfs_retrieve`, `amfs_graph_neighbors`, `amfs_briefing`) now return `{"count": N, "entries": [...]}` when results exist, and `{"status": "empty", "count": 0, "message": "..."}` when empty

**SDK** (`packages/sdk-python`):
- `Memory.briefing()` checks for adapter's native `briefing()` before falling back to local cortex (**from #144**)