### PR TITLE
fix: resolve _session_id AttributeError and improve 401 diagnostics

### DIFF
--- a/packages/core/src/amfs_core/lifecycle.py
+++ b/packages/core/src/amfs_core/lifecycle.py
@@ -84,6 +84,13 @@ class LifecycleManager:
                 archived = self.sweep()
                 if archived:
                     logger.info("TTL sweep archived %d entries", len(archived))
-            except Exception:
-                logger.exception("Error during TTL sweep")
+            except Exception as exc:
+                msg = str(exc)
+                if "401" in msg or "Unauthorized" in msg:
+                    logger.error(
+                        "TTL sweep failed with 401 Unauthorized — check that "
+                        "AMFS_API_KEY is set correctly in your MCP server env."
+                    )
+                else:
+                    logger.exception("Error during TTL sweep")
             self._stop_event.wait(timeout=self._interval)

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -171,6 +171,12 @@ def _get_adapter() -> AdapterABC:
             from amfs_adapter_http import HttpAdapter
 
             api_key = os.environ.get("AMFS_API_KEY", "")
+            if not api_key:
+                logger.warning(
+                    "AMFS_HTTP_URL is set but AMFS_API_KEY is empty or missing. "
+                    "API requests will likely fail with 401 Unauthorized. "
+                    "Set AMFS_API_KEY in your MCP server env configuration."
+                )
             logger.info(
                 "AMFS HTTP adapter mode — routing through %s", http_url
             )

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -585,7 +585,7 @@ class AgentMemory:
 
         buf = TransactionBuffer(
             agent_id=self.agent_id,
-            session_id=self._tagger._session_id,
+            session_id=self._tagger.session_id,
             branch=self._branch,
             namespace=self._config.namespace,
         )


### PR DESCRIPTION
## Summary

- **Fix crash in `amfs_commit_batch`**: `AgentMemory.transaction()` accessed `CausalTagger._session_id` which doesn't exist — `CausalTagger` exposes `session_id` as a public attribute. This caused an `AttributeError` for every user calling `amfs_commit_batch`.
- **Warn on missing API key**: Log a clear warning at adapter init when `AMFS_HTTP_URL` is set but `AMFS_API_KEY` is empty, so users immediately know what's wrong instead of hitting opaque 401 errors.
- **Better TTL sweep errors**: Surface a targeted one-liner on 401 in the lifecycle manager instead of dumping a full traceback every sweep interval.