### PR TITLE
fix: restrict agents list to user's own agents only

### DIFF
--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -1425,6 +1425,12 @@ async def list_agents(
         ):
             agent_data[aid]["first_seen"] = e.provenance.written_at
 
+    # Entry filtering allows room co-members' entries on shared entity
+    # paths, but the agents list must only show the user's own agents.
+    if vis is not None and vis.should_filter():
+        own = vis.get_user_agents()
+        agent_data = {aid: d for aid, d in agent_data.items() if aid in own}
+
     agent_registration: dict[str, dict[str, Any]] = {}
     known_agent_ids = list(agent_data.keys())
     if known_agent_ids:


### PR DESCRIPTION
## Root cause analysis

The visibility filter correctly allows entries from room co-members on shared entity paths (so entries on a room's entity can be seen by all room members). However, the `GET /api/v1/agents` endpoint derives its agent list from ALL visible entries. This means any room co-member who has entries on a shared entity_path appears on the Agents page as if they were the user's own agent.

Verified via direct API test:
- `whoami` shows `visible_agents: ["pulse"]` — filter works, only user's own agent
- `GET /api/v1/entries` via API key returns only 12 entries from `pulse` and `amfs-server`
- But the dashboard's agent list showed 4 agents including room co-members

## Fix

After building the agent_data dict from filtered entries, restrict it to only the user's own agents (`vis.get_user_agents()`). This is a 4-line addition.