### PR TITLE
feat: add Strands Agents integration with Plugin and standalone tool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           uv venv .venv
           source .venv/bin/activate
           uv pip install hatchling
-          for pkg in packages/core packages/adapters/filesystem packages/adapters/postgres packages/adapters/s3 packages/http-server packages/sdk-python packages/cli packages/mcp-server; do
+          for pkg in packages/core packages/adapters/filesystem packages/adapters/postgres packages/adapters/s3 packages/http-server packages/sdk-python packages/cli packages/mcp-server packages/integrations/strands; do
             echo "Building $pkg..."
             cd $pkg && python -m hatchling build && cd -
           done
@@ -34,7 +34,7 @@ jobs:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
           source .venv/bin/activate
-          for pkg in packages/core packages/adapters/filesystem packages/adapters/postgres packages/adapters/s3 packages/http-server packages/sdk-python packages/cli packages/mcp-server; do
+          for pkg in packages/core packages/adapters/filesystem packages/adapters/postgres packages/adapters/s3 packages/http-server packages/sdk-python packages/cli packages/mcp-server packages/integrations/strands; do
             uv publish --check-url https://pypi.org/simple/ $pkg/dist/*
           done
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ pip install amfs-http-server        # REST API server
 pip install amfs-adapter-postgres   # Postgres backend
 pip install amfs-adapter-s3         # S3 backend
 pip install amfs-cli                # CLI tools
+pip install amfs-strands            # Strands Agents plugin
 ```
 
 Or run with Docker:
@@ -88,7 +89,7 @@ docker run -p 8080:8080 -v amfs-data:/data ghcr.io/raia-live/amfs
 | **Hybrid Search** | Full-text + semantic + recency + confidence in a single ranked result set. |
 | **MCP Server** | First-class support for Cursor, Claude Code, and any MCP client. [Setup →](https://raia-live.github.io/amfs/guides/mcp/) · [Cursor plugin](https://github.com/raia-live/cursor-plugin) |
 | **Connectors** | Ingest events from PagerDuty, GitHub, Slack, Jira — or [build your own](https://raia-live.github.io/amfs/guides/connectors/). |
-| **Python & TypeScript** | Same API in both languages. Plus [CrewAI](https://raia-live.github.io/amfs/guides/crewai/), LangGraph, LangChain, AutoGen. |
+| **Python & TypeScript** | Same API in both languages. Plus [Strands Agents](https://raia-live.github.io/amfs/guides/strands/), [CrewAI](https://raia-live.github.io/amfs/guides/crewai/), LangGraph, LangChain, AutoGen. |
 
 ## Architecture
 
@@ -122,6 +123,8 @@ AMFS is open source under [Apache 2.0](LICENSE). The OSS edition gives you the f
 **[AMFS Pro](https://raia-live.github.io/amfs/editions/)** unlocks the full Git model: branching, merge, pull requests, access control, tags, rollback, cherry-pick, and fork. Plus multi-tenant SaaS isolation, immutable decision traces, automated pattern detection, an intelligence layer, and a web dashboard.
 
 Think of it this way: OSS gives you a single-branch repo with full history. Pro gives you GitHub.
+
+**Stripe, hosted billing, and the proprietary control-plane service** are implemented in the private SenseLab **`amfs-internal`** repository, not in this open-source tree.
 
 **[Full comparison →](https://raia-live.github.io/amfs/editions/)**
 

--- a/docs/guides/strands.md
+++ b/docs/guides/strands.md
@@ -1,0 +1,257 @@
+---
+title: Strands Agents Integration
+layout: default
+parent: Guides
+nav_order: 9
+description: "Use AMFS as a persistent memory plugin for Strands Agents — get versioning, provenance, causal tracing, and outcome tracking on top of Strands' agent orchestration."
+---
+
+# Strands Agents Integration
+{: .no_toc }
+
+AMFS integrates with Strands Agents as a **Plugin**, giving your agents persistent, versioned memory with automatic causal tracing — deeper than tool-only integrations.
+{: .fs-6 .fw-300 }
+
+## Table of Contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Overview
+
+[Strands Agents](https://strandsagents.com) is an open-source SDK for building AI agents with any model. AMFS integrates as a Strands **Plugin** — not just tools — which means your agents get persistent memory **and** automatic tracking of every tool call in the decision trace.
+
+```
+┌────────────────────────────────────────┐
+│           Strands Agent                │
+│                                        │
+│  ┌──────────────────────────────────┐  │
+│  │        AMFSPlugin                │  │
+│  │                                  │  │
+│  │  Tools:     @tool methods        │  │
+│  │  amfs_read, amfs_write,          │  │
+│  │  amfs_search, amfs_recall,       │  │
+│  │  amfs_list, amfs_record_context  │  │
+│  │                                  │  │
+│  │  Hooks:     @hook methods        │  │
+│  │  AfterToolCallEvent → auto-trace │  │
+│  └──────────┬───────────────────────┘  │
+└─────────────┼──────────────────────────┘
+              │
+              ▼
+     ┌────────────────┐
+     │  AgentMemory   │  CoW · Provenance · Outcomes
+     │  (AMFS)        │
+     └────────┬───────┘
+              │
+        Filesystem / Postgres / S3 / HTTP (SaaS)
+```
+
+---
+
+## Installation
+
+```bash
+pip install amfs-strands strands-agents
+```
+
+---
+
+## Plugin Setup (Recommended)
+
+The `AMFSPlugin` is the recommended way to use AMFS with Strands. It registers memory tools **and** hooks that automatically track every tool call in the AMFS causal chain.
+
+```python
+from strands import Agent
+from amfs import AgentMemory
+from amfs_strands import AMFSPlugin
+
+mem = AgentMemory(agent_id="research-agent")
+agent = Agent(
+    system_prompt="You are a research assistant with persistent memory.",
+    plugins=[AMFSPlugin(mem)],
+)
+
+agent("Research the latest AI papers and remember key findings")
+```
+
+The plugin registers six tools for your agent:
+
+| Tool | Description |
+|------|-------------|
+| `amfs_read` | Read a memory entry by entity path and key |
+| `amfs_write` | Write a value with confidence and memory type |
+| `amfs_search` | Search across entries with text query and filters |
+| `amfs_recall` | Agent-scoped read — only this agent's own entries |
+| `amfs_list` | List all entries under an entity path |
+| `amfs_record_context` | Record external context in the causal chain |
+
+---
+
+## Tools-Only Setup
+
+If you prefer a single tool (like mem0's `mem0_memory`), use the standalone `amfs_memory` tool:
+
+```python
+from strands import Agent
+from amfs_strands import amfs_memory
+
+agent = Agent(tools=[amfs_memory])
+agent("Remember that I prefer Python over TypeScript")
+```
+
+The tool supports four actions: `store`, `retrieve`, `search`, and `list`.
+
+Set `AMFS_AGENT_ID` to control the agent identity (defaults to `strands-agent`).
+
+---
+
+## What You Get
+
+### Versioning
+
+Every write creates a new CoW version. You can inspect how agent knowledge evolved:
+
+```python
+versions = mem.history("myapp", "retry-pattern")
+for v in versions:
+    print(f"v{v.version}  confidence={v.confidence}  at={v.provenance.written_at}")
+```
+
+### Provenance
+
+AMFS tracks which agent wrote each entry, in which session, and when:
+
+```python
+entry = mem.read("myapp", "research-findings")
+print(entry.provenance.agent_id)   # "research-agent"
+print(entry.provenance.session_id) # auto-generated
+```
+
+### Automatic Causal Tracing
+
+The plugin's `AfterToolCallEvent` hook records every non-AMFS tool call into the causal chain. When you call `explain()`, you see the complete picture — not just which memories were read, but which tools the agent used.
+
+### Outcome Back-Propagation
+
+Record whether outcomes were successful. AMFS adjusts confidence on all entries that were read during the decision process:
+
+```python
+from amfs import OutcomeType
+
+mem.commit_outcome("task-001", OutcomeType.SUCCESS)
+```
+
+### Decision Traces
+
+Use `explain()` to see the full causal chain:
+
+```python
+chain = mem.explain()
+# Shows: memories read, external contexts, tool calls traced via hooks
+```
+
+---
+
+## Connecting to AMFS SaaS
+
+When using AMFS as a hosted service, connect through the HTTP API:
+
+### Environment Variables
+
+```bash
+export AMFS_HTTP_URL="https://amfs-login.sense-lab.ai"
+export AMFS_API_KEY="amfs_sk_your_key_here"
+```
+
+`AgentMemory` auto-detects the HTTP adapter when `AMFS_HTTP_URL` is set.
+
+### Explicit HttpAdapter
+
+```python
+from amfs import AgentMemory
+from amfs_adapter_http import HttpAdapter
+from amfs_strands import AMFSPlugin
+
+adapter = HttpAdapter(
+    base_url="https://amfs-login.sense-lab.ai",
+    api_key="amfs_sk_your_key_here",
+)
+
+mem = AgentMemory(agent_id="my-agent", adapter=adapter)
+agent = Agent(plugins=[AMFSPlugin(mem)])
+```
+
+{: .warning }
+Never use `AMFS_POSTGRES_DSN` for external agents in multi-tenant mode. Always use `AMFS_HTTP_URL` + `AMFS_API_KEY`.
+
+---
+
+## Example: Memory Agent (Replacing mem0)
+
+This example mirrors the [Strands mem0 memory agent](https://strandsagents.com/docs/examples/python/memory_agent/) but uses AMFS:
+
+```python
+from strands import Agent
+from amfs import AgentMemory
+from amfs_strands import AMFSPlugin
+
+mem = AgentMemory(agent_id="memory-agent")
+plugin = AMFSPlugin(mem)
+
+agent = Agent(
+    system_prompt="""You are a personal assistant with persistent memory.
+
+    Use amfs_write to store information the user shares.
+    Use amfs_search to find relevant memories when answering questions.
+    Use amfs_recall to check what you already know.
+    Use amfs_list to show all stored memories.""",
+    plugins=[plugin],
+)
+
+# Interactive loop
+while True:
+    user_input = input("\n> ")
+    if user_input.lower() == "exit":
+        break
+    agent(user_input)
+
+mem.close()
+```
+
+---
+
+## Multi-Agent Setup
+
+When running multiple Strands agents that share knowledge, use separate `agent_id` values:
+
+```python
+researcher_mem = AgentMemory(agent_id="researcher")
+writer_mem = AgentMemory(agent_id="writer")
+
+researcher = Agent(plugins=[AMFSPlugin(researcher_mem)])
+writer = Agent(plugins=[AMFSPlugin(writer_mem)])
+
+# Researcher writes findings
+researcher("Research AI agent memory systems and save key findings")
+
+# Writer reads researcher's entries via shared AMFS storage
+writer("Read the research findings and write a summary report")
+```
+
+Both agents read from and write to the same storage. AMFS handles provenance automatically — you always know which agent produced which insight. Use `read_from()` for explicit cross-agent knowledge transfer.
+
+---
+
+## Disabling Auto-Tracing
+
+If you don't want the plugin to automatically record tool calls:
+
+```python
+plugin = AMFSPlugin(mem, auto_trace=False)
+```
+
+Tools still work; only the `AfterToolCallEvent` hook is disabled.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -37,6 +37,27 @@ See the [SaaS Connection Guide](/amfs/guides/saas/) for detailed setup instructi
 
 ---
 
+## Strands Agents
+
+Add persistent memory to Strands agents as a plugin:
+
+```bash
+pip install amfs-strands
+```
+
+```python
+from strands import Agent
+from amfs import AgentMemory
+from amfs_strands import AMFSPlugin
+
+mem = AgentMemory(agent_id="strands-agent")
+agent = Agent(plugins=[AMFSPlugin(mem)])
+```
+
+The plugin gives your Strands agents read, write, search, and recall tools — plus automatic causal tracing via hooks. See the [full guide](/amfs/guides/strands/) for details.
+
+---
+
 ## CrewAI
 
 Add AMFS tools to your CrewAI agents:

--- a/packages/integrations/strands/pyproject.toml
+++ b/packages/integrations/strands/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "amfs-strands"
+version = "0.1.0"
+description = "AMFS persistent memory plugin for Strands Agents"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+dependencies = [
+    "amfs",
+    "amfs-core",
+]
+
+[project.optional-dependencies]
+strands = ["strands-agents>=0.1"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/amfs_strands"]

--- a/packages/integrations/strands/src/amfs_strands/__init__.py
+++ b/packages/integrations/strands/src/amfs_strands/__init__.py
@@ -1,0 +1,11 @@
+"""AMFS integration for Strands Agents.
+
+Provides:
+- ``AMFSPlugin`` — a Strands Plugin with memory tools and causal tracing hooks
+- ``amfs_memory`` — a standalone @tool for action-based memory (mem0 drop-in)
+"""
+
+from amfs_strands.plugin import AMFSPlugin
+from amfs_strands.tools import amfs_memory
+
+__all__ = ["AMFSPlugin", "amfs_memory"]

--- a/packages/integrations/strands/src/amfs_strands/plugin.py
+++ b/packages/integrations/strands/src/amfs_strands/plugin.py
@@ -1,0 +1,229 @@
+"""AMFSPlugin — a Strands Agents Plugin that gives agents persistent memory.
+
+Provides @tool methods for read/write/search/recall/list and @hook methods
+for automatic causal tracing of tool calls.  Goes beyond tool-only
+integrations (like mem0) by passively building decision traces.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+try:
+    from strands import tool
+    from strands.hooks import AfterToolCallEvent
+    from strands.plugins import Plugin, hook
+
+    _HAS_STRANDS = True
+except ImportError:
+    _HAS_STRANDS = False
+
+if _HAS_STRANDS:
+
+    class AMFSPlugin(Plugin):
+        """Strands Plugin that wraps :class:`AgentMemory` for persistent memory.
+
+        Provides six tools (read, write, search, recall, list, record_context)
+        and a hook that auto-records tool call context into the AMFS causal
+        chain so decision traces capture every tool the agent uses.
+
+        Usage::
+
+            from strands import Agent
+            from amfs import AgentMemory
+            from amfs_strands import AMFSPlugin
+
+            mem = AgentMemory(agent_id="research-agent")
+            agent = Agent(plugins=[AMFSPlugin(mem)])
+            agent("Research the latest AI papers and remember key findings")
+        """
+
+        name = "amfs-memory"
+
+        def __init__(self, memory: Any, *, auto_trace: bool = True) -> None:
+            super().__init__()
+            self._memory = memory
+            self._auto_trace = auto_trace
+
+        @property
+        def memory(self) -> Any:
+            """The underlying :class:`AgentMemory` instance."""
+            return self._memory
+
+        # ------------------------------------------------------------------
+        # Hooks
+        # ------------------------------------------------------------------
+
+        @hook
+        def _trace_tool_call(self, event: AfterToolCallEvent) -> None:
+            """Auto-record every tool call into the AMFS causal chain."""
+            if not self._auto_trace:
+                return
+            tool_name = event.tool_use.get("name", "unknown")
+            if tool_name.startswith("amfs_"):
+                return
+            tool_input = event.tool_use.get("input", {})
+            try:
+                summary = f"Tool '{tool_name}' called with {json.dumps(tool_input, default=str)[:200]}"
+                self._memory.record_context(
+                    f"strands-tool-{tool_name}",
+                    summary,
+                    source="strands-agent",
+                )
+            except Exception:
+                logger.debug("Failed to record tool context for %s", tool_name, exc_info=True)
+
+        # ------------------------------------------------------------------
+        # Tools
+        # ------------------------------------------------------------------
+
+        @tool
+        def amfs_read(self, entity_path: str, key: str) -> str:
+            """Read a memory entry from AMFS persistent storage.
+
+            Args:
+                entity_path: Entity path (e.g. 'myapp/auth')
+                key: Key name to read
+            """
+            entry = self._memory.read(entity_path, key)
+            if entry is None:
+                return f"No entry found at {entity_path}/{key}"
+            return json.dumps(entry.model_dump(mode="json"), indent=2, default=str)
+
+        @tool
+        def amfs_write(
+            self,
+            entity_path: str,
+            key: str,
+            value: str,
+            confidence: float = 1.0,
+            memory_type: str = "fact",
+        ) -> str:
+            """Write a memory entry to AMFS persistent storage.
+
+            Args:
+                entity_path: Entity path (e.g. 'myapp/auth')
+                key: Key name to write
+                value: The value to store (string or JSON)
+                confidence: Confidence score 0.0–1.0
+                memory_type: One of 'fact', 'belief', or 'experience'
+            """
+            from amfs_core.models import MemoryType
+
+            mt = MemoryType(memory_type)
+            try:
+                parsed = json.loads(value)
+            except (json.JSONDecodeError, TypeError):
+                parsed = value
+
+            entry = self._memory.write(
+                entity_path,
+                key,
+                parsed,
+                confidence=confidence,
+                memory_type=mt,
+            )
+            return f"Written {entity_path}/{key} v{entry.version} (confidence={entry.confidence})"
+
+        @tool
+        def amfs_search(
+            self,
+            query: str = "",
+            entity_path: str = "",
+            min_confidence: float = 0.0,
+            limit: int = 10,
+        ) -> str:
+            """Search across AMFS memory entries with filters.
+
+            Args:
+                query: Text query for full-text search
+                entity_path: Optional entity path to scope the search
+                min_confidence: Minimum confidence threshold
+                limit: Maximum number of results
+            """
+            results = self._memory.search(
+                query=query or None,
+                entity_path=entity_path or None,
+                min_confidence=min_confidence,
+                limit=limit,
+            )
+            if not results:
+                return "No entries found matching the search criteria."
+            items = []
+            for entry in results:
+                items.append({
+                    "entity_path": entry.entity_path,
+                    "key": entry.key,
+                    "value": entry.value,
+                    "confidence": entry.confidence,
+                    "version": entry.version,
+                    "agent_id": entry.provenance.agent_id,
+                })
+            return json.dumps(items, indent=2, default=str)
+
+        @tool
+        def amfs_recall(self, entity_path: str, key: str) -> str:
+            """Recall this agent's own memory for a key (agent-scoped read).
+
+            Unlike amfs_read which returns the latest version by any agent,
+            recall returns only entries written by this agent.
+
+            Args:
+                entity_path: Entity path (e.g. 'myapp/auth')
+                key: Key name to recall
+            """
+            entry = self._memory.recall(entity_path, key)
+            if entry is None:
+                return f"No personal memory found at {entity_path}/{key}"
+            return json.dumps(entry.model_dump(mode="json"), indent=2, default=str)
+
+        @tool
+        def amfs_list(self, entity_path: str = "") -> str:
+            """List all memory entries, optionally filtered by entity path.
+
+            Args:
+                entity_path: Optional entity path filter
+            """
+            entries = self._memory.list(entity_path or None)
+            if not entries:
+                return "No entries found."
+            items = [
+                {
+                    "entity_path": e.entity_path,
+                    "key": e.key,
+                    "version": e.version,
+                    "confidence": e.confidence,
+                }
+                for e in entries
+            ]
+            return json.dumps(items, indent=2, default=str)
+
+        @tool
+        def amfs_record_context(self, label: str, summary: str, source: str = "") -> str:
+            """Record external context in the AMFS causal chain.
+
+            Use this after consulting an external tool, API, or data source so
+            that decision traces capture what informed the agent's decisions.
+
+            Args:
+                label: Short label for the context (e.g. 'api-response')
+                summary: Description of what was found
+                source: Where the information came from
+            """
+            self._memory.record_context(label, summary, source=source or None)
+            return f"Context recorded: {label}"
+
+else:
+
+    class AMFSPlugin:  # type: ignore[no-redef]
+        """Stub when strands-agents is not installed."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise ImportError(
+                "strands-agents is not installed. "
+                "Install with: pip install amfs-strands[strands]"
+            )

--- a/packages/integrations/strands/src/amfs_strands/tools.py
+++ b/packages/integrations/strands/src/amfs_strands/tools.py
@@ -1,0 +1,127 @@
+"""Standalone AMFS tool for Strands Agents — drop-in mem0 replacement.
+
+Provides a single ``amfs_memory`` tool with action-based dispatch
+(store, retrieve, search, list) that mirrors mem0's ``mem0_memory``
+interface.  Uses a module-level AgentMemory singleton.
+
+Usage::
+
+    from strands import Agent
+    from amfs_strands import amfs_memory
+
+    agent = Agent(tools=[amfs_memory])
+    agent("Remember that I prefer Python over TypeScript")
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_memory_instance: Any = None
+
+
+def _get_memory() -> Any:
+    """Lazy-init a module-level AgentMemory singleton."""
+    global _memory_instance
+    if _memory_instance is None:
+        from amfs import AgentMemory
+
+        agent_id = os.environ.get("AMFS_AGENT_ID", "strands-agent")
+        _memory_instance = AgentMemory(agent_id=agent_id)
+    return _memory_instance
+
+
+try:
+    from strands import tool as _strands_tool
+
+    @_strands_tool
+    def amfs_memory(
+        action: str,
+        entity_path: str = "default",
+        key: str = "",
+        value: str = "",
+        query: str = "",
+        confidence: float = 1.0,
+        limit: int = 10,
+    ) -> str:
+        """Store, retrieve, search, and list persistent agent memory with AMFS.
+
+        Args:
+            action: One of 'store', 'retrieve', 'search', or 'list'
+            entity_path: Entity path scope (e.g. 'myapp/auth')
+            key: Key name (required for store and retrieve)
+            value: Value to store (required for store action)
+            query: Search query text (required for search action)
+            confidence: Confidence score 0.0-1.0 (for store action)
+            limit: Maximum results (for search and list actions)
+        """
+        mem = _get_memory()
+
+        if action == "store":
+            if not key:
+                return "Error: 'key' is required for store action"
+            try:
+                parsed = json.loads(value)
+            except (json.JSONDecodeError, TypeError):
+                parsed = value
+            entry = mem.write(entity_path, key, parsed, confidence=confidence)
+            return f"Stored {entity_path}/{key} v{entry.version}"
+
+        elif action == "retrieve":
+            if not key:
+                return "Error: 'key' is required for retrieve action"
+            entry = mem.read(entity_path, key)
+            if entry is None:
+                return f"No entry found at {entity_path}/{key}"
+            return json.dumps(entry.model_dump(mode="json"), indent=2, default=str)
+
+        elif action == "search":
+            results = mem.search(
+                query=query or None,
+                entity_path=entity_path if entity_path != "default" else None,
+                limit=limit,
+            )
+            if not results:
+                return "No entries found."
+            items = [
+                {
+                    "entity_path": e.entity_path,
+                    "key": e.key,
+                    "value": e.value,
+                    "confidence": e.confidence,
+                }
+                for e in results
+            ]
+            return json.dumps(items, indent=2, default=str)
+
+        elif action == "list":
+            entries = mem.list(entity_path if entity_path != "default" else None)
+            if not entries:
+                return "No entries found."
+            items = [
+                {
+                    "entity_path": e.entity_path,
+                    "key": e.key,
+                    "version": e.version,
+                    "confidence": e.confidence,
+                }
+                for e in entries[:limit]
+            ]
+            return json.dumps(items, indent=2, default=str)
+
+        else:
+            return f"Unknown action '{action}'. Use 'store', 'retrieve', 'search', or 'list'."
+
+except ImportError:
+
+    def amfs_memory(*args: Any, **kwargs: Any) -> Any:  # type: ignore[misc]
+        """Stub when strands-agents is not installed."""
+        raise ImportError(
+            "strands-agents is not installed. "
+            "Install with: pip install amfs-strands[strands]"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dev = [
     "amfs-langchain",
     "amfs-langgraph",
     "amfs-autogen",
+    "amfs-strands",
 ]
 
 [tool.uv.workspace]
@@ -38,6 +39,7 @@ members = [
     "packages/integrations/langchain",
     "packages/integrations/langgraph",
     "packages/integrations/autogen",
+    "packages/integrations/strands",
 ]
 
 [tool.pytest.ini_options]
@@ -68,6 +70,7 @@ amfs-crewai = { workspace = true }
 amfs-langchain = { workspace = true }
 amfs-langgraph = { workspace = true }
 amfs-autogen = { workspace = true }
+amfs-strands = { workspace = true }
 
 [tool.mypy]
 python_version = "3.11"

--- a/tests/e2e/test_strands_saas.py
+++ b/tests/e2e/test_strands_saas.py
@@ -1,0 +1,140 @@
+"""E2E: Strands Agent with AMFSPlugin against AMFS SaaS.
+
+Exercises the full read/write/search loop through the HTTP adapter
+connected to the AMFS hosted service.  Skipped when credentials are
+not available.
+
+Requires:
+    AMFS_HTTP_URL  — SaaS endpoint (e.g. https://amfs-login.sense-lab.ai)
+    AMFS_API_KEY   — API key for authentication
+
+Optionally (for the full LLM agent loop test):
+    AWS_REGION / AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY — for Bedrock model
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+
+import pytest
+
+AMFS_HTTP_URL = os.environ.get("AMFS_HTTP_URL")
+AMFS_API_KEY = os.environ.get("AMFS_API_KEY")
+
+pytestmark = [
+    pytest.mark.skipif(
+        not AMFS_HTTP_URL or not AMFS_API_KEY,
+        reason="AMFS_HTTP_URL and AMFS_API_KEY not set — skipping SaaS E2E tests",
+    ),
+]
+
+try:
+    from strands.plugins import Plugin as _  # noqa: F401
+
+    _HAS_STRANDS = True
+except ImportError:
+    _HAS_STRANDS = False
+
+
+@pytest.mark.skipif(not _HAS_STRANDS, reason="strands-agents not installed")
+class TestStrandsWithSaaS:
+    """End-to-end tests: Strands Agent + AMFSPlugin + AMFS SaaS."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self) -> None:
+        from amfs import AgentMemory
+        from amfs_adapter_http import HttpAdapter
+        from amfs_strands import AMFSPlugin
+
+        self._test_scope = f"e2e-strands-{uuid.uuid4().hex[:8]}"
+        adapter = HttpAdapter(base_url=AMFS_HTTP_URL, api_key=AMFS_API_KEY)
+        self.mem = AgentMemory(agent_id="e2e-strands-agent", adapter=adapter)
+        self.plugin = AMFSPlugin(self.mem)
+        yield
+        self.mem.close()
+
+    def test_write_and_read_roundtrip(self) -> None:
+        """Write via plugin tool, read back via AgentMemory."""
+        ep = self._test_scope
+        result = self.plugin.amfs_write(
+            entity_path=ep, key="greeting", value='"hello from strands"'
+        )
+        assert "v1" in result
+
+        entry = self.mem.read(ep, "greeting")
+        assert entry is not None
+        assert entry.value == "hello from strands"
+
+    def test_read_via_plugin_tool(self) -> None:
+        """Write via SDK, read back via plugin tool."""
+        ep = self._test_scope
+        self.mem.write(ep, "data", {"status": "ok"})
+
+        result = self.plugin.amfs_read(entity_path=ep, key="data")
+        data = json.loads(result)
+        assert data["value"]["status"] == "ok"
+
+    def test_search_via_plugin_tool(self) -> None:
+        """Write entries and search via plugin tool."""
+        ep = self._test_scope
+        self.mem.write(ep, "pattern-retry", "exponential backoff")
+        self.mem.write(ep, "pattern-circuit", "circuit breaker")
+
+        result = self.plugin.amfs_search(entity_path=ep)
+        parsed = json.loads(result)
+        assert len(parsed) >= 2
+
+    def test_list_via_plugin_tool(self) -> None:
+        """List entries via plugin tool."""
+        ep = self._test_scope
+        self.mem.write(ep, "k1", "v1")
+        self.mem.write(ep, "k2", "v2")
+
+        result = self.plugin.amfs_list(ep)
+        parsed = json.loads(result)
+        keys = {e["key"] for e in parsed}
+        assert "k1" in keys
+        assert "k2" in keys
+
+    def test_recall_own_entries(self) -> None:
+        """Recall returns only entries written by this agent."""
+        ep = self._test_scope
+        self.mem.write(ep, "my-note", "agent's own note")
+
+        result = self.plugin.amfs_recall(ep, "my-note")
+        data = json.loads(result)
+        assert data["value"] == "agent's own note"
+
+    def test_record_context(self) -> None:
+        """Record context does not raise."""
+        result = self.plugin.amfs_record_context(
+            "e2e-test", "Testing context recording", source="pytest"
+        )
+        assert "Context recorded" in result
+
+    def test_full_agent_loop(self) -> None:
+        """Full LLM-driven loop: agent stores and retrieves a fact.
+
+        Requires a working LLM model (e.g. Bedrock Claude).
+        Skipped gracefully if no model is available.
+        """
+        from strands import Agent
+
+        ep = self._test_scope
+
+        try:
+            agent = Agent(
+                system_prompt=(
+                    f"You are a test agent. When asked to remember something, use "
+                    f"amfs_write with entity_path='{ep}'. When asked to recall, "
+                    f"use amfs_read with entity_path='{ep}'."
+                ),
+                plugins=[self.plugin],
+            )
+            agent(f"Remember that the project deadline is March 15th. Use key 'deadline' and entity_path '{ep}'.")
+            result = agent(f"What is the project deadline? Use amfs_read with entity_path '{ep}' and key 'deadline'.")
+            assert "March 15" in str(result) or "deadline" in str(result).lower()
+        except Exception as exc:
+            pytest.skip(f"No LLM model available for full agent loop test: {exc}")

--- a/tests/integration/test_framework_integrations.py
+++ b/tests/integration/test_framework_integrations.py
@@ -1,4 +1,4 @@
-"""Integration tests for CrewAI, LangChain, LangGraph, and AutoGen AMFS wrappers.
+"""Integration tests for CrewAI, LangChain, LangGraph, AutoGen, and Strands AMFS wrappers.
 
 Tests each framework wrapper against a real FilesystemAdapter-backed AgentMemory.
 No LLM or API key required — validates the memory plumbing end-to-end.
@@ -20,6 +20,13 @@ try:
     _HAS_CREWAI = True
 except ImportError:
     _HAS_CREWAI = False
+
+try:
+    from strands.plugins import Plugin as _StrandsPlugin  # noqa: F401
+
+    _HAS_STRANDS = True
+except ImportError:
+    _HAS_STRANDS = False
 
 
 # ---------------------------------------------------------------------------
@@ -352,3 +359,133 @@ class TestCrossFrameworkSharing:
             lc_mem.close()
             ag_mem.close()
             observer.close()
+
+
+# ---------------------------------------------------------------------------
+# Strands Agents — AMFSPlugin
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _HAS_STRANDS, reason="strands-agents not installed")
+class TestStrandsPlugin:
+    """Test AMFSPlugin tools (requires strands-agents)."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, mem: AgentMemory) -> None:
+        from amfs_strands import AMFSPlugin
+
+        self.plugin = AMFSPlugin(mem)
+        self.mem = mem
+
+    def test_plugin_has_name(self) -> None:
+        assert self.plugin.name == "amfs-memory"
+
+    def test_write_and_read(self) -> None:
+        result = self.plugin.amfs_write("svc", "config", '{"retries": 3}')
+        assert "v1" in result
+
+        read_result = self.plugin.amfs_read("svc", "config")
+        data = json.loads(read_result)
+        assert data["value"] == {"retries": 3}
+
+    def test_read_not_found(self) -> None:
+        result = self.plugin.amfs_read("nope", "nada")
+        assert "No entry found" in result
+
+    def test_write_with_confidence(self) -> None:
+        result = self.plugin.amfs_write("svc", "risk", '"high"', confidence=0.7)
+        assert "confidence=0.7" in result
+
+    def test_write_belief_type(self) -> None:
+        result = self.plugin.amfs_write(
+            "svc", "hypothesis", '"might work"', memory_type="belief"
+        )
+        assert "v1" in result
+        entry = self.mem.read("svc", "hypothesis")
+        assert entry is not None
+        assert entry.memory_type.value == "belief"
+
+    def test_search(self) -> None:
+        self.plugin.amfs_write("svc", "pattern-retry", '"exponential backoff"')
+        self.plugin.amfs_write("svc", "pattern-circuit", '"breaker"')
+        result = self.plugin.amfs_search(entity_path="svc")
+        parsed = json.loads(result)
+        assert len(parsed) >= 2
+
+    def test_search_empty(self) -> None:
+        result = self.plugin.amfs_search(entity_path="nonexistent")
+        assert "No entries found" in result
+
+    def test_list(self) -> None:
+        self.plugin.amfs_write("svc", "k1", '"v1"')
+        self.plugin.amfs_write("svc", "k2", '"v2"')
+        result = json.loads(self.plugin.amfs_list("svc"))
+        assert len(result) == 2
+        keys = {e["key"] for e in result}
+        assert keys == {"k1", "k2"}
+
+    def test_list_empty(self) -> None:
+        result = self.plugin.amfs_list("empty-path")
+        assert "No entries found" in result
+
+    def test_recall_own_entries(self) -> None:
+        self.mem.write("svc", "my-note", "agent's own note")
+        result = self.plugin.amfs_recall("svc", "my-note")
+        data = json.loads(result)
+        assert data["value"] == "agent's own note"
+
+    def test_recall_not_found(self) -> None:
+        result = self.plugin.amfs_recall("svc", "nonexistent")
+        assert "No personal memory" in result
+
+    def test_record_context(self) -> None:
+        result = self.plugin.amfs_record_context(
+            "api-call", "Got 200 from /users", source="http"
+        )
+        assert "Context recorded" in result
+
+
+@pytest.mark.skipif(not _HAS_STRANDS, reason="strands-agents not installed")
+class TestStrandsStandaloneTool:
+    """Test the standalone amfs_memory tool."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, mem: AgentMemory, monkeypatch: pytest.MonkeyPatch) -> None:
+        import amfs_strands.tools as tools_mod
+
+        monkeypatch.setattr(tools_mod, "_memory_instance", mem)
+
+    def test_store_and_retrieve(self) -> None:
+        from amfs_strands import amfs_memory
+
+        result = amfs_memory(
+            action="store", entity_path="test", key="greeting", value='"hello"'
+        )
+        assert "Stored" in result
+
+        result = amfs_memory(action="retrieve", entity_path="test", key="greeting")
+        data = json.loads(result)
+        assert data["value"] == "hello"
+
+    def test_list(self) -> None:
+        from amfs_strands import amfs_memory
+
+        amfs_memory(action="store", entity_path="test", key="a", value='"1"')
+        amfs_memory(action="store", entity_path="test", key="b", value='"2"')
+        result = amfs_memory(action="list", entity_path="test")
+        parsed = json.loads(result)
+        assert len(parsed) == 2
+
+    def test_search(self) -> None:
+        from amfs_strands import amfs_memory
+
+        amfs_memory(action="store", entity_path="test", key="item", value='"data"')
+        result = amfs_memory(action="search", entity_path="test")
+        parsed = json.loads(result)
+        assert len(parsed) >= 1
+
+    def test_unknown_action(self) -> None:
+        from amfs_strands import amfs_memory
+
+        result = amfs_memory(action="delete")
+        assert "Unknown action" in result


### PR DESCRIPTION
## Summary

- Adds `amfs-strands` package (`packages/integrations/strands/`) providing a **Strands Agents Plugin** (`AMFSPlugin`) and standalone `amfs_memory` `@tool` for persistent agent memory
- The Plugin goes deeper than tool-only integrations (like mem0) by using Strands' `@hook` system to automatically trace tool calls in the AMFS causal chain
- `AMFSPlugin` registers 6 tools (`amfs_read`, `amfs_write`, `amfs_search`, `amfs_recall`, `amfs_list`, `amfs_record_context`) and an `AfterToolCallEvent` hook for passive decision tracing
- Standalone `amfs_memory` tool provides mem0-compatible action-based interface (`store`, `retrieve`, `search`, `list`)

### Key differentiators vs mem0

| Feature | mem0 | AMFS |
|---------|------|------|
| Basic store/retrieve | Yes | Yes |
| Plugin with hooks | No (tools only) | Yes — auto-tracks tool usage |
| Causal tracing | No | Yes — decision traces across sessions |
| Confidence decay | No | Yes — stale knowledge fades |
| Agent-scoped recall | No | Yes — `recall()` vs `read()` |
| Cross-agent knowledge | No | Yes — `read_from()` |
| Version history | No | Yes — CoW versioning |

### Files changed

- **New package:** `packages/integrations/strands/` (pyproject.toml, plugin.py, tools.py, __init__.py)
- **Tests:** Strands section added to `tests/integration/test_framework_integrations.py` + new `tests/e2e/test_strands_saas.py`
- **Docs:** New `docs/guides/strands.md`, updated `docs/integrations/index.md`, updated `README.md`
- **CI:** `packages/integrations/strands` added to PyPI build+publish loop in `release.yml`
- **Workspace:** Added to `pyproject.toml` workspace members and dev dependencies