### PR TITLE
fix: auto-seal immutable traces with correct ID and account_id

### DIFF
--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -544,6 +544,8 @@ def _auto_seal_trace(mem: AgentMemory) -> str | None:
     if store is None:
         return None
     try:
+        from uuid import UUID as _UUID
+
         now = datetime.now(timezone.utc)
         causal = [
             TraceEntry(
@@ -572,7 +574,20 @@ def _auto_seal_trace(mem: AgentMemory) -> str | None:
         seq = _seal_sequence.get(session_id, 0)
         parent_hash = store.get_latest_hash(session_id)
 
+        trace_id = _UUID(oss_trace.id) if oss_trace.id else None
+
+        account_id = None
+        try:
+            from amfs_postgres.tenant_context import get_request_tenant_account_id
+            tid = get_request_tenant_account_id()
+            if tid:
+                account_id = _UUID(tid)
+        except (ImportError, ValueError):
+            pass
+
         imm = ImmutableDecisionTrace(
+            **({"id": trace_id} if trace_id else {}),
+            **({"account_id": account_id} if account_id else {}),
             agent_id=mem.agent_id,
             session_id=session_id,
             sequence_number=seq,
@@ -581,7 +596,7 @@ def _auto_seal_trace(mem: AgentMemory) -> str | None:
             decision_summary=getattr(oss_trace, "decision_summary", None),
             causal_entries=causal,
             external_contexts=contexts,
-            created_at=datetime.now(timezone.utc),
+            created_at=now,
         )
         sealed = seal(
             imm,


### PR DESCRIPTION
## Summary

Fixes two bugs in `_auto_seal_trace()` that caused verify/replay/diff to always return 404 "Immutable trace not found", even though traces were being created and sealed.

**Bug 1 — ID mismatch**: `ImmutableDecisionTrace` was constructed without passing `id=`, so `uuid4()` generated a new random UUID. The dashboard passes the OSS `DecisionTrace.id` to verify/replay/diff, but the immutable row in `amfs_immutable_traces` had a completely different auto-generated ID. Every lookup by OSS trace ID returned no row → 404.

**Bug 2 — Missing `account_id`**: No `account_id` was set on the immutable trace, so it was inserted with `NULL`. With RLS enabled (`account_id = current_setting('amfs.current_account_id')::uuid`), rows with `NULL` account_id are invisible to tenant-scoped queries, even if the ID matched.

**Fix**:
- Pass `id=UUID(oss_trace.id)` so the immutable trace shares the same ID as the OSS trace
- Read `account_id` from the request thread-local tenant context (`get_request_tenant_account_id()`) and pass it to the immutable trace