### PR TITLE
fix: propagate team_id and is_account_admin in dashboard tenant middleware

### DIFF
--- a/packages/http-server/src/amfs_http/tenant_middleware.py
+++ b/packages/http-server/src/amfs_http/tenant_middleware.py
@@ -23,6 +23,8 @@ def apply_tenant_headers_from_request(request: Request) -> None:
     try:
         from amfs_postgres.tenant_context import (
             set_tls_tenant_account_id,
+            set_tls_tenant_team_id,
+            set_tls_is_account_admin,
         )
     except ImportError:
         return
@@ -43,6 +45,17 @@ def apply_tenant_headers_from_request(request: Request) -> None:
     set_tls_tenant_account_id(raw)
     request.state.account_id = UUID(raw)
 
+    team_raw = request.headers.get("X-AMFS-Dashboard-Team-Id")
+    if team_raw:
+        try:
+            UUID(team_raw)
+            set_tls_tenant_team_id(team_raw)
+        except ValueError:
+            logger.warning("Invalid X-AMFS-Dashboard-Team-Id header")
+
+    is_admin = request.headers.get("X-AMFS-Dashboard-Is-Admin") == "true"
+    set_tls_is_account_admin(is_admin)
+
     user_id_raw = request.headers.get("X-AMFS-Dashboard-User-Id")
     if user_id_raw:
         try:
@@ -53,7 +66,13 @@ def apply_tenant_headers_from_request(request: Request) -> None:
 
 def clear_tenant_headers() -> None:
     try:
-        from amfs_postgres.tenant_context import clear_tls_tenant_account_id
+        from amfs_postgres.tenant_context import (
+            clear_tls_tenant_account_id,
+            clear_tls_tenant_team_id,
+            clear_tls_is_account_admin,
+        )
     except ImportError:
         return
     clear_tls_tenant_account_id()
+    clear_tls_tenant_team_id()
+    clear_tls_is_account_admin()


### PR DESCRIPTION
## Summary

- The OSS `tenant_middleware.py` now reads `X-AMFS-Dashboard-Team-Id` and `X-AMFS-Dashboard-Is-Admin` headers from dashboard proxy requests and sets the corresponding thread-local values (`set_tls_tenant_team_id`, `set_tls_is_account_admin`).
- `clear_tenant_headers()` now clears all three TLS slots (account, team, admin) to prevent cross-request leakage.
- Without this fix, `amfs.current_team_id` was always empty in the Postgres session, causing every RLS policy's `NULLIF(current_setting('amfs.current_team_id', true), '') IS NULL` condition to evaluate TRUE — granting account-wide visibility regardless of team membership.