### PR TITLE
fix: implement get_event() in Postgres adapter for rollback

### DIFF
--- a/packages/adapters/postgres/pyproject.toml
+++ b/packages/adapters/postgres/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-adapter-postgres"
-version = "0.1.2"
+version = "0.1.3"
 description = "AMFS Postgres adapter with back-propagation triggers"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -1665,6 +1665,22 @@ class PostgresAdapter(AdapterABC):
 
         return [self._row_to_event(r) for r in rows]
 
+    def get_event(self, event_id: str, namespace: str = "default") -> Event | None:
+        sql = """
+            SELECT id, namespace, agent_id, branch, event_type,
+                   summary, details, actor_agent_id, created_at
+            FROM amfs_events
+            WHERE id = %s AND namespace = %s
+            LIMIT 1
+        """
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, (event_id, namespace))
+                row = cur.fetchone()
+        if row is None:
+            return None
+        return self._row_to_event(row)
+
     @staticmethod
     def _row_to_event(row: dict[str, Any]) -> Event:
         details = row.get("details") or {}

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -1726,6 +1726,11 @@ async def rollback(
 
     if target_event_id:
         event = mem._adapter.get_event(target_event_id, mem.namespace)
+        if event is None and agent_id:
+            for e in mem._adapter.list_events(agent_id, mem.namespace, limit=10000):
+                if e.id == target_event_id:
+                    event = e
+                    break
         if event is None:
             raise HTTPException(status_code=404, detail="Event not found")
         timestamp = event.created_at


### PR DESCRIPTION
## Summary
- Implements `get_event()` in the Postgres adapter — was missing, causing rollback to always fail with "Event not found"
- Adds a `list_events` scan fallback in the OSS `/api/v1/rollback` endpoint for adapters that don't implement `get_event()`
- Bumps `amfs-adapter-postgres` to 0.1.3

## Root cause
The `AdapterABC.get_event()` default returns `None`. The Postgres adapter never overrode it. The rollback endpoint called `get_event()`, got `None`, and returned 404.