### PR TITLE
feat: embed agent instructions in MCP server — no more manual rules file

### DIFF
--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -136,12 +136,7 @@ Add to your project's `.cursor/mcp.json`:
 }
 ```
 
-Then copy the agent rules to teach Cursor when to use memory:
-
-```bash
-cp /path/to/amfs/.cursor/rules/amfs-memory.mdc \
-   /path/to/your/project/.cursor/rules/
-```
+The MCP server automatically sends agent instructions to Cursor when it connects — no separate rules file needed.
 
 ### Claude Code
 
@@ -163,11 +158,7 @@ Add to `~/.claude/claude_desktop_config.json`:
 }
 ```
 
-Copy the agent instructions to your project:
-
-```bash
-cp /path/to/amfs/CLAUDE.md /path/to/your/project/
-```
+The MCP server automatically sends agent instructions to Claude Code when it connects. For additional customization, you can optionally copy `CLAUDE.md` to your project root.
 
 ---
 
@@ -313,7 +304,7 @@ Use **kebab-case role/domain names** that persist across conversations about the
 
 If continuing work a previous agent started, **use the same name** to build on their knowledge.
 
-The agent rules (`amfs-memory.mdc` / `CLAUDE.md`) already instruct agents to do this automatically.
+The MCP server's built-in instructions already instruct agents to do this automatically.
 
 ### Default Identity (Auto-Detection)
 
@@ -377,7 +368,7 @@ Machine B (Claude Code / Alice):
 Run `uv sync` in the AMFS directory and verify the path in your MCP config.
 
 **Agent doesn't use memory tools**
-Ensure the rules file (`.cursor/rules/amfs-memory.mdc` or `CLAUDE.md`) is in your project.
+The MCP server embeds agent instructions automatically. If agents still don't use memory tools, verify the MCP server is connected (check for "amfs" in your IDE's MCP panel). For extra reinforcement, you can add `.cursor/rules/amfs-memory.mdc` or `CLAUDE.md` to your project.
 
 **Memory not persisting**
 Check that `.amfs/` exists. For Postgres, verify the DSN and network connectivity.

--- a/examples/mcp_setup.md
+++ b/examples/mcp_setup.md
@@ -56,11 +56,7 @@ Add to your project's `.cursor/mcp.json` (create the file if it doesn't exist):
 
 Replace `/absolute/path/to/amfs` with the actual path to your AMFS clone.
 
-Copy the agent rules file to teach Cursor when to use memory:
-
-```bash
-cp /path/to/amfs/.cursor/rules/amfs-memory.mdc /path/to/your/project/.cursor/rules/
-```
+The MCP server automatically sends agent instructions to Cursor when it connects — no separate rules file needed.
 
 ### Claude Code
 
@@ -229,7 +225,7 @@ Machine B (Claude Code/Alice):
 Make sure you've run `uv sync` in the AMFS directory and the path in your MCP config is correct.
 
 **Agent doesn't use memory tools**
-Ensure the agent rules file (`.cursor/rules/amfs-memory.mdc` or `CLAUDE.md`) is in your project.
+The MCP server embeds agent instructions automatically. Verify the server is connected in your IDE's MCP panel. For extra reinforcement, add `.cursor/rules/amfs-memory.mdc` or `CLAUDE.md` to your project.
 
 **Memory not persisting between sessions**
 Check that your `.amfs/` directory exists and isn't being cleared. For team sharing, verify Postgres connectivity.

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -44,7 +44,48 @@ from amfs_mcp.agent_id import detect_agent_id, detect_platform
 
 logger = logging.getLogger(__name__)
 
-mcp = FastMCP(name="amfs")
+_INSTRUCTIONS = """\
+You have access to AMFS (Agent Memory File System) — persistent memory that survives across sessions, agents, and machines. Use it to build institutional knowledge over time.
+
+## MANDATORY FIRST STEP: Set Your Identity
+
+You MUST call `amfs_set_identity` before doing anything else. Without it, all your work is attributed to a generic default.
+
+```
+amfs_set_identity("<role-name>", "<one-line description of current task>")
+```
+
+Use kebab-case role/domain names that persist across conversations (e.g. "dashboard-agent", "api-agent"). If continuing work a previous agent started, use the same name.
+
+## Workflow
+
+1. **Get briefed**: `amfs_briefing(entity_path="<repo>/<module>")` for compiled knowledge, then `amfs_recall` / `amfs_search` for specifics.
+2. **Read & explore**: `amfs_read` for known keys, `amfs_search(query="...")` for text search, `amfs_retrieve` for semantic retrieval, `amfs_graph_neighbors` for related entities.
+3. **Record decisions as they happen**: `amfs_record_context("user-decision", "User chose X over Y", source="chat")`.
+4. **Write knowledge**: `amfs_write("<repo>/<module>", "task-summary-<desc>", "<what and why>")`. Use `memory_type="belief"` for hypotheses, `"experience"` for actions taken.
+5. **Commit outcomes**: `amfs_commit_outcome("<ref>", "success")` after completing significant work. This snapshots the full decision trace.
+
+## Entity Naming
+
+Use `{repo}/{service-or-module}` paths (e.g. `myapp/auth`, `amfs/core-engine`).
+
+## Key Patterns
+
+- **Patterns**: `amfs_write(..., "pattern-<name>", "...", pattern_refs=["related-key"])`
+- **Risks**: `amfs_write(..., "risk-<name>", "...", confidence=0.8, memory_type="belief")`
+- **Cross-agent reads**: `amfs_read_from("<agent_id>", ...)` for tracked knowledge transfer.
+- **Browse past traces**: `amfs_list_traces(entity_path="...", limit=5)` before making similar decisions.
+
+## Confidence Scale
+
+- 1.0 = verified fact | 0.7-0.9 = high confidence | 0.4-0.6 = hypothesis | < 0.4 = speculative
+
+## Quality Feedback
+
+`amfs_write` responses include a `quality` score. If below 0.8, review `issues` and rewrite with more detail.
+"""
+
+mcp = FastMCP(name="amfs", instructions=_INSTRUCTIONS)
 
 # ---------------------------------------------------------------------------
 # Quality evaluation


### PR DESCRIPTION
## Summary
- The MCP server now passes agent behavioral instructions to clients via FastMCP's `instructions` parameter. Cursor and Claude Code receive the workflow, identity setup, entity naming, and key patterns automatically when the server connects.
- Users no longer need to manually download `amfs-memory.mdc` or copy `CLAUDE.md` — it's all built into the MCP server.
- Updated `docs/guides/mcp.md` and `examples/mcp_setup.md` to remove the manual copy steps.

## Test plan
- [x] All MCP server tests pass (46 passed)
- [ ] Verify instructions appear in Cursor's MCP tool panel after restart