### PR TITLE
fix: prevent OSS tenant middleware from overriding Pro RLS context

### DIFF
--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -479,30 +479,7 @@ async def list_entries(
     if vis is not None and vis.should_filter():
         entries = vis.filter_entries(entries)
 
-    user_id = getattr(request.state, "user_id", None)
-    has_dash = bool(request.headers.get("x-amfs-dashboard-secret"))
-    debug: dict[str, Any] = {
-        "filter_exists": vis is not None,
-        "should_filter": vis.should_filter() if vis is not None else None,
-        "user_id": str(user_id) if user_id else None,
-        "has_dashboard_headers": has_dash,
-        "total_before": total_before,
-        "total_after": len(entries),
-    }
-    if vis is not None and vis.should_filter():
-        try:
-            debug["user_agents"] = sorted(vis.get_user_agents())
-        except Exception:
-            debug["user_agents_error"] = True
-        try:
-            rm = vis.get_room_map()
-            debug["room_map"] = {k: sorted(v) for k, v in rm.items()}
-        except Exception:
-            debug["room_map_error"] = True
-    return {
-        "entries": [_entry_to_response(e) for e in entries],
-        "_debug_visibility": debug,
-    }
+    return {"entries": [_entry_to_response(e) for e in entries]}
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/packages/http-server/src/amfs_http/tenant_middleware.py
+++ b/packages/http-server/src/amfs_http/tenant_middleware.py
@@ -14,12 +14,19 @@ logger = logging.getLogger(__name__)
 def apply_tenant_headers_from_request(request: Request) -> None:
     """If proxy secret + account id headers match env, set thread-local tenant for DB RLS.
 
-    When valid dashboard proxy headers are present, they ALWAYS take
-    precedence — even if a prior middleware (e.g. Pro scope) already set
-    the thread-local tenant.  The dashboard proxy carries the actual
-    end-user's account ID, which must override whatever account the
-    service API key resolved to.
+    When the Pro scope-enforcement middleware (amfs_tenant) has already
+    resolved a TenantContext it also sets the thread-local RLS variables
+    to the API key's account — which is the account that actually owns
+    the stored entries.  Overriding those values with the dashboard
+    user's account/team headers would cause RLS to hide all entries
+    whenever the service API key's account differs from the logged-in
+    user's account (or when team IDs don't match).
+
+    So: skip entirely when tenant_ctx is already present.
     """
+    if getattr(request.state, "tenant_ctx", None) is not None:
+        return
+
     try:
         from amfs_postgres.tenant_context import (
             set_tls_tenant_account_id,


### PR DESCRIPTION
## Summary

- The `_dashboard_tenant_middleware` (OSS layer in `server.py`) was overriding the TLS `account_id` and `team_id` set by the Pro scope-enforcement middleware (`http_deps.py`) with the dashboard user's header values. When the service API key's account or team differs from the logged-in user's, RLS hid all entries — producing **0 results on every dashboard page** (Overview, Agents, Entities, Traces).
- Fix: skip the OSS tenant override when `request.state.tenant_ctx` is already present (Pro middleware has set up the correct RLS context).
- Also removes the temporary `_debug_visibility` output from the `/api/v1/entries` endpoint.

## Root cause

Two middlewares were fighting over the same TLS ContextVars:

1. **Pro middleware** (`http_deps.py`): resolves API key → sets `amfs.current_account_id` to the key's account (where entries are stored) ✅
2. **OSS dashboard middleware** (`tenant_middleware.py`): reads `X-AMFS-Dashboard-Account-Id` header → **overrides** `amfs.current_account_id` to the dashboard user's account ❌

Entries are stored with the API key's `account_id` (set at INSERT time via column DEFAULT). When the dashboard overrode RLS to the user's account/team, none of the entries matched.