### PR TITLE
fix: apply text search filtering before limit truncation

### DIFF
--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-core"
-version = "0.3.1"
+version = "0.3.2"
 description = "AMFS core models, engine, and adapter ABC"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/core/src/amfs_core/abc.py
+++ b/packages/core/src/amfs_core/abc.py
@@ -174,9 +174,21 @@ class AdapterABC(ABC):
     def search(self, query: SearchQuery) -> list[MemoryEntry]:
         """Search entries with rich filters. Default: filter over list().
 
-        Adapters may override with optimised implementations (e.g. SQL WHERE).
+        When ``query.query`` is set **and** ``recall_config`` is *not* set,
+        performs case-insensitive substring matching against key, value
+        (stringified), and entity_path **before** applying sort and limit —
+        so text filtering is never silently truncated.
+
+        When ``recall_config`` is set the query text is intended for semantic
+        scoring in the SDK layer, so the adapter skips substring filtering
+        to avoid pre-emptively discarding valid candidates.
+
+        Adapters may override with optimised implementations (e.g. SQL WHERE
+        with tsvector FTS).
         """
         entries = self.list(query.entity_path)
+        use_text_filter = query.query and query.recall_config is None
+        query_lower = query.query.lower() if use_text_filter else None
         results: list[MemoryEntry] = []
         for entry in entries:
             if entry.confidence < query.min_confidence:
@@ -188,6 +200,12 @@ class AdapterABC(ABC):
             if query.since is not None and entry.provenance.written_at < query.since:
                 continue
             if query.pattern_ref is not None and query.pattern_ref not in entry.provenance.pattern_refs:
+                continue
+            if query_lower is not None and not (
+                query_lower in entry.key.lower()
+                or query_lower in str(entry.value).lower()
+                or query_lower in entry.entity_path.lower()
+            ):
                 continue
             results.append(entry)
 

--- a/packages/http-server/pyproject.toml
+++ b/packages/http-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-http-server"
-version = "0.3.1"
+version = "0.3.2"
 description = "AMFS HTTP/REST API server with SSE support"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -438,16 +438,6 @@ async def search_entries(
     except TypeError:
         results = mem._adapter.search(sq)
 
-    if req.query and not getattr(mem._adapter, "_has_search_tsv", False):
-        query_lower = req.query.lower()
-        results = [
-            e
-            for e in results
-            if query_lower in e.key.lower()
-            or query_lower in str(e.value).lower()
-            or query_lower in e.entity_path.lower()
-        ]
-
     return [_entry_to_response(e) for e in results]
 
 

--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-mcp-server"
-version = "0.4.1"
+version = "0.4.2"
 description = "AMFS MCP Server — expose Agent Memory as MCP tools for Cursor and Claude Code"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -449,16 +449,6 @@ def amfs_search(
         depth=depth,
     )
 
-    if query and not _adapter_supports_fts(mem):
-        query_lower = query.lower()
-        results = [
-            e
-            for e in results
-            if query_lower in e.key.lower()
-            or query_lower in str(e.value).lower()
-            or query_lower in e.entity_path.lower()
-        ]
-
     if not results:
         return json.dumps({
             "status": "empty",
@@ -475,12 +465,6 @@ def amfs_search(
         "count": len(results),
         "entries": [_serialize_entry(e) for e in results],
     }, default=str)
-
-
-def _adapter_supports_fts(mem) -> bool:
-    """Check if the adapter handles full-text search natively."""
-    adapter = getattr(mem, "_adapter", None) or getattr(mem, "adapter", None)
-    return getattr(adapter, "_has_search_tsv", False)
 
 
 @mcp.tool


### PR DESCRIPTION
## Summary

- **Fix critical search bug**: `AdapterABC.search()` completely ignored `SearchQuery.query` — text filtering never happened at the adapter level. The MCP/HTTP servers applied substring matching *after* the adapter had already truncated results to `limit` (20 for MCP, 100 for HTTP), so most text queries returned empty results.
- **Move substring filtering into the adapter**: Case-insensitive matching on key, value, and entity_path now runs inside the filter loop *before* sort and limit. When `recall_config` is set, substring filtering is skipped since the query text is for semantic/embedding scoring.
- **Remove redundant post-hoc filters**: Cleaned up the now-unnecessary substring filters from `amfs_search` (MCP) and `POST /api/v1/search` (HTTP), along with the unused `_adapter_supports_fts` helper.

### Versions bumped
- `amfs-core`: 0.3.1 → 0.3.2
- `amfs-mcp-server`: 0.4.1 → 0.4.2
- `amfs-http-server`: 0.3.1 → 0.3.2

## Test plan
- [x] All 269 unit tests pass (`pytest tests/unit/`)
- [x] Search pipeline tests pass including semantic scoring with `recall_config`
- [x] Filesystem adapter integration tests pass
- [ ] Verify `amfs_search(query="logout")` returns results via MCP
- [ ] Verify `POST /api/v1/search {"query": "..."}` returns results via HTTP
- [ ] Verify Postgres adapter with FTS still works correctly (no behavior change — FTS path untouched)