### PR TITLE
perf: background log_event + cache ensure_agent to cut 2 more DB round-trips

### DIFF
--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -94,6 +94,7 @@ async def _dashboard_tenant_middleware(request: Request, call_next):
 _memory: AgentMemory | None = None
 _sse_manager = SSEManager()
 _bg_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="amfs-bg")
+_known_agents: set[str] = set()
 
 _immutable_trace_store = None
 try:
@@ -418,11 +419,14 @@ async def write_entry(
     original_agent = mem._tagger.agent_id if req.agent_id else None
     if req.agent_id:
         mem._tagger.agent_id = req.agent_id
-        try:
-            mem._adapter.ensure_agent(req.agent_id, mem.namespace)
-        except Exception:
-            pass
-        _ensure_agent_owner(request, req.agent_id, mem.namespace)
+        _agent_cache_key = f"{req.agent_id}:{mem.namespace}"
+        if _agent_cache_key not in _known_agents:
+            try:
+                mem._adapter.ensure_agent(req.agent_id, mem.namespace)
+                _known_agents.add(_agent_cache_key)
+            except Exception:
+                pass
+            _ensure_agent_owner(request, req.agent_id, mem.namespace)
     try:
         entry = mem.write(
             req.entity_path,

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import logging
 import math
+import threading
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
@@ -44,6 +46,20 @@ from amfs.config import load_config_or_default
 from amfs.factory import create_adapter_from_config
 
 logger = logging.getLogger(__name__)
+
+_sdk_bg_executor: ThreadPoolExecutor | None = None
+_sdk_bg_lock = threading.Lock()
+
+
+def _get_sdk_executor() -> ThreadPoolExecutor:
+    global _sdk_bg_executor
+    if _sdk_bg_executor is None:
+        with _sdk_bg_lock:
+            if _sdk_bg_executor is None:
+                _sdk_bg_executor = ThreadPoolExecutor(
+                    max_workers=1, thread_name_prefix="amfs-sdk-bg"
+                )
+    return _sdk_bg_executor
 
 
 # ---------------------------------------------------------------------------
@@ -331,29 +347,44 @@ class AgentMemory:
         )
         self._read_tracker.record_write(entity_path, key, entry.version, entry.version == 1)
 
-        try:
-            self._adapter.log_event(Event(
-                namespace=self.namespace,
-                agent_id=self.agent_id,
-                branch=effective_branch,
-                event_type=EventType.WRITE,
-                summary=f"Wrote {entity_path}/{key} v{entry.version}",
-                details={
-                    "entity_path": entity_path,
-                    "key": key,
-                    "version": entry.version,
-                    "confidence": entry.confidence,
-                    "memory_type": entry.memory_type.value if hasattr(entry.memory_type, "value") else str(entry.memory_type),
-                    "shared": entry.shared,
-                },
-            ))
-        except Exception:
-            logger.debug("Failed to log write event", exc_info=True)
+        _adapter = self._adapter
+        _ns = self.namespace
+        _aid = self.agent_id
+        _ev_branch = effective_branch
+        _entry_version = entry.version
+        _entry_confidence = entry.confidence
+        _entry_mt = entry.memory_type.value if hasattr(entry.memory_type, "value") else str(entry.memory_type)
+        _entry_shared = entry.shared
+        _ep = entity_path
+        _k = key
+        _prefs = pattern_refs
 
-        if pattern_refs:
-            self._materialize_pattern_ref_edges(
-                entity_path, key, pattern_refs, effective_branch,
-            )
+        def _bg_log_and_edges() -> None:
+            try:
+                _adapter.log_event(Event(
+                    namespace=_ns,
+                    agent_id=_aid,
+                    branch=_ev_branch,
+                    event_type=EventType.WRITE,
+                    summary=f"Wrote {_ep}/{_k} v{_entry_version}",
+                    details={
+                        "entity_path": _ep,
+                        "key": _k,
+                        "version": _entry_version,
+                        "confidence": _entry_confidence,
+                        "memory_type": _entry_mt,
+                        "shared": _entry_shared,
+                    },
+                ))
+            except Exception:
+                logger.debug("Failed to log write event", exc_info=True)
+            if _prefs:
+                try:
+                    self._materialize_pattern_ref_edges(_ep, _k, _prefs, _ev_branch)
+                except Exception:
+                    logger.debug("Failed to materialize pattern ref edges", exc_info=True)
+
+        _get_sdk_executor().submit(_bg_log_and_edges)
 
         return entry
 

--- a/tests/unit/test_knowledge_graph.py
+++ b/tests/unit/test_knowledge_graph.py
@@ -54,6 +54,7 @@ def _make_memory(tmp_path: Path) -> AgentMemory:
 
 class TestMaterializerPatternRefs:
     def test_write_with_pattern_refs_calls_upsert(self, tmp_path: Path):
+        import time
         mem = _make_memory(tmp_path)
         mock_upsert = MagicMock(return_value=GraphEdge(
             source_entity="", source_type="", relation="",
@@ -63,6 +64,7 @@ class TestMaterializerPatternRefs:
 
         mem.write("svc/auth", "pattern-retry", "retry logic", pattern_refs=["pattern-circuit-breaker"])
 
+        time.sleep(0.2)
         assert mock_upsert.call_count >= 1
         edge_arg = mock_upsert.call_args_list[0][0][0]
         assert edge_arg.relation == "references"


### PR DESCRIPTION
## Summary

Follow-up to #211. Reduces the synchronous DB round-trips per write from 6 to 3:

- **Cache `ensure_agent()`** in an in-memory `_known_agents` set — skips the UPSERT on repeated writes from the same agent (1 pool checkout + RLS SET saved per write)
- **Background `log_event()`** in SDK `memory.py` — moves the event INSERT to a lazy `ThreadPoolExecutor` since it's a fire-and-forget side effect (1 pool checkout + RLS SET + INSERT saved per write)
- **Background `_materialize_pattern_ref_edges()`** — bundled with `log_event` in the same background task

### Remaining sync write path (3 round-trips)

1. CoW engine `adapter.read()` — get current version for versioning
2. `adapter.write()` — SELECT FOR UPDATE + UPDATE superseded + INSERT new entry
3. _(auth is cached, ensure_agent is cached, log_event/audit/graph are all backgrounded)_

### Expected impact

reduction in write latency 