### PR TITLE
feat: add team_id and is_account_admin to tenant context

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -100,14 +100,28 @@ class _TenantRLSConnection:
         self._inner_ctx = inner_ctx
 
     def __enter__(self) -> Any:
-        from amfs_postgres.tenant_context import get_request_tenant_account_id
+        from amfs_postgres.tenant_context import (
+            get_request_tenant_account_id,
+            get_request_tenant_team_id,
+            get_request_is_account_admin,
+        )
 
         conn = self._inner_ctx.__enter__()
         tid = get_request_tenant_account_id()
+        team_id = get_request_tenant_team_id()
+        is_admin = get_request_is_account_admin()
         with conn.cursor() as cur:
             cur.execute(
                 "SELECT set_config('amfs.current_account_id', %s, false)",
                 (tid if tid else "",),
+            )
+            cur.execute(
+                "SELECT set_config('amfs.current_team_id', %s, false)",
+                (team_id if team_id else "",),
+            )
+            cur.execute(
+                "SELECT set_config('amfs.is_account_admin', %s, false)",
+                ("true" if is_admin else "false",),
             )
         return conn
 

--- a/packages/adapters/postgres/src/amfs_postgres/tenant_context.py
+++ b/packages/adapters/postgres/src/amfs_postgres/tenant_context.py
@@ -1,4 +1,10 @@
-"""Per-request tenant account id for Postgres RLS (thread-local for HTTP server workers)."""
+"""Per-request tenant context for Postgres RLS (thread-local for HTTP server workers).
+
+Stores account_id, team_id, and is_account_admin for two-layer tenancy:
+  - account_id  -> amfs.current_account_id  (outer boundary)
+  - team_id     -> amfs.current_team_id     (inner boundary)
+  - is_admin    -> amfs.is_account_admin    (admin bypass)
+"""
 
 from __future__ import annotations
 
@@ -6,6 +12,8 @@ import threading
 
 _tls = threading.local()
 
+
+# -- account_id --
 
 def set_tls_tenant_account_id(account_id: str | None) -> None:
     """Called from HTTP middleware before handling a request."""
@@ -21,3 +29,33 @@ def clear_tls_tenant_account_id() -> None:
 def get_request_tenant_account_id() -> str | None:
     """Read by PostgresAdapter when checking out a connection."""
     return getattr(_tls, "account_id", None)
+
+
+# -- team_id --
+
+def set_tls_tenant_team_id(team_id: str | None) -> None:
+    _tls.team_id = team_id or None
+
+
+def clear_tls_tenant_team_id() -> None:
+    if hasattr(_tls, "team_id"):
+        delattr(_tls, "team_id")
+
+
+def get_request_tenant_team_id() -> str | None:
+    return getattr(_tls, "team_id", None)
+
+
+# -- is_account_admin --
+
+def set_tls_is_account_admin(is_admin: bool) -> None:
+    _tls.is_account_admin = is_admin
+
+
+def clear_tls_is_account_admin() -> None:
+    if hasattr(_tls, "is_account_admin"):
+        delattr(_tls, "is_account_admin")
+
+
+def get_request_is_account_admin() -> bool:
+    return getattr(_tls, "is_account_admin", False)


### PR DESCRIPTION
## Summary

Extends the per-request thread-local tenant context to carry `team_id` and `is_account_admin` alongside `account_id`, enabling per-team RLS policies in the Pro tenant layer.

**Changes:**

- **`tenant_context.py`**: Add `set_tls_tenant_team_id`, `get_request_tenant_team_id`, `set_tls_is_account_admin`, `get_request_is_account_admin` (plus clear functions)
- **`adapter.py`** (`_TenantRLSConnection.__enter__`): Set 3 Postgres GUCs on every connection checkout: `amfs.current_account_id` (existing), `amfs.current_team_id` (new), `amfs.is_account_admin` (new)

No changes to the adapter's `write()` method — `team_id` is populated via column `DEFAULT` from the GUC (set in the Pro migration).