### PR TITLE
fix: add ILIKE fallback to PostgreSQL adapter search

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -656,6 +656,12 @@ class PostgresAdapter(AdapterABC):
         if use_fts:
             conditions.append("search_tsv @@ plainto_tsquery('english', %s)")
             params.append(query.query)
+        elif query.query and query.recall_config is None:
+            conditions.append(
+                "(key ILIKE %s OR entity_path ILIKE %s OR value::text ILIKE %s)"
+            )
+            like_pattern = f"%{query.query}%"
+            params.extend([like_pattern, like_pattern, like_pattern])
 
         order_map = {
             "confidence": "confidence DESC",


### PR DESCRIPTION
## Summary
- The PostgreSQL adapter's `search()` completely ignores `query.query` when `search_tsv` column doesn't exist (no FTS). This means all search queries return unfiltered results — the root cause of search not working in production.
- Adds case-insensitive `ILIKE` matching on `key`, `entity_path`, and `value::text` as a fallback when FTS is unavailable and `recall_config` is not set.

## Test plan
- [x] All existing tests pass (183 passed, 1 pre-existing unrelated failure)
- [x] Search pipeline tests pass