### PR TITLE
feat: capture agent session metadata (model, tools, platform) in MCP

### DIFF
--- a/.cursor/rules/amfs-memory.mdc
+++ b/.cursor/rules/amfs-memory.mdc
@@ -13,8 +13,10 @@ You have access to AMFS (Agent Memory File System) through MCP tools. AMFS gives
 > **You MUST call `amfs_set_identity` before doing anything else.** Without it, all your work is attributed to a generic default and you won't appear as a distinct agent on the AMFS dashboard.
 
 ```
-amfs_set_identity("<role-name>", "<one-line description of current task>")
+amfs_set_identity("<role-name>", "<one-line description of current task>", model="<your-model-name>")
 ```
+
+Always pass `model=` with your LLM model name (e.g. `"claude-4-opus"`, `"gpt-4o"`, `"claude-3.5-sonnet"`). This is recorded in decision traces so we know which model made each decision.
 
 **Sticky identity**: Once set, the identity is saved to `~/.amfs/.identity` and automatically restored in future sessions — even across process restarts (e.g. Claude Desktop). You only need to call `amfs_set_identity` again to change roles or update the description.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ You have access to AMFS (Agent Memory File System) through MCP tools. AMFS gives
 ## Available MCP Tools
 
 ### Identity
-- `amfs_set_identity(name, description?)` — set your agent identity. Persisted to disk (sticky) — survives process restarts. Call first.
+- `amfs_set_identity(name, description?, model?, client_name?, tools_available?)` — set your agent identity. Persisted to disk (sticky) — survives process restarts. Always pass `model=` with your LLM model name. Call first.
 - `amfs_whoami()` — check which identity is active and where it came from (in-process, sticky file, or auto-detected)
 - `amfs_reset_identity()` — clear the sticky identity and revert to auto-detection
 
@@ -37,8 +37,10 @@ You have access to AMFS (Agent Memory File System) through MCP tools. AMFS gives
 > **You MUST call `amfs_set_identity` before doing anything else.** Without it, all your work is attributed to a generic default and you won't appear as a distinct agent on the AMFS dashboard.
 
 ```
-amfs_set_identity("<role-name>", "<one-line description of current task>")
+amfs_set_identity("<role-name>", "<one-line description of current task>", model="<your-model-name>")
 ```
+
+Always pass `model=` with your LLM model name (e.g. `"claude-4-opus"`, `"gpt-4o"`, `"claude-3.5-sonnet"`). This is recorded in decision traces so we know which model made each decision.
 
 **Sticky identity**: Once set, the identity is saved to `~/.amfs/.identity` and automatically restored in future sessions — even across process restarts (e.g. Claude Desktop). You only need to call `amfs_set_identity` again to change roles or update the description.
 

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-core"
-version = "0.3.2"
+version = "0.3.3"
 description = "AMFS core models, engine, and adapter ABC"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/core/src/amfs_core/models.py
+++ b/packages/core/src/amfs_core/models.py
@@ -291,6 +291,7 @@ class DecisionTrace(BaseModel):
     query_events: list[QueryEvent] = Field(default_factory=list)
     error_events: list[ErrorEvent] = Field(default_factory=list)
     state_diff: MemoryStateDiff | None = None
+    session_metadata: SessionMetadata | None = None
     session_started_at: datetime | None = None
     session_ended_at: datetime | None = None
     session_duration_ms: float | None = None
@@ -515,6 +516,22 @@ class EventType(str, Enum):
     SNAPSHOT_RECOVERED = "snapshot_recovered"
 
 
+class SessionMetadata(BaseModel):
+    """Metadata about the agent's runtime environment.
+
+    Captured once per session (typically via amfs_set_identity) and attached
+    to the AgentProfile and DecisionTrace so every trace records which model,
+    platform, and toolset produced the decisions.
+    """
+
+    model: str | None = None
+    client_name: str | None = None
+    platform: str | None = None
+    tools_available: list[str] = Field(default_factory=list)
+    mcp_client_id: str | None = None
+    mcp_session_id: str | None = None
+
+
 class AgentProfile(BaseModel):
     """Declarative profile describing an agent's role and defaults."""
 
@@ -522,6 +539,7 @@ class AgentProfile(BaseModel):
     default_branch: str = "main"
     auto_context_paths: list[str] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list)
+    session_metadata: SessionMetadata | None = None
 
 
 class AgentCapability(BaseModel):

--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-mcp-server"
-version = "0.6.0"
+version = "0.7.0"
 description = "AMFS MCP Server — expose Agent Memory as MCP tools for Cursor and Claude Code"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -29,9 +29,9 @@ import time
 from pathlib import Path
 from typing import Any
 
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP
 
-from amfs import AgentMemory, MemoryType, OutcomeType
+from amfs import AgentMemory, MemoryType, OutcomeType, SessionMetadata
 from amfs.config import load_config_or_default
 from amfs_core.abc import AdapterABC
 from amfs_core.models import AMFSConfig, LayerConfig
@@ -53,10 +53,10 @@ You have access to AMFS (Agent Memory File System) — persistent memory that su
 You MUST call `amfs_set_identity` before doing anything else. Without it, all your work is attributed to a generic default.
 
 ```
-amfs_set_identity("<role-name>", "<one-line description of current task>")
+amfs_set_identity("<role-name>", "<one-line description of current task>", model="<your-model-name>")
 ```
 
-Use kebab-case role/domain names that persist across conversations (e.g. "dashboard-agent", "api-agent"). If continuing work a previous agent started, use the same name.
+Use kebab-case role/domain names that persist across conversations (e.g. "dashboard-agent", "api-agent"). If continuing work a previous agent started, use the same name. Always pass `model=` with your LLM model name (e.g. "claude-4-opus", "gpt-4o") — this is recorded in decision traces.
 
 **Sticky identity**: Once set, your identity persists across sessions automatically. You only need to call `amfs_set_identity` if you want to change to a different role or update your description.
 
@@ -174,6 +174,7 @@ _adapter: AdapterABC | None = None
 _memories: dict[str, AgentMemory] = {}
 _active_identity: str | None = None
 _last_activity: float = 0.0
+_session_metadata: SessionMetadata | None = None
 
 _IDENTITY_COOLDOWN_SECONDS = 30
 
@@ -321,6 +322,38 @@ def _resolve_config() -> AMFSConfig:
     return load_config_or_default()
 
 
+def _enrich_metadata_from_context(ctx: Context | None) -> None:
+    """Passively capture MCP client metadata from the FastMCP Context.
+
+    Called on tool invocations that have a Context parameter.  Merges
+    client_id and session_id from the MCP handshake into the module-level
+    SessionMetadata without overwriting fields the agent explicitly set.
+    """
+    global _session_metadata
+    if ctx is None:
+        return
+    try:
+        client_id = ctx.client_id
+        session_id = ctx.session_id if ctx.request_context else None
+    except Exception:
+        return
+
+    if client_id is None and session_id is None:
+        return
+
+    if _session_metadata is None:
+        _session_metadata = SessionMetadata()
+
+    if client_id and not _session_metadata.mcp_client_id:
+        _session_metadata.mcp_client_id = client_id
+    if session_id and not _session_metadata.mcp_session_id:
+        _session_metadata.mcp_session_id = session_id
+
+    mem = _memories.get(_active_identity or "")
+    if mem:
+        mem.session_metadata = _session_metadata
+
+
 def _serialize_entry(entry: Any) -> dict[str, Any]:
     """Convert a MemoryEntry to a JSON-safe dict for MCP responses."""
     data = entry.model_dump(mode="json")
@@ -334,7 +367,14 @@ def _serialize_entry(entry: Any) -> dict[str, Any]:
 
 
 @mcp.tool
-def amfs_set_identity(name: str, description: str | None = None) -> str:
+async def amfs_set_identity(
+    name: str,
+    description: str | None = None,
+    model: str | None = None,
+    client_name: str | None = None,
+    tools_available: list[str] | None = None,
+    ctx: Context | None = None,
+) -> str:
     """Set the agent identity for this conversation. CALL THIS FIRST before any other AMFS tool.
 
     Without this, all your work is attributed to a generic default identity.
@@ -345,7 +385,7 @@ def amfs_set_identity(name: str, description: str | None = None) -> str:
     session or the same session), this is a no-op.
 
     MANDATORY WORKFLOW — follow this order every session:
-    1. amfs_set_identity(name, description)  ← you are here
+    1. amfs_set_identity(name, description, model)  ← you are here
     2. amfs_briefing(entity_path="repo/module")  ← get compiled context before starting work
     3. Do your work, calling amfs_write() for important discoveries, decisions, and patterns
     4. amfs_record_context() for external tool results and user decisions as they happen
@@ -365,21 +405,47 @@ def amfs_set_identity(name: str, description: str | None = None) -> str:
         name: Short, descriptive name (e.g. "dashboard-fixer", "auth-debugger",
               "mcp-integration"). Use kebab-case.
         description: Optional one-line description of what this agent is doing.
+        model: The LLM model you are running as (e.g. "claude-4-opus",
+               "gpt-4o", "claude-3.5-sonnet"). You know your own model name — pass it here.
+        client_name: The IDE or client platform (e.g. "cursor", "claude-code",
+                     "windsurf", "cline"). Auto-detected when possible.
+        tools_available: Optional list of tool names available to you in this session
+                         (e.g. ["Shell", "Read", "Write", "Grep"]). Helps AMFS understand
+                         what capabilities drove a decision.
 
-    Example: amfs_set_identity("tenant-isolation-agent", "Fixing RLS propagation for Pro tenancy")
+    Example: amfs_set_identity("tenant-isolation-agent", "Fixing RLS propagation for Pro tenancy", model="claude-4-opus")
     """
-    global _active_identity, _last_activity
+    global _active_identity, _last_activity, _session_metadata
     now = time.monotonic()
 
-    # Idempotent: same name is always a no-op
+    # Build / update session metadata from explicit params + MCP context
+    if model or client_name or tools_available:
+        if _session_metadata is None:
+            _session_metadata = SessionMetadata()
+        if model:
+            _session_metadata.model = model
+        if client_name:
+            _session_metadata.client_name = client_name
+        if tools_available:
+            _session_metadata.tools_available = tools_available
+
+    if _session_metadata is None:
+        _session_metadata = SessionMetadata()
+    _session_metadata.platform = detect_platform()
+
+    _enrich_metadata_from_context(ctx)
+
+    # Idempotent: same name is always a no-op (but still update metadata)
     if _active_identity == name:
         _last_activity = now
         mem = _get_memory()
+        mem.session_metadata = _session_metadata
         return json.dumps({
             "identity": name,
             "session_id": mem.session_id,
             "status": "already_active",
             "sticky": True,
+            "session_metadata": _session_metadata.model_dump(mode="json"),
         }, default=str)
 
     # Guard: reject if a *different* identity was recently active
@@ -410,30 +476,32 @@ def amfs_set_identity(name: str, description: str | None = None) -> str:
     _save_sticky_identity(name)
 
     mem = _get_memory()
+    mem.session_metadata = _session_metadata
 
     logger.info(
-        "Identity set: %s → %s (session=%s, platform=%s, description=%s)",
-        old_identity, name, mem.session_id, detect_platform(), description or "",
+        "Identity set: %s → %s (session=%s, platform=%s, model=%s, description=%s)",
+        old_identity, name, mem.session_id, detect_platform(),
+        model or "unknown", description or "",
     )
 
-    # Register / update the agent profile with the description so it
-    # shows up on the dashboard.  This is a fire-and-forget best-effort
-    # call — identity setting always succeeds even if profile update fails.
-    if description:
-        try:
-            from amfs_core.models import AgentProfile
+    # Register / update the agent profile with the description and session
+    # metadata so it shows up on the dashboard.  Fire-and-forget best-effort
+    # — identity setting always succeeds even if profile update fails.
+    try:
+        from amfs_core.models import AgentProfile
 
-            current_agent = mem._adapter.get_agent(name, namespace=mem.namespace)
-            existing = current_agent.profile if current_agent else None
-            profile = AgentProfile(
-                description=description,
-                default_branch=existing.default_branch if existing else "main",
-                auto_context_paths=existing.auto_context_paths if existing else [],
-                tags=existing.tags if existing else [],
-            )
-            mem._adapter.update_agent_profile(name, profile, namespace=mem.namespace)
-        except Exception:
-            logger.debug("Could not update agent profile for %s", name, exc_info=True)
+        current_agent = mem._adapter.get_agent(name, namespace=mem.namespace)
+        existing = current_agent.profile if current_agent else None
+        profile = AgentProfile(
+            description=description or (existing.description if existing else ""),
+            default_branch=existing.default_branch if existing else "main",
+            auto_context_paths=existing.auto_context_paths if existing else [],
+            tags=existing.tags if existing else [],
+            session_metadata=_session_metadata,
+        )
+        mem._adapter.update_agent_profile(name, profile, namespace=mem.namespace)
+    except Exception:
+        logger.debug("Could not update agent profile for %s", name, exc_info=True)
 
     result: dict[str, Any] = {
         "previous_identity": old_identity,
@@ -441,6 +509,7 @@ def amfs_set_identity(name: str, description: str | None = None) -> str:
         "session_id": mem.session_id,
         "sticky": True,
         "hint": "Identity saved — it will be auto-restored in future sessions.",
+        "session_metadata": _session_metadata.model_dump(mode="json"),
     }
     if description:
         result["description"] = description
@@ -455,14 +524,17 @@ def amfs_whoami() -> str:
     is being used for reads/writes.
     """
     sticky = _load_sticky_identity()
-    return json.dumps({
+    result: dict[str, Any] = {
         "active_identity": _active_identity,
         "sticky_identity": sticky,
         "detected_identity": detect_agent_id(),
         "effective_identity": _active_identity or sticky or detect_agent_id(),
         "platform": detect_platform(),
         "identity_file": str(_identity_file()),
-    })
+    }
+    if _session_metadata:
+        result["session_metadata"] = _session_metadata.model_dump(mode="json")
+    return json.dumps(result)
 
 
 @mcp.tool

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -367,7 +367,7 @@ def _serialize_entry(entry: Any) -> dict[str, Any]:
 
 
 @mcp.tool
-async def amfs_set_identity(
+def amfs_set_identity(
     name: str,
     description: str | None = None,
     model: str | None = None,

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs"
-version = "0.5.0"
+version = "0.5.1"
 description = "AMFS Python SDK — Agent Memory File System"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/sdk-python/src/amfs/__init__.py
+++ b/packages/sdk-python/src/amfs/__init__.py
@@ -18,6 +18,7 @@ from amfs_core.models import (
     ScoredEntry,
     SearchQuery,
     SemanticQuery,
+    SessionMetadata,
 )
 
 from amfs.memory import AgentMemory, MemoryScope
@@ -42,4 +43,5 @@ __all__ = [
     "ScoredEntry",
     "SearchQuery",
     "SemanticQuery",
+    "SessionMetadata",
 ]

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -35,6 +35,7 @@ from amfs_core.models import (
     ScoredEntry,
     SearchQuery,
     SemanticQuery,
+    SessionMetadata,
     TraceEntry,
 )
 from amfs_core.outcome import OutcomeBackPropagator
@@ -154,6 +155,7 @@ class AgentMemory:
         self._on_conflict = on_conflict
         self._importance_evaluator = importance_evaluator
         self._branch = "main"
+        self._session_metadata: SessionMetadata | None = None
 
         self._lifecycle: LifecycleManager | None = None
         if ttl_sweep_interval is not None:
@@ -173,6 +175,14 @@ class AgentMemory:
     @property
     def session_id(self) -> str:
         return self._tagger.session_id
+
+    @property
+    def session_metadata(self) -> SessionMetadata | None:
+        return self._session_metadata
+
+    @session_metadata.setter
+    def session_metadata(self, value: SessionMetadata | None) -> None:
+        self._session_metadata = value
 
     @property
     def namespace(self) -> str:
@@ -878,6 +888,7 @@ class AgentMemory:
             causal_entries=causal_trace_entries,
             external_contexts=ext_contexts,
             query_events=query_events,
+            session_metadata=self._session_metadata,
             session_started_at=session_started,
             session_ended_at=now,
             session_duration_ms=session_duration,

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -319,12 +319,14 @@ class TestIdentityGuard:
         srv._active_identity = None
         srv._memories = {}
         srv._last_activity = 0.0
+        srv._session_metadata = None
         yield
         for m in srv._memories.values():
             m.close()
         srv._memories = {}
         srv._adapter = None
         srv._active_identity = None
+        srv._session_metadata = None
 
     def test_set_identity_creates_memory(self) -> None:
         import amfs_mcp.server as srv


### PR DESCRIPTION
## Summary

- Adds `SessionMetadata` model to capture LLM model name, client platform, tools available, and MCP client/session IDs for every agent session
- Extends `amfs_set_identity` with optional `model`, `client_name`, and `tools_available` parameters — agents self-report their LLM model name
- Passively captures `ctx.client_id` and `ctx.session_id` from the FastMCP MCP handshake
- Wires `session_metadata` into `AgentProfile` and `DecisionTrace` so every committed trace records which model produced the decisions
- Updates CLAUDE.md, cursor rules, and MCP instructions to tell agents to pass `model=`
- Bumps `amfs-mcp-server` to **0.7.0** (already published to PyPI)

### Packages changed
| Package | Change |
|---|---|
| `amfs-core` | New `SessionMetadata` model, added to `AgentProfile` and `DecisionTrace` |
| `amfs` (SDK) | Import + expose `SessionMetadata`, add `session_metadata` property to `AgentMemory`, wire into `commit_outcome` |
| `amfs-mcp-server` | Extended `amfs_set_identity`, passive MCP context capture, bumped 0.6.0 → 0.7.0 |