### PR TITLE
fix: guard amfs_patterns import and protect detected_patterns migration

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -237,21 +237,24 @@ class PostgresAdapter(AdapterABC):
             ADD COLUMN IF NOT EXISTS default_branch TEXT
         """)
         cur.execute("""
-            ALTER TABLE amfs_detected_patterns
-            ADD COLUMN IF NOT EXISTS category TEXT NOT NULL DEFAULT 'collaboration'
-        """)
-        cur.execute("""
-            ALTER TABLE amfs_detected_patterns DROP CONSTRAINT IF EXISTS chk_pattern_type
-        """)
-        cur.execute("""
-            ALTER TABLE amfs_detected_patterns ADD CONSTRAINT chk_pattern_type CHECK (
-                pattern_type IN (
-                    'knowledge_conflict', 'stale_knowledge', 'orphaned_branch',
-                    'redundant_writes', 'single_point_of_knowledge', 'passive_consumer',
-                    'unreviewed_changes', 'recurring_failure',
-                    'hot_entity', 'stale_cluster', 'confidence_drift'
-                )
-            )
+            DO $$ BEGIN
+                IF EXISTS (SELECT 1 FROM information_schema.tables
+                           WHERE table_name = 'amfs_detected_patterns') THEN
+                    ALTER TABLE amfs_detected_patterns
+                        ADD COLUMN IF NOT EXISTS category TEXT NOT NULL DEFAULT 'collaboration';
+                    ALTER TABLE amfs_detected_patterns
+                        DROP CONSTRAINT IF EXISTS chk_pattern_type;
+                    ALTER TABLE amfs_detected_patterns
+                        ADD CONSTRAINT chk_pattern_type CHECK (
+                            pattern_type IN (
+                                'knowledge_conflict', 'stale_knowledge', 'orphaned_branch',
+                                'redundant_writes', 'single_point_of_knowledge', 'passive_consumer',
+                                'unreviewed_changes', 'recurring_failure',
+                                'hot_entity', 'stale_cluster', 'confidence_drift'
+                            )
+                        );
+                END IF;
+            END $$
         """)
         cur.execute("""
             CREATE OR REPLACE FUNCTION amfs_notify_write() RETURNS TRIGGER AS $$

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -2621,7 +2621,11 @@ async def list_detected_patterns(
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
     """List previously detected patterns from the database."""
-    from amfs_patterns.detector import PATTERN_CATEGORIES, PATTERN_METADATA
+    try:
+        from amfs_patterns.detector import PATTERN_CATEGORIES, PATTERN_METADATA
+    except ImportError:
+        PATTERN_CATEGORIES = {}
+        PATTERN_METADATA = {}
 
     pool = _get_db_pool()
     if pool is None:


### PR DESCRIPTION
## Summary
- Wrap the `from amfs_patterns.detector import ...` in `GET /api/v1/admin/patterns` with try/except — the unguarded import causes a 500 when the optional `amfs-patterns` package is missing or fails to load
- Wrap `ALTER TABLE amfs_detected_patterns` migration statements in `IF EXISTS` guards for consistency with other optional-table migrations

## Context
Production logs showed a `500 Internal Server Error` on `GET /api/v1/admin/patterns?agent_id=agent%2Fbrunoandrade`. The `amfs-patterns` package is an optional Pro dependency (`[pro]` extra), and the import was not protected like the `/admin/patterns/scan` endpoint already was.