### PR TITLE
docs: rename npm package from @amfs/sdk to @senselab-ai/amfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ mem.commit_outcome("INC-1042", OutcomeType.CRITICAL_FAILURE)
 
 ```bash
 pip install amfs                    # Python SDK
-npm install @amfs/sdk               # TypeScript SDK
+npm install @senselab-ai/amfs        # TypeScript SDK
 pip install amfs-http-server        # REST API server
 pip install amfs-adapter-postgres   # Postgres backend
 pip install amfs-adapter-s3         # S3 backend

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -68,7 +68,7 @@ amfs/
 │   │   ├── filesystem/          # CoW via atomic rename
 │   │   └── postgres/            # psycopg3 + triggers
 │   ├── sdk-python/              # AgentMemory, config, factory
-│   ├── sdk-typescript/          # @amfs/sdk (TypeScript port)
+│   ├── sdk-typescript/          # @senselab-ai/amfs (TypeScript port)
 │   ├── integrations/
 │   │   ├── crewai/
 │   │   ├── langgraph/

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -246,7 +246,7 @@ The open-source layer ([github.com/raia-live/amfs](https://github.com/raia-live/
 | `amfs-http-server` | REST API server (FastAPI/Uvicorn) for remote access, branch-aware endpoints |
 | `amfs-mcp-server` | MCP server exposing 12 tools: `amfs_read`, `amfs_write`, `amfs_search`, `amfs_retrieve`, `amfs_list`, `amfs_stats`, `amfs_commit_outcome`, `amfs_record_context`, `amfs_history`, `amfs_explain`, `amfs_graph_neighbors`, `amfs_timeline` |
 | `amfs-cli` | Terminal tools for inspecting, diffing, snapshotting, and restoring memory |
-| `@amfs/sdk` | TypeScript SDK (full parity with Python: ReadTracker, search, stats, history, explain, recordContext) |
+| `@senselab-ai/amfs` | TypeScript SDK (full parity with Python: ReadTracker, search, stats, history, explain, recordContext) |
 
 ### Key Primitives
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -56,7 +56,7 @@ pip install amfs-mcp-server         # MCP server for AI coding agents
 ## TypeScript SDK
 
 ```bash
-npm install @amfs/sdk
+npm install @senselab-ai/amfs
 ```
 
 ---

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -9,7 +9,7 @@ description: "Using AMFS from TypeScript and Node.js applications."
 # TypeScript SDK
 {: .no_toc }
 
-The TypeScript SDK (`@amfs/sdk`) provides full parity with the Python SDK for Node.js and TypeScript applications — including ReadTracker, auto-causal linking, search, history, stats, and explainability.
+The TypeScript SDK (`@senselab-ai/amfs`) provides full parity with the Python SDK for Node.js and TypeScript applications — including ReadTracker, auto-causal linking, search, history, stats, and explainability.
 
 ## Table of Contents
 {: .no_toc .text-delta }
@@ -22,7 +22,7 @@ The TypeScript SDK (`@amfs/sdk`) provides full parity with the Python SDK for No
 ## Installation
 
 ```bash
-npm install @amfs/sdk
+npm install @senselab-ai/amfs
 ```
 
 ---
@@ -30,7 +30,7 @@ npm install @amfs/sdk
 ## Quick Start
 
 ```typescript
-import { AgentMemory, OutcomeType } from "@amfs/sdk";
+import { AgentMemory, OutcomeType } from "@senselab-ai/amfs";
 
 const mem = new AgentMemory("review-agent");
 
@@ -106,7 +106,7 @@ const recent = mem.history("checkout-service", "retry-pattern", {
 ## Search
 
 ```typescript
-import { SearchOptions } from "@amfs/sdk";
+import { SearchOptions } from "@senselab-ai/amfs";
 
 const results = mem.search({
   entityPath: "checkout-service",  // filter by entity
@@ -279,7 +279,7 @@ import {
   SearchOptions,
   MemoryStats,
   ArtifactRef,
-} from "@amfs/sdk";
+} from "@senselab-ai/amfs";
 ```
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -145,7 +145,7 @@ curl http://localhost:8080/api/v1/entries/checkout-service/retry-pattern
 | `amfs-http-server` | Python | `pip install amfs-http-server` |
 | `amfs-cli` | Python | `pip install amfs-cli` |
 | `amfs-mcp-server` | Python | `pip install amfs-mcp-server` |
-| `@amfs/sdk` | TypeScript | `npm install @amfs/sdk` |
+| `@senselab-ai/amfs` | TypeScript | `npm install @senselab-ai/amfs` |
 
 ---
 

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amfs/sdk",
+  "name": "@senselab-ai/amfs",
   "version": "0.1.0",
   "description": "AMFS TypeScript SDK — Agent Memory File System",
   "type": "module",

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @amfs/sdk — Agent Memory File System TypeScript SDK
+ * @senselab-ai/amfs — Agent Memory File System TypeScript SDK
  */
 
 export { AgentMemory, MemoryScope } from "./memory.js";

--- a/packages/sdk-typescript/tsconfig.json
+++ b/packages/sdk-typescript/tsconfig.json
@@ -13,5 +13,5 @@
     "resolveJsonModule": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/__tests__"]
 }


### PR DESCRIPTION
## Summary

- Renames all references to the TypeScript SDK from `@amfs/sdk` to `@senselab-ai/amfs` to match the published npm package.
- Updated: README, docs (installation, typescript guide, editions, contributing, index), `package.json`, and source comment.
- Excludes test files from the TypeScript build output (`tsconfig.json`).

The package is now live at https://www.npmjs.com/package/@senselab-ai/amfs