### PR TITLE
fix: user-level visibility scope for multi-tenant API isolation

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -629,6 +629,11 @@ class PostgresAdapter(AdapterABC):
                     table, cname, exc,
                 )
 
+        cur.execute("""
+            ALTER TABLE amfs_api_keys
+            ADD COLUMN IF NOT EXISTS created_by UUID
+        """)
+
     def _detect_optional_columns(self) -> None:
         """Check whether optional columns (embedding, search_tsv) exist.
 

--- a/packages/adapters/postgres/src/amfs_postgres/schema.sql
+++ b/packages/adapters/postgres/src/amfs_postgres/schema.sql
@@ -91,7 +91,8 @@ CREATE TABLE IF NOT EXISTS amfs_api_keys (
     rate_limit_rpm INTEGER DEFAULT 120,
     last_used TIMESTAMPTZ,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    expires_at TIMESTAMPTZ
+    expires_at TIMESTAMPTZ,
+    created_by UUID
 );
 
 CREATE INDEX IF NOT EXISTS idx_api_keys_namespace

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -2222,12 +2222,14 @@ async def create_api_key(
     key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
     ns = _get_namespace()
 
+    user_id = getattr(request.state, "user_id", None)
+
     with pool.connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 """INSERT INTO amfs_api_keys
-                       (namespace, name, key_hash, prefix, key_type, scopes, rate_limit_rpm, expires_at)
-                   VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s)
+                       (namespace, name, key_hash, prefix, key_type, scopes, rate_limit_rpm, expires_at, created_by)
+                   VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s)
                    RETURNING id, created_at""",
                 (
                     ns,
@@ -2238,6 +2240,7 @@ async def create_api_key(
                     json.dumps(req.scopes),
                     req.rate_limit_rpm,
                     req.expires_at,
+                    str(user_id) if user_id else None,
                 ),
             )
             row = cur.fetchone()


### PR DESCRIPTION
## Summary

- **Adds `created_by UUID` column to `amfs_api_keys`** (schema + additive migration) so OSS keys created from the dashboard track which user created them
- **Populates `created_by` on key creation** — the `POST /api/v1/admin/api-keys` endpoint now captures `user_id` from the dashboard session headers
- **Enforces user-scoped visibility on all API endpoints** (from prior commit) — `UserVisibilityFilter` restricts list/search/stats/agents results to only the user's own agents + room co-members

### Root Cause
The dashboard creates keys in `amfs_api_keys` (OSS table, SHA-256 hash), but the Pro middleware only queried the Pro `api_keys` table for `created_by`. Since OSS keys weren't there, `user_id` was never set on the request, the visibility filter was never created, and invited users could see all agents in the account via the API.