### PR TITLE
fix: require strands-agents>=1.0 to avoid placeholder package

### DIFF
--- a/packages/integrations/strands/pyproject.toml
+++ b/packages/integrations/strands/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-strands"
-version = "0.1.0"
+version = "0.1.1"
 description = "AMFS persistent memory plugin for Strands Agents"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -10,7 +10,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-strands = ["strands-agents>=0.1"]
+strands = ["strands-agents>=1.0"]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary

- Bumps the `strands-agents` optional dependency from `>=0.1` to `>=1.0`
- The `strands-agents` 0.0.1 on PyPI is a placeholder stub that doesn't provide the `strands` module, causing `ImportError` at runtime
- Discovered during live E2E testing of the Strands integration against AMFS SaaS