### PR TITLE
feat: add Entity Rooms support to OSS layer

### DIFF
--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -178,6 +178,13 @@ except ImportError:
     pass
 
 try:
+    from amfs_rooms import mount_rooms
+    mount_rooms(app, get_memory=_get_memory, db_pool=_get_db_pool())
+    logger.info("Room endpoints mounted")
+except ImportError:
+    pass
+
+try:
     from amfs_tenant.http_deps import mount_scope_enforcement
     mount_scope_enforcement(app)
 except ImportError:

--- a/packages/http-server/src/amfs_http/sse.py
+++ b/packages/http-server/src/amfs_http/sse.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 class SSEManager:
     def __init__(self) -> None:
         self._subscribers: dict[str, list[asyncio.Queue[dict[str, Any]]]] = {}
+        self._room_subscribers: dict[str, list[asyncio.Queue[dict[str, Any]]]] = {}
 
     def subscribe(self, entity_path: str = "*") -> asyncio.Queue[dict[str, Any]]:
         queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
@@ -24,6 +25,19 @@ class SSEManager:
 
     def unsubscribe(self, entity_path: str, queue: asyncio.Queue[dict[str, Any]]) -> None:
         subs = self._subscribers.get(entity_path, [])
+        if queue in subs:
+            subs.remove(queue)
+
+    def subscribe_room(self, room_id: str) -> asyncio.Queue[dict[str, Any]]:
+        """Subscribe to all events for a specific room."""
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        if room_id not in self._room_subscribers:
+            self._room_subscribers[room_id] = []
+        self._room_subscribers[room_id].append(queue)
+        return queue
+
+    def unsubscribe_room(self, room_id: str, queue: asyncio.Queue[dict[str, Any]]) -> None:
+        subs = self._room_subscribers.get(room_id, [])
         if queue in subs:
             subs.remove(queue)
 
@@ -43,6 +57,21 @@ class SSEManager:
                     except asyncio.QueueFull:
                         logger.debug("SSE queue full, dropping event")
 
+    def broadcast_room_event(
+        self,
+        room_id: str,
+        event_type: str,
+        data: dict[str, Any],
+    ) -> None:
+        """Broadcast a room-scoped event (join, leave, write, read, etc.)."""
+        event = {"type": event_type, "room_id": room_id, **data}
+        queues = self._room_subscribers.get(room_id, [])
+        for queue in queues:
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                logger.debug("Room SSE queue full, dropping event for room %s", room_id)
+
     async def event_generator(self, entity_path: str = "*"):
         queue = self.subscribe(entity_path)
         try:
@@ -54,3 +83,17 @@ class SSEManager:
                 }
         finally:
             self.unsubscribe(entity_path, queue)
+
+    async def room_event_generator(self, room_id: str):
+        """SSE generator for room-scoped events."""
+        queue = self.subscribe_room(room_id)
+        try:
+            while True:
+                event = await queue.get()
+                event_type = event.pop("type", "room_event")
+                yield {
+                    "event": event_type,
+                    "data": json.dumps(event, default=str),
+                }
+        finally:
+            self.unsubscribe_room(room_id, queue)

--- a/packages/http-server/src/amfs_http/tenant_middleware.py
+++ b/packages/http-server/src/amfs_http/tenant_middleware.py
@@ -41,6 +41,14 @@ def apply_tenant_headers_from_request(request: Request) -> None:
         logger.warning("Invalid X-AMFS-Dashboard-Account-Id header")
         return
     set_tls_tenant_account_id(raw)
+    request.state.account_id = UUID(raw)
+
+    user_id_raw = request.headers.get("X-AMFS-Dashboard-User-Id")
+    if user_id_raw:
+        try:
+            request.state.user_id = UUID(user_id_raw)
+        except ValueError:
+            logger.warning("Invalid X-AMFS-Dashboard-User-Id header")
 
 
 def clear_tenant_headers() -> None:

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -113,6 +113,19 @@ Use `{repo}/{service-or-module}` paths (e.g. `myapp/auth`, `amfs/core-engine`). 
 ## Quality Feedback
 
 `amfs_write` responses include a `quality` score. If below 0.8, review `issues` and rewrite with more detail. Use `pattern_refs` to link related entries.
+
+## Rooms (Pro — collaborative entities)
+
+If available, rooms let multiple users' agents collaborate on a shared entity:
+
+1. **Discover rooms**: `amfs_my_rooms()` — see rooms you own or are invited to
+2. **Join a room**: `amfs_room_join(room_id)` — triggers auto-briefing with room history
+3. **Read & write normally**: entries on room entities are shared with all members
+4. **Check updates**: `amfs_room_updates(room_id, since="...")` — poll for new activity between tasks
+5. **Get room details**: `amfs_room_info(room_id)` — members, settings, discussion status
+6. **Leave when done**: `amfs_room_leave(room_id)` — knowledge snapshot preserved in your memory
+
+Room writes auto-propagate to all members. Cross-user reads through rooms are logged on both agent timelines.
 """
 
 mcp = FastMCP(name="amfs", instructions=_INSTRUCTIONS)

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -1416,6 +1416,198 @@ class AgentMemory:
         self._read_tracker.clear()
 
     # ------------------------------------------------------------------
+    # Room operations (Pro — requires HTTP adapter with rooms backend)
+    # ------------------------------------------------------------------
+
+    def room_join(self, room_id: str) -> dict[str, Any]:
+        """Join a room. The user owning this agent must have an accepted invite.
+
+        Returns membership details and a briefing of room history.
+        """
+        return self._room_request("POST", f"/api/v1/rooms/{room_id}/agents", {
+            "agent_id": self.agent_id,
+        })
+
+    def room_leave(self, room_id: str) -> dict[str, Any]:
+        """Leave a room. Knowledge snapshots are preserved in private memory."""
+        return self._room_request("DELETE", f"/api/v1/rooms/{room_id}/agents/{self.agent_id}")
+
+    def my_rooms(self) -> list[dict[str, Any]]:
+        """List rooms this agent's user owns or is invited to."""
+        result = self._room_request("GET", "/api/v1/rooms")
+        if isinstance(result, list):
+            return result
+        return result.get("rooms", []) if isinstance(result, dict) else []
+
+    def room_info(self, room_id: str) -> dict[str, Any]:
+        """Get room details including members, settings, and discussion status."""
+        return self._room_request("GET", f"/api/v1/rooms/{room_id}")
+
+    def room_updates(
+        self, room_id: str, *, since: str | None = None
+    ) -> dict[str, Any]:
+        """Get recent room activity (writes, joins, discussions, negotiations).
+
+        Args:
+            room_id: UUID of the room
+            since: ISO timestamp — only return events after this time
+        """
+        params = f"?since={since}" if since else ""
+        return self._room_request("GET", f"/api/v1/rooms/{room_id}/activity{params}")
+
+    # ------------------------------------------------------------------
+    # Room: Discussions
+    # ------------------------------------------------------------------
+
+    def room_discuss(
+        self,
+        room_id: str,
+        content: str,
+        *,
+        message_type: str = "message",
+        addressed_to: str | None = None,
+    ) -> dict[str, Any]:
+        """Post a discussion message in a room.
+
+        Args:
+            room_id: UUID of the room
+            content: Message text
+            message_type: One of 'message', 'question', 'answer', 'proposal', 'summary'
+            addressed_to: Optional agent_id to address the message to
+        """
+        return self._room_request("POST", f"/api/v1/rooms/{room_id}/discussions", {
+            "agent_id": self.agent_id,
+            "content": content,
+            "message_type": message_type,
+            "addressed_to": addressed_to,
+        })
+
+    def room_discussions(
+        self,
+        room_id: str,
+        *,
+        limit: int = 50,
+        since: str | None = None,
+    ) -> dict[str, Any]:
+        """List discussion messages in a room.
+
+        Args:
+            room_id: UUID of the room
+            limit: Max messages to return
+            since: ISO timestamp — only messages after this time
+        """
+        params = f"?limit={limit}"
+        if since:
+            params += f"&since={since}"
+        return self._room_request("GET", f"/api/v1/rooms/{room_id}/discussions{params}")
+
+    # ------------------------------------------------------------------
+    # Room: Negotiations
+    # ------------------------------------------------------------------
+
+    def negotiate_create(
+        self,
+        room_id: str,
+        title: str,
+        *,
+        description: str | None = None,
+        max_rounds: int = 10,
+    ) -> dict[str, Any]:
+        """Create a new negotiation session in a room.
+
+        Args:
+            room_id: UUID of the room
+            title: Topic of negotiation
+            description: Detailed description of what needs to be decided
+            max_rounds: Maximum rounds before timeout
+        """
+        return self._room_request("POST", f"/api/v1/rooms/{room_id}/negotiations", {
+            "title": title,
+            "description": description,
+            "agent_id": self.agent_id,
+            "max_rounds": max_rounds,
+        })
+
+    def negotiate_propose(
+        self,
+        room_id: str,
+        session_id: str,
+        *,
+        action: str = "propose",
+        proposal: dict[str, Any] | None = None,
+        rationale: str | None = None,
+    ) -> dict[str, Any]:
+        """Submit a proposal or response in a negotiation.
+
+        Args:
+            room_id: UUID of the room
+            session_id: UUID of the negotiation session
+            action: 'propose', 'counter', 'accept', 'reject', 'abstain'
+            proposal: JSON-serializable dict with values for each issue
+            rationale: Reasoning for this action
+        """
+        return self._room_request("POST", f"/api/v1/rooms/{room_id}/negotiations/{session_id}/propose", {
+            "agent_id": self.agent_id,
+            "action": action,
+            "proposal": proposal or {},
+            "rationale": rationale,
+        })
+
+    def negotiate_respond(
+        self,
+        room_id: str,
+        session_id: str,
+        *,
+        action: str,
+        rationale: str | None = None,
+    ) -> dict[str, Any]:
+        """Respond to the current proposal (accept/reject/counter).
+
+        Args:
+            room_id: UUID of the room
+            session_id: UUID of the negotiation session
+            action: 'accept', 'reject', 'counter', 'abstain'
+            rationale: Your reasoning
+        """
+        return self.negotiate_propose(
+            room_id, session_id, action=action, rationale=rationale,
+        )
+
+    def negotiate_status(
+        self,
+        room_id: str,
+        session_id: str,
+    ) -> dict[str, Any]:
+        """Get the current state of a negotiation session.
+
+        Args:
+            room_id: UUID of the room
+            session_id: UUID of the negotiation session
+        """
+        return self._room_request("GET", f"/api/v1/rooms/{room_id}/negotiations/{session_id}")
+
+    def _room_request(self, method: str, path: str, body: dict | None = None) -> Any:
+        """Send a request to the rooms API via the HTTP adapter."""
+        adapter = self._adapter
+        if hasattr(adapter, "_base_url") and hasattr(adapter, "_session"):
+            import requests
+            url = f"{adapter._base_url.rstrip('/')}{path}"
+            headers = getattr(adapter, "_headers", {})
+            if method == "GET":
+                resp = adapter._session.get(url, headers=headers)
+            elif method == "POST":
+                resp = adapter._session.post(url, json=body or {}, headers=headers)
+            elif method == "DELETE":
+                resp = adapter._session.delete(url, headers=headers)
+            else:
+                resp = adapter._session.request(method, url, json=body, headers=headers)
+            resp.raise_for_status()
+            return resp.json()
+        raise NotImplementedError(
+            "Room operations require the HTTP adapter (set AMFS_HTTP_URL)"
+        )
+
+    # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 

--- a/packages/sdk-typescript/src/memory.ts
+++ b/packages/sdk-typescript/src/memory.ts
@@ -626,7 +626,7 @@ export class AgentMemory {
     path: string,
     body?: Record<string, unknown>
   ): Promise<Record<string, unknown>> {
-    const adapter = this.adapter as Record<string, unknown>;
+    const adapter = this.adapter as unknown as Record<string, unknown>;
     const baseUrl = adapter._baseUrl ?? adapter.baseUrl;
     if (typeof baseUrl !== "string") {
       throw new Error("Room operations require the HTTP adapter (set AMFS_HTTP_URL)");

--- a/packages/sdk-typescript/src/memory.ts
+++ b/packages/sdk-typescript/src/memory.ts
@@ -519,6 +519,135 @@ export class AgentMemory {
   clearReadLog(): void {
     this.readTracker.clear();
   }
+
+  // ── Room operations (Pro — requires HTTP adapter with rooms backend) ──
+
+  /** Join a room. The user owning this agent must have an accepted invite. */
+  async roomJoin(roomId: string): Promise<Record<string, unknown>> {
+    return this._roomRequest("POST", `/api/v1/rooms/${roomId}/agents`, {
+      agent_id: this.agentId,
+    });
+  }
+
+  /** Leave a room. Knowledge snapshots are preserved in private memory. */
+  async roomLeave(roomId: string): Promise<Record<string, unknown>> {
+    return this._roomRequest("DELETE", `/api/v1/rooms/${roomId}/agents/${this.agentId}`);
+  }
+
+  /** List rooms this agent's user owns or is invited to. */
+  async myRooms(): Promise<Record<string, unknown>[]> {
+    const result = await this._roomRequest("GET", "/api/v1/rooms");
+    return Array.isArray(result) ? result : (result as Record<string, unknown>).rooms as Record<string, unknown>[] ?? [];
+  }
+
+  /** Get room details including members, settings, and discussion status. */
+  async roomInfo(roomId: string): Promise<Record<string, unknown>> {
+    return this._roomRequest("GET", `/api/v1/rooms/${roomId}`);
+  }
+
+  /** Get recent room activity (writes, joins, discussions, negotiations). */
+  async roomUpdates(roomId: string, options?: { since?: string }): Promise<Record<string, unknown>> {
+    const params = options?.since ? `?since=${options.since}` : "";
+    return this._roomRequest("GET", `/api/v1/rooms/${roomId}/activity${params}`);
+  }
+
+  // -- Discussions --
+
+  async roomDiscuss(
+    roomId: string,
+    content: string,
+    options?: { messageType?: string; addressedTo?: string }
+  ): Promise<Record<string, unknown>> {
+    return this._roomRequest("POST", `/api/v1/rooms/${roomId}/discussions`, {
+      agent_id: this.agentId,
+      content,
+      message_type: options?.messageType ?? "message",
+      addressed_to: options?.addressedTo ?? null,
+    });
+  }
+
+  async roomDiscussions(
+    roomId: string,
+    options?: { limit?: number; since?: string }
+  ): Promise<Record<string, unknown>> {
+    const params = new URLSearchParams();
+    if (options?.limit) params.set("limit", String(options.limit));
+    if (options?.since) params.set("since", options.since);
+    const qs = params.toString();
+    return this._roomRequest("GET", `/api/v1/rooms/${roomId}/discussions${qs ? `?${qs}` : ""}`);
+  }
+
+  // -- Negotiations --
+
+  async negotiateCreate(
+    roomId: string,
+    title: string,
+    options?: { description?: string; maxRounds?: number }
+  ): Promise<Record<string, unknown>> {
+    return this._roomRequest("POST", `/api/v1/rooms/${roomId}/negotiations`, {
+      title,
+      description: options?.description ?? null,
+      agent_id: this.agentId,
+      max_rounds: options?.maxRounds ?? 10,
+    });
+  }
+
+  async negotiatePropose(
+    roomId: string,
+    sessionId: string,
+    options?: { action?: string; proposal?: Record<string, unknown>; rationale?: string }
+  ): Promise<Record<string, unknown>> {
+    return this._roomRequest("POST", `/api/v1/rooms/${roomId}/negotiations/${sessionId}/propose`, {
+      agent_id: this.agentId,
+      action: options?.action ?? "propose",
+      proposal: options?.proposal ?? {},
+      rationale: options?.rationale ?? null,
+    });
+  }
+
+  async negotiateRespond(
+    roomId: string,
+    sessionId: string,
+    action: string,
+    options?: { rationale?: string }
+  ): Promise<Record<string, unknown>> {
+    return this.negotiatePropose(roomId, sessionId, {
+      action,
+      rationale: options?.rationale,
+    });
+  }
+
+  async negotiateStatus(roomId: string, sessionId: string): Promise<Record<string, unknown>> {
+    return this._roomRequest("GET", `/api/v1/rooms/${roomId}/negotiations/${sessionId}`);
+  }
+
+  private async _roomRequest(
+    method: string,
+    path: string,
+    body?: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    const adapter = this.adapter as Record<string, unknown>;
+    const baseUrl = adapter._baseUrl ?? adapter.baseUrl;
+    if (typeof baseUrl !== "string") {
+      throw new Error("Room operations require the HTTP adapter (set AMFS_HTTP_URL)");
+    }
+    const url = `${baseUrl.replace(/\/$/, "")}${path}`;
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    const apiKey = adapter._apiKey ?? adapter.apiKey;
+    if (typeof apiKey === "string") {
+      headers["Authorization"] = `Bearer ${apiKey}`;
+    }
+
+    const resp = await fetch(url, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!resp.ok) {
+      throw new Error(`Room API error: ${resp.status} ${resp.statusText}`);
+    }
+    return resp.json() as Promise<Record<string, unknown>>;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Server hooks**: `mount_rooms()` optional import in HTTP server for Pro rooms integration
- **SSE extension**: Room-scoped event broadcasting (`subscribe_room`, `broadcast_room_event`, `room_event_generator`) in `SSEManager`
- **Tenant middleware**: Forward `user_id` via `X-AMFS-Dashboard-User-Id` proxy header and set `request.state.user_id` / `request.state.account_id`
- **MCP instructions**: Added "Rooms (Pro)" workflow section covering discovery, joining, polling, and leaving
- **Python SDK**: Added `room_join`, `room_leave`, `my_rooms`, `room_info`, `room_updates`, `room_discuss`, `room_discussions`, `negotiate_create`, `negotiate_propose`, `negotiate_respond`, `negotiate_status` to `AgentMemory`
- **TypeScript SDK**: Added matching `roomJoin`, `roomLeave`, `myRooms`, `roomInfo`, `roomUpdates`, `roomDiscuss`, `roomDiscussions`, `negotiateCreate`, `negotiatePropose`, `negotiateRespond`, `negotiateStatus` to `AgentMemory`

These are the OSS-side hooks that enable the proprietary `amfs-rooms` package (in `amfs-internal`) to integrate when installed. Without the Pro package, all existing behavior is unchanged.