### PR TITLE
fix: add text query support to TypeScript SDK search

### DIFF
--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senselab-ai/amfs",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "AMFS TypeScript SDK — Agent Memory File System",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk-typescript/src/memory.ts
+++ b/packages/sdk-typescript/src/memory.ts
@@ -18,6 +18,7 @@ export interface AgentMemoryOptions {
 }
 
 export interface SearchOptions {
+  query?: string;
   entityPath?: string;
   entityPaths?: string[];
   minConfidence?: number;
@@ -150,8 +151,19 @@ export class AgentMemory {
         );
       }
 
+      const queryLower =
+        options?.query && !options?.recallConfig
+          ? options.query.toLowerCase()
+          : undefined;
+
       for (const entry of entries) {
         if (!entry.shared && entry.provenance.agentId !== this.agentId) continue;
+        if (
+          queryLower &&
+          !entry.key.toLowerCase().includes(queryLower) &&
+          !String(entry.value).toLowerCase().includes(queryLower) &&
+          !entry.entityPath.toLowerCase().includes(queryLower)
+        ) continue;
         const ek = `${entry.entityPath}/${entry.key}`;
         if (!seenKeys.has(ek)) {
           seenKeys.add(ek);


### PR DESCRIPTION
## Summary

- **Add `query` field to `SearchOptions`**: TS SDK users couldn't pass a text query — the field didn't exist in the interface.
- **Implement text matching in `search()`**: Case-insensitive substring matching against key, value (stringified), and entityPath, applied before sort and limit. Skipped when `recallConfig` is set (query text is for semantic scoring).
- Mirrors the Python adapter fix from #161 (`amfs-core` 0.3.2).

### Version
- `@senselab-ai/amfs`: 0.2.0 → 0.2.1

## Test plan
- [x] All 37 existing TS SDK tests pass
- [ ] Verify `mem.search({ query: "some term" })` returns matching entries
- [ ] Verify `query` is ignored when `recallConfig` is provided