### PR TITLE
fix: prevent recompile_all from silently skipping agent briefs

### DIFF
--- a/packages/cortex/src/amfs_cortex/compiler.py
+++ b/packages/cortex/src/amfs_cortex/compiler.py
@@ -103,20 +103,37 @@ class DigestCompiler:
                 agent_ids.add(aid)
 
         count = 0
+        errors = 0
         for ep in entity_paths:
-            if self.compile(f"entity:{ep}", branch=b):
-                count += 1
-            if self.compile(f"connection:{ep}", branch=b):
-                count += 1
+            try:
+                if self.compile(f"entity:{ep}", branch=b):
+                    count += 1
+            except Exception:
+                errors += 1
+                logger.exception("Failed to compile entity digest for %s", ep)
+            try:
+                if self.compile(f"connection:{ep}", branch=b):
+                    count += 1
+            except Exception:
+                errors += 1
+                logger.exception("Failed to compile connection digest for %s", ep)
         for aid in agent_ids:
-            if self.compile(f"agent:{aid}", branch=b):
-                count += 1
+            try:
+                if self.compile(f"agent:{aid}", branch=b):
+                    count += 1
+            except Exception:
+                errors += 1
+                logger.exception("Failed to compile agent digest for %s", aid)
         for sid in source_ids:
-            if self.compile(f"source:{sid}", branch=b):
-                count += 1
+            try:
+                if self.compile(f"source:{sid}", branch=b):
+                    count += 1
+            except Exception:
+                errors += 1
+                logger.exception("Failed to compile source digest for %s", sid)
 
-        logger.info("Recompiled %d digests (%d entities, %d agents, %d sources) branch=%s",
-                     count, len(entity_paths), len(agent_ids), len(source_ids), b)
+        logger.info("Recompiled %d digests (%d entities, %d agents, %d sources, %d errors) branch=%s",
+                     count, len(entity_paths), len(agent_ids), len(source_ids), errors, b)
         return count
 
     def compute_scope_fingerprint(self, scope_key: str, *, branch: str | None = None) -> str | None:

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -2912,9 +2912,10 @@ async def cortex_status(
 @app.get("/api/v1/cortex/digests")
 async def list_cortex_digests(
     digest_type: str | None = Query(None),
+    scope: str | None = Query(None),
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
-    """List all compiled digests."""
+    """List compiled digests, optionally filtered by type and scope."""
     try:
         from amfs_postgres.adapter import PostgresAdapter
         from amfs_core.models import DigestType
@@ -2923,13 +2924,18 @@ async def list_cortex_digests(
         adapter = mem._adapter
         if isinstance(adapter, PostgresAdapter):
             dt = DigestType(digest_type) if digest_type else None
-            digests = adapter.list_digests(digest_type=dt)
+            namespace = getattr(adapter, "_namespace", "default")
+            digests = adapter.list_digests(digest_type=dt, namespace=namespace)
+            if scope:
+                digests = [d for d in digests if d.scope == scope]
             return {
                 "digests": [d.model_dump(mode="json") for d in digests],
                 "total": len(digests),
             }
-    except (ImportError, ValueError, Exception):
+    except (ImportError, ValueError):
         pass
+    except Exception:
+        logger.exception("Failed to list cortex digests")
 
     return {"digests": [], "total": 0}
 


### PR DESCRIPTION
## Summary

- **`recompile_all()` crashes on single failure, skipping all agent briefs.** The method compiles entity → connection → agent → source digests in sequence with no per-item error handling. Any exception (e.g. in `compile_connection_map`) would abort the loop before agent briefs were ever compiled. This is why triggering a manual recompile temporarily fixed it — the recompile succeeded that one time, but on the next cold start or reconnect it would crash again at the same point.
- **`list_cortex_digests` endpoint ignores adapter namespace.** Calls `list_digests()` without passing the adapter's configured namespace, relying on the hardcoded default `"default"`. Also silently swallows all exceptions with `except (ImportError, ValueError, Exception): pass`.
- **Adds `scope` query param to `/api/v1/cortex/digests`** for server-side filtering instead of forcing the dashboard to download all digests and filter client-side.