### PR TITLE
fix: use explicit transactions for constraint migrations, fix memory singleton

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -531,53 +531,89 @@ class PostgresAdapter(AdapterABC):
 
         # Multi-tenant unique constraints: include account_id so different
         # tenants can have entries/agents/branches/tags with the same names.
-        # Use plain SQL (no DO $$ EXCEPTION block) so failures are visible
-        # rather than silently swallowed by PL/pgSQL subtransaction rollback.
-        cur.execute("""
-            ALTER TABLE amfs_memory_entries
-                DROP CONSTRAINT IF EXISTS uq_entry_version
-        """)
-        cur.execute("""
-            ALTER TABLE amfs_memory_entries
-                ADD CONSTRAINT uq_entry_version
-                UNIQUE (namespace, entity_path, key, version, account_id)
-        """)
-        cur.execute("""
-            DO $$ BEGIN
-                IF EXISTS (SELECT 1 FROM information_schema.tables
-                           WHERE table_name = 'amfs_agents') THEN
-                    EXECUTE 'ALTER TABLE amfs_agents DROP CONSTRAINT IF EXISTS uq_agent';
-                    EXECUTE 'ALTER TABLE amfs_agents ADD CONSTRAINT uq_agent UNIQUE (namespace, agent_id, account_id)';
-                END IF;
-            END $$
-        """)
-        cur.execute("""
-            DO $$ BEGIN
-                IF EXISTS (SELECT 1 FROM information_schema.tables
-                           WHERE table_name = 'amfs_branches') THEN
-                    EXECUTE 'ALTER TABLE amfs_branches DROP CONSTRAINT IF EXISTS uq_branch_name';
-                    EXECUTE 'ALTER TABLE amfs_branches ADD CONSTRAINT uq_branch_name UNIQUE (namespace, name, account_id)';
-                END IF;
-            END $$
-        """)
-        cur.execute("""
-            DO $$ BEGIN
-                IF EXISTS (SELECT 1 FROM information_schema.tables
-                           WHERE table_name = 'amfs_tags') THEN
-                    EXECUTE 'ALTER TABLE amfs_tags DROP CONSTRAINT IF EXISTS uq_tag_name';
-                    EXECUTE 'ALTER TABLE amfs_tags ADD CONSTRAINT uq_tag_name UNIQUE (namespace, name, account_id)';
-                END IF;
-            END $$
-        """)
-        cur.execute("""
-            DO $$ BEGIN
-                IF EXISTS (SELECT 1 FROM information_schema.tables
-                           WHERE table_name = 'amfs_branch_access') THEN
-                    EXECUTE 'ALTER TABLE amfs_branch_access DROP CONSTRAINT IF EXISTS uq_branch_access';
-                    EXECUTE 'ALTER TABLE amfs_branch_access ADD CONSTRAINT uq_branch_access UNIQUE (namespace, branch_name, grantee_type, grantee_id, account_id)';
-                END IF;
-            END $$
-        """)
+        #
+        # Each DROP+ADD pair runs inside an explicit transaction (BEGIN/COMMIT)
+        # so that if ADD fails, the DROP is rolled back and the old constraint
+        # stays in place.  The pool uses autocommit=True, so without an
+        # explicit transaction each statement would commit immediately.
+        _CONSTRAINT_MIGRATIONS: list[tuple[str, str, str, list[str]]] = [
+            (
+                "amfs_memory_entries",
+                "uq_entry_version",
+                "UNIQUE (namespace, entity_path, key, version, account_id)",
+                ["namespace", "entity_path", "key", "version", "account_id"],
+            ),
+            (
+                "amfs_agents",
+                "uq_agent",
+                "UNIQUE (namespace, agent_id, account_id)",
+                ["namespace", "agent_id", "account_id"],
+            ),
+            (
+                "amfs_branches",
+                "uq_branch_name",
+                "UNIQUE (namespace, name, account_id)",
+                ["namespace", "name", "account_id"],
+            ),
+            (
+                "amfs_tags",
+                "uq_tag_name",
+                "UNIQUE (namespace, name, account_id)",
+                ["namespace", "name", "account_id"],
+            ),
+            (
+                "amfs_branch_access",
+                "uq_branch_access",
+                "UNIQUE (namespace, branch_name, grantee_type, grantee_id, account_id)",
+                ["namespace", "branch_name", "grantee_type", "grantee_id", "account_id"],
+            ),
+        ]
+        for table, cname, cdef, cols in _CONSTRAINT_MIGRATIONS:
+            try:
+                cur.execute(
+                    "SELECT 1 FROM information_schema.tables "
+                    "WHERE table_schema = 'public' AND table_name = %s",
+                    (table,),
+                )
+                if cur.fetchone() is None:
+                    continue
+
+                col_list = ", ".join(cols)
+                null_clause = " AND ".join(f"{c} IS NOT NULL" for c in cols)
+
+                cur.execute(f"""
+                    DELETE FROM "{table}" a USING (
+                        SELECT ctid, ROW_NUMBER() OVER (
+                            PARTITION BY {col_list} ORDER BY ctid
+                        ) AS rn
+                        FROM "{table}"
+                        WHERE {null_clause}
+                    ) b
+                    WHERE a.ctid = b.ctid AND b.rn > 1
+                """)
+                if cur.rowcount and cur.rowcount > 0:
+                    logger.warning(
+                        "Removed %d duplicate rows from %s before adding %s",
+                        cur.rowcount, table, cname,
+                    )
+
+                cur.execute("BEGIN")
+                cur.execute(
+                    f'ALTER TABLE "{table}" DROP CONSTRAINT IF EXISTS {cname}'
+                )
+                cur.execute(
+                    f'ALTER TABLE "{table}" ADD CONSTRAINT {cname} {cdef}'
+                )
+                cur.execute("COMMIT")
+            except Exception as exc:
+                try:
+                    cur.execute("ROLLBACK")
+                except Exception:
+                    pass
+                logger.warning(
+                    "Constraint migration %s.%s failed (non-fatal): %s",
+                    table, cname, exc,
+                )
 
     def _detect_optional_columns(self) -> None:
         """Check whether optional columns (embedding, search_tsv) exist.

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -152,21 +152,22 @@ def _get_memory() -> AgentMemory:
     ttl_sweep_interval = float(ttl_interval_str) if ttl_interval_str else 300.0
 
     logger.info("AMFS HTTP server starting — agent_id=%s", agent_id)
-    _memory = AgentMemory(
+    mem = AgentMemory(
         agent_id=agent_id,
         config_path=None,
         adapter=None,
         ttl_sweep_interval=ttl_sweep_interval,
     )
 
-    _memory._config = config
+    mem._config = config
     from amfs.factory import create_adapter_from_config
 
     adapter = create_adapter_from_config(config)
-    _memory._adapter = adapter
-    _memory._engine._adapter = adapter
-    _memory._propagator._adapter = adapter
+    mem._adapter = adapter
+    mem._engine._adapter = adapter
+    mem._propagator._adapter = adapter
 
+    _memory = mem
     return _memory
 
 


### PR DESCRIPTION
## Summary

PR #184 removed the EXCEPTION handlers but introduced three new bugs:

1. **Constraint migration + autocommit**: The connection pool uses `autocommit=True`, so `DROP CONSTRAINT` was permanently committed before `ADD CONSTRAINT` ran. When ADD failed ("Duplicate keys exist"), the constraint was gone forever with no rollback. Now each DROP+ADD pair runs inside an explicit `BEGIN`/`COMMIT` block so they roll back together on failure.

2. **Duplicate data handling**: Before adding each constraint, the migration now removes any duplicate rows that would violate it. This handles orphaned data from previous failed purges or pre-multi-tenancy entries.

3. **Memory singleton poisoning**: `_get_memory()` set the global `_memory` before the adapter was created. If adapter creation failed (because the Postgres constraint migration crashed), subsequent calls returned the broken singleton (adapter=None), causing `_get_db_pool()` to return None — which made all admin endpoints (API keys, teams, etc.) return "requires a Postgres backend" errors. Now `_memory` is only set after full initialization succeeds.

## Symptoms this fixes

- "API key management requires a Postgres backend" during onboarding
- Dashboard showing 0 entries/agents/outcomes despite MCP writes working
- Empty API keys page despite key created during onboarding