### PR TITLE
feat: auto-generate agent profiles and persist via set_identity

### DIFF
--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -299,6 +299,20 @@ class HttpAdapter(AdapterABC):
         # Return a stub so AgentMemory.__init__ doesn't hit the ABC no-op.
         return Agent(agent_id=agent_id, namespace=namespace)
 
+    def update_agent_profile(
+        self,
+        agent_id: str,
+        profile: Any,
+        namespace: str = "default",
+    ) -> Agent:
+        from urllib.parse import quote
+        resp = self._client.put(
+            f"/api/v1/agents/{quote(agent_id, safe='')}/profile",
+            json=profile.model_dump(),
+        )
+        resp.raise_for_status()
+        return Agent.model_validate(resp.json())
+
     def list_digests(
         self,
         digest_type: Any = None,

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -415,6 +415,19 @@ class PostgresAdapter(AdapterABC):
             ON amfs_team_members (namespace, email)
             WHERE removed_at IS NOT NULL
         """)
+        # Agent profile persistence
+        cur.execute("""
+            ALTER TABLE amfs_agents
+            ADD COLUMN IF NOT EXISTS profile JSONB
+        """)
+        cur.execute("""
+            ALTER TABLE amfs_agents
+            ADD COLUMN IF NOT EXISTS capabilities JSONB DEFAULT '[]'::jsonb
+        """)
+        cur.execute("""
+            ALTER TABLE amfs_agents
+            ADD COLUMN IF NOT EXISTS contracts JSONB DEFAULT '[]'::jsonb
+        """)
         # Tenant isolation — account_id scoping on optional tables.
         # These tables are created by separate migration files and may not
         # exist in minimal test environments, so guard with IF EXISTS.
@@ -1737,20 +1750,23 @@ class PostgresAdapter(AdapterABC):
 
     # ── Agent registration (Pro) ────────────────────────────────────────
 
+    _AGENT_COLUMNS = """id, namespace, agent_id, display_name,
+                    created_at, last_active_at, entry_count,
+                    profile, capabilities, contracts"""
+
     def ensure_agent(self, agent_id: str, namespace: str = "default") -> Agent:
         account_id = self._get_current_account_id()
         with self._pool.connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    """
+                    f"""
                     INSERT INTO amfs_agents (namespace, agent_id, account_id)
                     VALUES (%s, %s, %s)
                     ON CONFLICT ON CONSTRAINT uq_agent DO UPDATE
                         SET last_active_at = NOW(),
                             entry_count = amfs_agents.entry_count + 1,
                             account_id = COALESCE(amfs_agents.account_id, EXCLUDED.account_id)
-                    RETURNING id, namespace, agent_id, display_name,
-                              created_at, last_active_at, entry_count
+                    RETURNING {self._AGENT_COLUMNS}
                     """,
                     (namespace, agent_id, account_id),
                 )
@@ -1769,8 +1785,7 @@ class PostgresAdapter(AdapterABC):
             with conn.cursor() as cur:
                 cur.execute(
                     f"""
-                    SELECT id, namespace, agent_id, display_name,
-                           created_at, last_active_at, entry_count
+                    SELECT {self._AGENT_COLUMNS}
                     FROM amfs_agents
                     WHERE namespace = %s AND agent_id = %s {account_filter}
                     """,
@@ -1791,8 +1806,7 @@ class PostgresAdapter(AdapterABC):
             with conn.cursor() as cur:
                 cur.execute(
                     f"""
-                    SELECT id, namespace, agent_id, display_name,
-                           created_at, last_active_at, entry_count
+                    SELECT {self._AGENT_COLUMNS}
                     FROM amfs_agents
                     WHERE namespace = %s {account_filter}
                     ORDER BY last_active_at DESC
@@ -1804,6 +1818,17 @@ class PostgresAdapter(AdapterABC):
 
     @staticmethod
     def _row_to_agent(row: dict[str, Any]) -> Agent:
+        from amfs_core.models import AgentProfile, AgentCapability, MemoryContract
+
+        profile_raw = row.get("profile")
+        profile = AgentProfile.model_validate(profile_raw) if profile_raw else None
+
+        caps_raw = row.get("capabilities") or []
+        capabilities = [AgentCapability.model_validate(c) for c in caps_raw]
+
+        contracts_raw = row.get("contracts") or []
+        contracts = [MemoryContract.model_validate(c) for c in contracts_raw]
+
         return Agent(
             id=str(row["id"]),
             namespace=row["namespace"],
@@ -1812,7 +1837,75 @@ class PostgresAdapter(AdapterABC):
             created_at=row["created_at"],
             last_active_at=row["last_active_at"],
             entry_count=row.get("entry_count", 0),
+            profile=profile,
+            capabilities=capabilities,
+            contracts=contracts,
         )
+
+    def update_agent_profile(
+        self,
+        agent_id: str,
+        profile: Any,
+        namespace: str = "default",
+    ) -> Agent:
+        self.ensure_agent(agent_id, namespace)
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    UPDATE amfs_agents
+                    SET profile = %s
+                    WHERE namespace = %s AND agent_id = %s
+                    RETURNING {self._AGENT_COLUMNS}
+                    """,
+                    (json.dumps(profile.model_dump()), namespace, agent_id),
+                )
+                row = cur.fetchone()
+        return self._row_to_agent(row)
+
+    def update_agent_capabilities(
+        self,
+        agent_id: str,
+        capabilities: list[Any],
+        namespace: str = "default",
+    ) -> Agent:
+        self.ensure_agent(agent_id, namespace)
+        caps_json = json.dumps([c.model_dump() for c in capabilities])
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    UPDATE amfs_agents
+                    SET capabilities = %s
+                    WHERE namespace = %s AND agent_id = %s
+                    RETURNING {self._AGENT_COLUMNS}
+                    """,
+                    (caps_json, namespace, agent_id),
+                )
+                row = cur.fetchone()
+        return self._row_to_agent(row)
+
+    def update_agent_contracts(
+        self,
+        agent_id: str,
+        contracts: list[Any],
+        namespace: str = "default",
+    ) -> Agent:
+        self.ensure_agent(agent_id, namespace)
+        contracts_json = json.dumps([c.model_dump() for c in contracts])
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    UPDATE amfs_agents
+                    SET contracts = %s
+                    WHERE namespace = %s AND agent_id = %s
+                    RETURNING {self._AGENT_COLUMNS}
+                    """,
+                    (contracts_json, namespace, agent_id),
+                )
+                row = cur.fetchone()
+        return self._row_to_agent(row)
 
     # ── Event log / timeline (Pro) ────────────────────────────────────
 

--- a/packages/adapters/postgres/src/amfs_postgres/schema.sql
+++ b/packages/adapters/postgres/src/amfs_postgres/schema.sql
@@ -205,6 +205,9 @@ CREATE TABLE IF NOT EXISTS amfs_agents (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     last_active_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     entry_count INTEGER DEFAULT 0,
+    profile JSONB,
+    capabilities JSONB DEFAULT '[]'::jsonb,
+    contracts JSONB DEFAULT '[]'::jsonb,
     CONSTRAINT uq_agent UNIQUE (namespace, agent_id)
 );
 

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -543,7 +543,12 @@ async def get_agent_profile(
     agent_id: str,
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
-    """Return an agent's profile, stats, and registration info."""
+    """Return an agent's profile, stats, and registration info.
+
+    When no explicit profile has been registered, synthesises one from the
+    agent's actual activity — entity paths become auto-inferred capabilities
+    and memory-type distribution is included.
+    """
     mem = _get_memory()
     agent = mem._adapter.get_agent(agent_id, namespace=mem.namespace)
 
@@ -568,13 +573,104 @@ async def get_agent_profile(
         "decisionTraces": len(traces),
         "lastActive": last_active.isoformat() if last_active else None,
     }
+
     if agent:
-        result["profile"] = agent.profile.model_dump() if agent.profile else {}
-        result["capabilities"] = [c.model_dump() for c in agent.capabilities]
-        result["contracts"] = [c.model_dump() for c in agent.contracts]
+        profile = agent.profile
+        capabilities = agent.capabilities
+        contracts = agent.contracts
+
+        if not profile and not capabilities and entries:
+            profile, capabilities = _synthesize_agent_profile(
+                agent_id, entries, traces,
+            )
+
+        result["profile"] = profile.model_dump() if profile else {}
+        result["capabilities"] = [c.model_dump() for c in capabilities]
+        result["contracts"] = [c.model_dump() for c in contracts]
         result["displayName"] = agent.display_name
         result["createdAt"] = agent.created_at.isoformat() if agent.created_at else None
     return result
+
+
+def _synthesize_agent_profile(
+    agent_id: str,
+    entries: list,
+    traces: list,
+) -> tuple:
+    """Build an AgentProfile and capabilities from observed activity."""
+    from amfs_core.models import AgentProfile, AgentCapability, MemoryType
+    from collections import Counter
+
+    entities_touched = {e.entity_path for e in entries}
+    memory_types: Counter[str] = Counter()
+    key_prefixes: Counter[str] = Counter()
+    for e in entries:
+        mt = e.memory_type if hasattr(e, "memory_type") and e.memory_type else MemoryType.FACT
+        memory_types[mt.value if hasattr(mt, "value") else str(mt)] += 1
+        prefix = e.key.split("-")[0] if "-" in e.key else e.key
+        key_prefixes[prefix] += 1
+
+    top_prefixes = [p for p, _ in key_prefixes.most_common(5)]
+    type_summary = ", ".join(
+        f"{count} {mtype}" for mtype, count in memory_types.most_common()
+    )
+    desc_parts = []
+    if type_summary:
+        desc_parts.append(f"Writes: {type_summary}.")
+    if entities_touched:
+        desc_parts.append(
+            f"Active across {len(entities_touched)} "
+            f"entit{'y' if len(entities_touched) == 1 else 'ies'}."
+        )
+    if traces:
+        desc_parts.append(f"{len(traces)} decision trace(s) recorded.")
+
+    profile = AgentProfile(
+        description=" ".join(desc_parts),
+        auto_context_paths=sorted(entities_touched)[:10],
+        tags=_infer_tags(agent_id, top_prefixes, memory_types),
+    )
+
+    capabilities = []
+    entity_groups: dict[str, list[str]] = {}
+    for ep in sorted(entities_touched):
+        group = ep.split("/")[0] if "/" in ep else ep
+        entity_groups.setdefault(group, []).append(ep)
+
+    for group, paths in entity_groups.items():
+        capabilities.append(AgentCapability(
+            name=group,
+            description=f"Works on {len(paths)} entit{'y' if len(paths) == 1 else 'ies'} under {group}/",
+            entity_paths=paths[:10],
+        ))
+
+    return profile, capabilities
+
+
+def _infer_tags(
+    agent_id: str,
+    key_prefixes: list[str],
+    memory_types: "Counter",
+) -> list[str]:
+    """Derive a small set of tags from the agent's activity."""
+    tags: list[str] = []
+    prefix_tag_map = {
+        "task": "task-executor",
+        "pattern": "pattern-detector",
+        "risk": "risk-assessor",
+        "decision": "decision-maker",
+        "action": "action-logger",
+    }
+    for prefix in key_prefixes:
+        if prefix in prefix_tag_map and prefix_tag_map[prefix] not in tags:
+            tags.append(prefix_tag_map[prefix])
+
+    if memory_types.get("belief", 0) > memory_types.get("fact", 0):
+        tags.append("hypothesis-driven")
+    if memory_types.get("experience", 0) > 0:
+        tags.append("experiential")
+
+    return tags[:5]
 
 
 @app.put("/api/v1/agents/{agent_id:path}/profile")

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -343,14 +343,29 @@ def amfs_set_identity(name: str, description: str | None = None) -> str:
 
     mem = _get_memory()
 
-    # Log identity change for debugging — but do NOT write to _system/agents.
-    # Writing system metadata as regular memory entries pollutes agent stats
-    # (entry counts, entity lists) and creates ghost agents on the dashboard.
-    # Agent identity is already tracked via provenance on every real entry.
     logger.info(
         "Identity set: %s → %s (session=%s, platform=%s, description=%s)",
         old_identity, name, mem.session_id, detect_platform(), description or "",
     )
+
+    # Register / update the agent profile with the description so it
+    # shows up on the dashboard.  This is a fire-and-forget best-effort
+    # call — identity setting always succeeds even if profile update fails.
+    if description:
+        try:
+            from amfs_core.models import AgentProfile
+
+            current_agent = mem._adapter.get_agent(name, namespace=mem.namespace)
+            existing = current_agent.profile if current_agent else None
+            profile = AgentProfile(
+                description=description,
+                default_branch=existing.default_branch if existing else "main",
+                auto_context_paths=existing.auto_context_paths if existing else [],
+                tags=existing.tags if existing else [],
+            )
+            mem._adapter.update_agent_profile(name, profile, namespace=mem.namespace)
+        except Exception:
+            logger.debug("Could not update agent profile for %s", name, exc_info=True)
 
     result: dict[str, Any] = {
         "previous_identity": old_identity,


### PR DESCRIPTION
## Summary

- **Persist agent profiles in DB**: Added `profile`, `capabilities`, `contracts` JSONB columns to `amfs_agents` with migration + full CRUD in Postgres adapter
- **set_identity registers profile**: When an agent calls `amfs_set_identity("name", "description")`, the description is now auto-saved as the agent's profile — it shows up on the dashboard Agent Profile card
- **Auto-synthesise profiles**: When GET `/agents/{id}/profile` is called and no explicit profile exists, the server generates one from the agent's activity: entity groups become capabilities, key prefixes and memory types become tags, and a summary description is built from write/trace stats

## Before

Agent Profile card was always empty — `set_identity` didn't persist anything, profile columns didn't exist in DB, and the ABC default was in-memory only.

## After

- Agents that call `set_identity("claude-desktop", "Exploring AMFS features")` → profile card shows the description
- Agents with no explicit profile → card shows auto-generated capabilities (grouped by entity namespace), inferred tags (task-executor, pattern-detector, etc.), and activity summary
- Empty profile card is hidden entirely (dashboard fix in amfs-internal)