### PR TITLE
fix: remove EXCEPTION handlers from constraint migrations

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -531,71 +531,51 @@ class PostgresAdapter(AdapterABC):
 
         # Multi-tenant unique constraints: include account_id so different
         # tenants can have entries/agents/branches/tags with the same names.
+        # Use plain SQL (no DO $$ EXCEPTION block) so failures are visible
+        # rather than silently swallowed by PL/pgSQL subtransaction rollback.
         cur.execute("""
-            DO $$ BEGIN
-                ALTER TABLE amfs_memory_entries
-                    DROP CONSTRAINT IF EXISTS uq_entry_version;
-                ALTER TABLE amfs_memory_entries
-                    ADD CONSTRAINT uq_entry_version
-                    UNIQUE (namespace, entity_path, key, version, account_id);
-            EXCEPTION WHEN others THEN
-                RAISE NOTICE 'uq_entry_version migration skipped: %', SQLERRM;
-            END $$
+            ALTER TABLE amfs_memory_entries
+                DROP CONSTRAINT IF EXISTS uq_entry_version
+        """)
+        cur.execute("""
+            ALTER TABLE amfs_memory_entries
+                ADD CONSTRAINT uq_entry_version
+                UNIQUE (namespace, entity_path, key, version, account_id)
         """)
         cur.execute("""
             DO $$ BEGIN
                 IF EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE table_name = 'amfs_agents') THEN
-                    ALTER TABLE amfs_agents
-                        DROP CONSTRAINT IF EXISTS uq_agent;
-                    ALTER TABLE amfs_agents
-                        ADD CONSTRAINT uq_agent
-                        UNIQUE (namespace, agent_id, account_id);
+                    EXECUTE 'ALTER TABLE amfs_agents DROP CONSTRAINT IF EXISTS uq_agent';
+                    EXECUTE 'ALTER TABLE amfs_agents ADD CONSTRAINT uq_agent UNIQUE (namespace, agent_id, account_id)';
                 END IF;
-            EXCEPTION WHEN others THEN
-                RAISE NOTICE 'uq_agent migration skipped: %', SQLERRM;
             END $$
         """)
         cur.execute("""
             DO $$ BEGIN
                 IF EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE table_name = 'amfs_branches') THEN
-                    ALTER TABLE amfs_branches
-                        DROP CONSTRAINT IF EXISTS uq_branch_name;
-                    ALTER TABLE amfs_branches
-                        ADD CONSTRAINT uq_branch_name
-                        UNIQUE (namespace, name, account_id);
+                    EXECUTE 'ALTER TABLE amfs_branches DROP CONSTRAINT IF EXISTS uq_branch_name';
+                    EXECUTE 'ALTER TABLE amfs_branches ADD CONSTRAINT uq_branch_name UNIQUE (namespace, name, account_id)';
                 END IF;
-            EXCEPTION WHEN others THEN
-                RAISE NOTICE 'uq_branch_name migration skipped: %', SQLERRM;
             END $$
         """)
         cur.execute("""
             DO $$ BEGIN
                 IF EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE table_name = 'amfs_tags') THEN
-                    ALTER TABLE amfs_tags
-                        DROP CONSTRAINT IF EXISTS uq_tag_name;
-                    ALTER TABLE amfs_tags
-                        ADD CONSTRAINT uq_tag_name
-                        UNIQUE (namespace, name, account_id);
+                    EXECUTE 'ALTER TABLE amfs_tags DROP CONSTRAINT IF EXISTS uq_tag_name';
+                    EXECUTE 'ALTER TABLE amfs_tags ADD CONSTRAINT uq_tag_name UNIQUE (namespace, name, account_id)';
                 END IF;
-            EXCEPTION WHEN others THEN
-                RAISE NOTICE 'uq_tag_name migration skipped: %', SQLERRM;
             END $$
         """)
         cur.execute("""
             DO $$ BEGIN
                 IF EXISTS (SELECT 1 FROM information_schema.tables
                            WHERE table_name = 'amfs_branch_access') THEN
-                    ALTER TABLE amfs_branch_access
-                        DROP CONSTRAINT IF EXISTS uq_branch_access;
-                    ALTER TABLE amfs_branch_access
-                        ADD CONSTRAINT uq_branch_access
-                        UNIQUE (namespace, branch_name, grantee_type, grantee_id, account_id);
+                    EXECUTE 'ALTER TABLE amfs_branch_access DROP CONSTRAINT IF EXISTS uq_branch_access';
+                    EXECUTE 'ALTER TABLE amfs_branch_access ADD CONSTRAINT uq_branch_access UNIQUE (namespace, branch_name, grantee_type, grantee_id, account_id)';
                 END IF;
-            EXCEPTION WHEN others THEN
-                RAISE NOTICE 'uq_branch_access migration skipped: %', SQLERRM;
             END $$
         """)
 


### PR DESCRIPTION
## Summary

- The `DO $$ BEGIN ... EXCEPTION WHEN others THEN ... END $$` pattern in the tenant unique constraint migrations (PR #183) silently swallows errors via PL/pgSQL subtransaction rollback
- When `ADD CONSTRAINT` fails inside the EXCEPTION block, the `DROP CONSTRAINT` that ran before it is **also rolled back** — leaving the old constraint in place with no error visible
- This is why the user's writes are still hitting `UniqueViolation` on `uq_entry_version` even after #183 was deployed: the migration appeared to succeed but the constraint was never actually updated

### Changes
- `amfs_memory_entries`: use plain SQL `DROP CONSTRAINT IF EXISTS` + `ADD CONSTRAINT` (no table-existence check needed, no exception swallowing)
- Other tables (`amfs_agents`, `amfs_branches`, `amfs_tags`, `amfs_branch_access`): keep `DO $$ ... IF EXISTS ... $$` for table-existence check but **remove the EXCEPTION handler** so any failure propagates to Python and is logged