### PR TITLE
fix: prevent empty-string UUID cast crash in RLS policies

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -107,7 +107,9 @@ class _TenantRLSConnection:
                     (tid,),
                 )
             else:
-                cur.execute("RESET amfs.current_account_id")
+                cur.execute(
+                    "SELECT set_config('amfs.current_account_id', '', false)"
+                )
         return conn
 
     def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Any:

--- a/packages/adapters/postgres/src/amfs_postgres/tenant_context.py
+++ b/packages/adapters/postgres/src/amfs_postgres/tenant_context.py
@@ -9,7 +9,7 @@ _tls = threading.local()
 
 def set_tls_tenant_account_id(account_id: str | None) -> None:
     """Called from HTTP middleware before handling a request."""
-    _tls.account_id = account_id
+    _tls.account_id = account_id or None
 
 
 def clear_tls_tenant_account_id() -> None:


### PR DESCRIPTION
## Summary
- Fix `psycopg.errors.InvalidTextRepresentation: invalid input syntax for type uuid: ""` crash that occurs when background workers (cortex catchup scan) query RLS-protected tables without HTTP request context
- Normalize empty-string tenant IDs to `None` in `set_tls_tenant_account_id` so they can't propagate
- Use `set_config(..., '', false)` instead of `RESET` in `_TenantRLSConnection` for explicit, predictable GUC behavior

## Root cause
When `_TenantRLSConnection.__enter__` runs without a tenant context (e.g. cortex background threads), it calls `RESET amfs.current_account_id`, setting the GUC to `''`. The RLS policies from migration 001 do `current_setting('amfs.current_account_id', true)::uuid` — casting `''` to UUID crashes.

A companion migration (014) in the internal repo updates all RLS policies to use `NULLIF(current_setting(...), '')::uuid` so empty strings safely become NULL.