### PR TITLE
refactor: replace recompile_all with event-driven + catchup architecture

### DIFF
--- a/packages/cortex/src/amfs_cortex/worker.py
+++ b/packages/cortex/src/amfs_cortex/worker.py
@@ -132,9 +132,6 @@ class CortexWorker:
 
             logger.info("Cortex worker active — listening for events")
 
-            self._compiler.recompile_all()
-            self._last_full_recompile = time.monotonic()
-
             conn.execute("LISTEN amfs_write")
             conn.execute("LISTEN amfs_outcome")
 
@@ -142,6 +139,11 @@ class CortexWorker:
                 target=self._recompile_loop, daemon=True, name="cortex-recompile"
             )
             recompile_thread.start()
+
+            init_thread = threading.Thread(
+                target=self._initial_recompile, daemon=True, name="cortex-init-recompile"
+            )
+            init_thread.start()
 
             while not self._stop.is_set():
                 for notify in conn.notifies(timeout=5.0):
@@ -177,8 +179,7 @@ class CortexWorker:
                 break
             if self._try_acquire_lock(conn):
                 logger.info("Standby worker promoted to active")
-                self._compiler.recompile_all()
-                self._last_full_recompile = time.monotonic()
+
                 conn.execute("LISTEN amfs_write")
                 conn.execute("LISTEN amfs_outcome")
 
@@ -186,6 +187,11 @@ class CortexWorker:
                     target=self._recompile_loop, daemon=True, name="cortex-recompile"
                 )
                 recompile_thread.start()
+
+                init_thread = threading.Thread(
+                    target=self._initial_recompile, daemon=True, name="cortex-init-recompile"
+                )
+                init_thread.start()
 
                 while not self._stop.is_set():
                     for notify in conn.notifies(timeout=5.0):
@@ -248,6 +254,25 @@ class CortexWorker:
 
         if self._pro_forwarder:
             self._pro_forwarder.enqueue({"channel": channel, **payload})
+
+    def _initial_recompile(self) -> None:
+        """Run initial full recompile in a background thread.
+
+        This runs separately so the main event loop can start processing
+        NOTIFY events immediately instead of blocking for minutes while
+        LLM-based compilation runs for every agent.
+        """
+        try:
+            count = self._compiler.recompile_all()
+            self._last_full_recompile = time.monotonic()
+            logger.info("Initial recompile complete: %d digests", count)
+            self._activity_log.append({
+                "type": "initial_recompile",
+                "digests_compiled": count,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            })
+        except Exception:
+            logger.exception("Initial recompile failed")
 
     def _maybe_periodic_recompile(self) -> None:
         """Trigger a full recompile if enough time has passed since the last one.

--- a/packages/cortex/src/amfs_cortex/worker.py
+++ b/packages/cortex/src/amfs_cortex/worker.py
@@ -36,14 +36,14 @@ class CortexWorker:
         debounce_ms: int = 3000,
         use_advisory_lock: bool = True,
         drift_threshold: float = 0.0,
-        periodic_recompile_s: float = 300.0,
+        catchup_interval_s: float = 300.0,
     ) -> None:
         self._dsn = dsn
         self._compiler = compiler
         self._debounce_ms = debounce_ms
         self._use_advisory_lock = use_advisory_lock
         self._drift_threshold = drift_threshold
-        self._periodic_recompile_s = periodic_recompile_s
+        self._catchup_interval_s = catchup_interval_s
         self._pending: dict[str, float] = {}
         self._stop = threading.Event()
         self._lock = threading.Lock()
@@ -52,7 +52,7 @@ class CortexWorker:
         self._drift_skipped = 0
         self._started_at: float | None = None
         self._last_event_at: float | None = None
-        self._last_full_recompile: float = 0.0
+        self._last_catchup: float = 0.0
         self._activity_log: deque[dict[str, Any]] = deque(maxlen=_ACTIVITY_LOG_MAX)
         self._outcome_wiring: Any = None
         self._hot_tracker: Any = None
@@ -140,17 +140,17 @@ class CortexWorker:
             )
             recompile_thread.start()
 
-            init_thread = threading.Thread(
-                target=self._initial_recompile, daemon=True, name="cortex-init-recompile"
+            catchup_thread = threading.Thread(
+                target=self._catchup_missing_digests, daemon=True, name="cortex-catchup"
             )
-            init_thread.start()
+            catchup_thread.start()
 
             while not self._stop.is_set():
                 for notify in conn.notifies(timeout=5.0):
                     if self._stop.is_set():
                         break
                     self._handle_notify(notify)
-                self._maybe_periodic_recompile()
+                self._maybe_catchup()
 
         finally:
             conn.close()
@@ -188,17 +188,17 @@ class CortexWorker:
                 )
                 recompile_thread.start()
 
-                init_thread = threading.Thread(
-                    target=self._initial_recompile, daemon=True, name="cortex-init-recompile"
+                catchup_thread = threading.Thread(
+                    target=self._catchup_missing_digests, daemon=True, name="cortex-catchup"
                 )
-                init_thread.start()
+                catchup_thread.start()
 
                 while not self._stop.is_set():
                     for notify in conn.notifies(timeout=5.0):
                         if self._stop.is_set():
                             break
                         self._handle_notify(notify)
-                    self._maybe_periodic_recompile()
+                    self._maybe_catchup()
                 break
 
     def _handle_notify(self, notify) -> None:
@@ -255,49 +255,72 @@ class CortexWorker:
         if self._pro_forwarder:
             self._pro_forwarder.enqueue({"channel": channel, **payload})
 
-    def _initial_recompile(self) -> None:
-        """Run initial full recompile in a background thread.
+    def _catchup_missing_digests(self) -> None:
+        """Find agents/entities that have entries but no digest, queue them.
 
-        This runs separately so the main event loop can start processing
-        NOTIFY events immediately instead of blocking for minutes while
-        LLM-based compilation runs for every agent.
+        Unlike recompile_all(), this only targets scopes that are completely
+        missing a digest. It queues them through the normal debounce pipeline
+        so they compile one at a time without blocking the event loop.
         """
         try:
-            count = self._compiler.recompile_all()
-            self._last_full_recompile = time.monotonic()
-            logger.info("Initial recompile complete: %d digests", count)
+            adapter = self._compiler._adapter
+            branch = self._compiler._branch
+            namespace = self._compiler._namespace
+
+            entries = adapter.list(branch=branch)
+            entity_paths: set[str] = set()
+            agent_ids: set[str] = set()
+
+            for entry in entries:
+                entity_paths.add(entry.entity_path)
+                aid = entry.provenance.agent_id
+                if not aid.startswith(("webhook/", "external/")):
+                    agent_ids.add(aid)
+
+            existing_digests = adapter.list_digests(namespace=namespace)
+            existing_scopes: set[str] = set()
+            for d in existing_digests:
+                existing_scopes.add(f"{d.digest_type.value}:{d.scope}")
+
+            queued = 0
+            for aid in agent_ids:
+                if f"agent_brief:{aid}" not in existing_scopes:
+                    with self._lock:
+                        self._pending[f"agent:{aid}@{branch}"] = time.monotonic()
+                    queued += 1
+
+            for ep in entity_paths:
+                if f"entity:{ep}" not in existing_scopes:
+                    with self._lock:
+                        self._pending[f"entity:{ep}@{branch}"] = time.monotonic()
+                    queued += 1
+
+            self._last_catchup = time.monotonic()
+
+            if queued > 0:
+                logger.info("Catchup: queued %d missing digests for compilation", queued)
+            else:
+                logger.info("Catchup: all %d agents and %d entities have digests",
+                            len(agent_ids), len(entity_paths))
+
             self._activity_log.append({
-                "type": "initial_recompile",
-                "digests_compiled": count,
+                "type": "catchup_scan",
+                "missing_scopes": queued,
+                "total_agents": len(agent_ids),
+                "total_entities": len(entity_paths),
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             })
         except Exception:
-            logger.exception("Initial recompile failed")
+            logger.exception("Catchup scan failed")
 
-    def _maybe_periodic_recompile(self) -> None:
-        """Trigger a full recompile if enough time has passed since the last one.
-
-        Acts as a safety net for environments where NOTIFY events can be lost
-        (Cloud Run scale-to-zero, connection poolers, connection drops).
-        """
-        if self._periodic_recompile_s <= 0:
+    def _maybe_catchup(self) -> None:
+        """Periodically scan for missing digests as a lightweight safety net."""
+        if self._catchup_interval_s <= 0:
             return
-        elapsed = time.monotonic() - self._last_full_recompile
-        if elapsed < self._periodic_recompile_s:
+        elapsed = time.monotonic() - self._last_catchup
+        if elapsed < self._catchup_interval_s:
             return
-
-        logger.info("Periodic recompile triggered (%.0fs since last)", elapsed)
-        try:
-            count = self._compiler.recompile_all()
-            self._last_full_recompile = time.monotonic()
-            self._activity_log.append({
-                "type": "periodic_recompile",
-                "digests_compiled": count,
-                "interval_s": round(elapsed),
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-            })
-        except Exception:
-            logger.exception("Periodic recompile failed")
+        self._catchup_missing_digests()
 
     def _recompile_loop(self) -> None:
         """Background thread that recompiles debounced pending digests."""


### PR DESCRIPTION
## Summary

- Removes all `recompile_all()` calls from the worker startup and periodic paths
- Event-driven compilation now works from the first second — LISTEN starts immediately
- Startup catchup only queues scopes that are **missing** a digest, not everything
- Periodic safety net (every 5 min) runs the same lightweight catchup scan

## Why recompile_all was the problem

`recompile_all()` iterated over every agent and entity, calling the LLMStrategy for each one. With 56+ agents and OpenAI API calls, this blocked for **3-5 minutes** on startup. During that entire window, `LISTEN amfs_write` was never executed, so every NOTIFY event from agent writes was silently lost. New agents never got brain briefs.

## New architecture

```
Startup:
  1. LISTEN amfs_write, amfs_outcome    (immediate)
  2. Start debounce recompile thread    (immediate)
  3. Start catchup thread               (background, ~100ms)
     - Scans for agents/entities with entries but no digest
     - Queues only those into _pending (feeds the debounce pipeline)
  4. Event loop starts                  (immediate)

Runtime:
  - NOTIFY fires → _handle_notify queues specific agent + entity
  - Debounce thread compiles them one at a time (3s debounce)
  - Every 5 min: catchup scan for anything missed

Manual:
  - POST /api/v1/cortex/recompile still calls recompile_all() as escape hatch
```