### PR TITLE
fix: remove rooms from community MCP instructions, improve briefing hints

### DIFF
--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-mcp-server"
-version = "0.7.0"
+version = "0.7.1"
 description = "AMFS MCP Server — expose Agent Memory as MCP tools for Cursor and Claude Code"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -119,19 +119,6 @@ Use `{repo}/{service-or-module}` paths (e.g. `myapp/auth`, `amfs/core-engine`). 
 ## Quality Feedback
 
 `amfs_write` responses include a `quality` score. If below 0.8, review `issues` and rewrite with more detail. Use `pattern_refs` to link related entries.
-
-## Rooms (Pro — collaborative entities)
-
-If available, rooms let multiple users' agents collaborate on a shared entity:
-
-1. **Discover rooms**: `amfs_my_rooms()` — see rooms you own or are invited to
-2. **Join a room**: `amfs_room_join(room_id)` — triggers auto-briefing with room history
-3. **Read & write normally**: entries on room entities are shared with all members
-4. **Check updates**: `amfs_room_updates(room_id, since="...")` — poll for new activity between tasks
-5. **Get room details**: `amfs_room_info(room_id)` — members, settings, discussion status
-6. **Leave when done**: `amfs_room_leave(room_id)` — knowledge snapshot preserved in your memory
-
-Room writes auto-propagate to all members. Cross-user reads through rooms are logged on both agent timelines.
 """
 
 mcp = FastMCP(name="amfs", instructions=_INSTRUCTIONS)
@@ -1246,8 +1233,9 @@ def amfs_briefing(
     if not digests:
         hint = (
             "No compiled briefings yet. "
-            "Use amfs_search() or amfs_recall() to find existing memories, "
-            "or amfs_write() to start building knowledge."
+            "Try amfs_my_rooms() to check for shared rooms with team knowledge, "
+            "or use amfs_search() / amfs_recall() to find existing memories. "
+            "Use amfs_write() to start building knowledge."
         )
         return json.dumps({"status": "empty", "message": hint})
     return json.dumps(


### PR DESCRIPTION
## Summary

- Remove the "Rooms (Pro)" section from community MCP server `_INSTRUCTIONS` — rooms tools are only registered in the Pro server, and having them in community instructions confused Claude Desktop into referencing non-existent tools
- Improve `amfs_briefing` empty response to suggest checking `amfs_my_rooms()` for shared team knowledge
- Bump `amfs-mcp-server` to `0.7.1`

**Companion PR:** raia-live/amfs-internal#222 (dashboard, rooms, Pro MCP fixes)