### PR TITLE
fix: briefing returns empty despite entity having data

### DIFF
--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "amfs-mcp-server"
-version = "0.7.1"
+version = "0.7.2"
 description = "AMFS MCP Server — expose Agent Memory as MCP tools for Cursor and Claude Code"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 dependencies = [
     "amfs",
-    "amfs-adapter-http>=0.1.1",
+    "amfs-adapter-http>=0.1.3",
     "fastmcp>=2.0",
 ]
 

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -1230,18 +1230,40 @@ def amfs_briefing(
         agent_id=agent_id,
         limit=limit,
     )
-    if not digests:
-        hint = (
-            "No compiled briefings yet. "
-            "Try amfs_my_rooms() to check for shared rooms with team knowledge, "
-            "or use amfs_search() / amfs_recall() to find existing memories. "
-            "Use amfs_write() to start building knowledge."
+    if digests:
+        return json.dumps(
+            [d.model_dump(mode="json") for d in digests],
+            default=str,
         )
-        return json.dumps({"status": "empty", "message": hint})
-    return json.dumps(
-        [d.model_dump(mode="json") for d in digests],
-        default=str,
+
+    # Fallback: if adapter.briefing() is unavailable (older amfs-adapter-http)
+    # or Cortex has no compiled digests yet, synthesize a summary from entries.
+    entries = mem.list(entity_path) if entity_path else []
+    if entries:
+        keys = [e.key for e in entries]
+        agents = sorted({e.provenance.agent_id for e in entries})
+        avg_conf = sum(e.confidence for e in entries) / len(entries)
+        return json.dumps({
+            "status": "synthesized",
+            "message": (
+                "No compiled Cortex digests available. "
+                "Showing a summary built from existing memory entries."
+            ),
+            "entity_path": entity_path,
+            "entry_count": len(entries),
+            "avg_confidence": round(avg_conf, 2),
+            "contributing_agents": agents,
+            "keys": keys,
+            "entries": [_serialize_entry(e) for e in entries[:limit]],
+        }, default=str)
+
+    hint = (
+        "No compiled briefings yet. "
+        "Try amfs_my_rooms() to check for shared rooms with team knowledge, "
+        "or use amfs_search() / amfs_recall() to find existing memories. "
+        "Use amfs_write() to start building knowledge."
     )
+    return json.dumps({"status": "empty", "message": hint})
 
 
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Root cause**: `amfs-mcp-server` required `amfs-adapter-http>=0.1.1`, but `briefing()` and `list_digests()` were only added in `0.1.3`. Agents with older cached adapter versions got silent empty responses from `amfs_briefing` while `amfs_search` worked fine.
- Bumps `amfs-adapter-http` minimum to `>=0.1.3`
- Adds a synthesized fallback in `amfs_briefing`: when Cortex digests are unavailable, but entries exist, returns a summary from `mem.list()` (entry count, keys, contributing agents, avg confidence, entries) instead of the unhelpful "No compiled briefings yet" message
- Bumps version to `0.6.1`