### PR TITLE
fix: never set team_id from dashboard session in OSS middleware

### DIFF
--- a/packages/http-server/src/amfs_http/tenant_middleware.py
+++ b/packages/http-server/src/amfs_http/tenant_middleware.py
@@ -54,16 +54,13 @@ def apply_tenant_headers_from_request(request: Request) -> bool:
     set_tls_tenant_account_id(raw)
     request.state.account_id = UUID(raw)
 
-    team_raw = request.headers.get("X-AMFS-Dashboard-Team-Id")
-    if team_raw:
-        try:
-            UUID(team_raw)
-            set_tls_tenant_team_id(team_raw)
-        except ValueError:
-            logger.warning("Invalid X-AMFS-Dashboard-Team-Id header")
-
-    is_admin = request.headers.get("X-AMFS-Dashboard-Is-Admin") == "true"
-    set_tls_is_account_admin(is_admin)
+    # Never propagate team_id from the dashboard user's session.
+    # The logged-in user's team can differ from the team that owns the
+    # agents and entries in the shared account (e.g. invited users).
+    # Setting a mismatched team_id causes RLS to hide all data.
+    # Per-user scoping is handled by UserVisibilityFilter, not team RLS.
+    set_tls_tenant_team_id(None)
+    set_tls_is_account_admin(False)
 
     user_id_raw = request.headers.get("X-AMFS-Dashboard-User-Id")
     if user_id_raw:


### PR DESCRIPTION
## Summary
- Stops propagating the dashboard user's session `team_id` into the RLS GUC
- Always sets `team_id=None` and `is_admin=false` in the OSS middleware fallback path
- This prevents RLS from blocking data when an invited user's team differs from the data owner's team

## Root cause
The diagnostic logs from the deployed build revealed the full chain:

1. Dashboard API key resolves as `ctx=None` (key is in OSS table, not Pro table)
2. Pro middleware takes early return → OSS middleware runs
3. OSS middleware sets TLS from dashboard headers, including the **invited user's `team_id`** (`e3313cb6-...`)
4. RLS policy on `agents` and `amfs_memory_entries` requires team match → `total_agents_visible_via_rls=0`
5. Admin works because their session sends `is_admin=true` which bypasses team check

## Why this is general (not account-specific)
This affects **any** account where:
- The shared API key resolves via `ctx=None` (key in OSS `amfs_api_keys` table)
- An invited user logs in with a different `team_id` than the account owner
- The invited user is not an admin (`is_admin=false`)

The fix ensures `team_id` is never propagated from dashboard sessions. Per-user data scoping is handled by `UserVisibilityFilter`, not RLS team isolation.