### PR TITLE
perf: eliminate commit_outcome bottleneck — skip re-reads, background edges

### DIFF
--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -9,6 +9,7 @@ synchronous.
 from __future__ import annotations
 
 import logging
+import time
 from datetime import datetime
 from typing import Any, Callable
 
@@ -64,15 +65,23 @@ class HttpAdapter(AdapterABC):
 
     # ── helpers ────────────────────────────────────────────────────────
 
+    def _request(self, method: str, path: str, **kwargs: Any) -> Any:
+        max_retries = 4
+        for attempt in range(max_retries):
+            resp = self._client.request(method, path, **kwargs)
+            if resp.status_code == 429 and attempt < max_retries - 1:
+                wait = float(resp.headers.get("Retry-After", 2 ** attempt))
+                logger.debug("Rate limited on %s %s, retrying in %.1fs", method, path, wait)
+                time.sleep(wait)
+                continue
+            resp.raise_for_status()
+            return resp.json()
+
     def _get(self, path: str, **params: Any) -> Any:
-        resp = self._client.get(path, params={k: v for k, v in params.items() if v is not None})
-        resp.raise_for_status()
-        return resp.json()
+        return self._request("GET", path, params={k: v for k, v in params.items() if v is not None})
 
     def _post(self, path: str, body: dict[str, Any] | None = None) -> Any:
-        resp = self._client.post(path, json=body or {})
-        resp.raise_for_status()
-        return resp.json()
+        return self._request("POST", path, json=body or {})
 
     # ── required abstract methods ─────────────────────────────────────
 

--- a/packages/core/src/amfs_core/engine.py
+++ b/packages/core/src/amfs_core/engine.py
@@ -66,6 +66,8 @@ class ReadTracker:
         self._versions[entry.entry_key] = entry.version
         self._entries[entry.entry_key] = {
             "value": entry.value,
+            "confidence": entry.confidence,
+            "version": entry.version,
             "memory_type": entry.memory_type.value if hasattr(entry.memory_type, 'value') else str(entry.memory_type),
             "written_by": entry.provenance.agent_id,
         }

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -855,18 +855,29 @@ class AgentMemory:
             if len(parts) != 2:
                 continue
             ep, k = parts
-            entry = self._adapter.read(ep, k)
-            if entry:
-                snapshot = self._read_tracker.entry_snapshot(ek)
+            snapshot = self._read_tracker.entry_snapshot(ek)
+            if snapshot:
                 causal_trace_entries.append(TraceEntry(
                     entity_path=ep, key=k,
-                    version=self._read_tracker.read_version(ek) or entry.version,
-                    confidence=entry.confidence,
-                    value=snapshot.get("value") if snapshot else None,
-                    memory_type=snapshot.get("memory_type") if snapshot else None,
-                    written_by=snapshot.get("written_by") if snapshot else None,
+                    version=self._read_tracker.read_version(ek) or snapshot.get("version", 1),
+                    confidence=snapshot.get("confidence", 1.0),
+                    value=snapshot.get("value"),
+                    memory_type=snapshot.get("memory_type"),
+                    written_by=snapshot.get("written_by"),
                     read_at=self._read_tracker._reads.get(ek),
                 ))
+            else:
+                entry = self._adapter.read(ep, k)
+                if entry:
+                    causal_trace_entries.append(TraceEntry(
+                        entity_path=ep, key=k,
+                        version=self._read_tracker.read_version(ek) or entry.version,
+                        confidence=entry.confidence,
+                        value=entry.value,
+                        memory_type=entry.memory_type.value if entry.memory_type else None,
+                        written_by=entry.written_by,
+                        read_at=self._read_tracker._reads.get(ek),
+                    ))
 
         ext_contexts = [
             ExternalContext(
@@ -931,24 +942,34 @@ class AgentMemory:
         except Exception:
             logger.debug("Failed to persist decision trace", exc_info=True)
 
-        try:
-            self._adapter.log_event(Event(
-                namespace=self.namespace,
-                agent_id=self.agent_id,
-                branch=self._branch,
-                event_type=EventType.OUTCOME,
-                summary=f"Committed outcome '{outcome_ref}' ({outcome_type.value})",
-                details={
-                    "outcome_ref": outcome_ref,
-                    "outcome_type": outcome_type.value,
-                    "causal_entries": len(causal_entry_keys),
-                    "entries_updated": len(updated),
-                },
-            ))
-        except Exception:
-            logger.debug("Failed to log outcome event", exc_info=True)
+        executor = _get_sdk_executor()
+        adapter = self._adapter
+        agent_id = self.agent_id
+        namespace = self.namespace
+        branch = self._branch
+        n_updated = len(updated)
+        n_causal = len(causal_entry_keys)
 
-        self._materialize_causal_edges(outcome_ref, outcome_type, causal_entry_keys)
+        def _bg_log_and_edges() -> None:
+            try:
+                adapter.log_event(Event(
+                    namespace=namespace,
+                    agent_id=agent_id,
+                    branch=branch,
+                    event_type=EventType.OUTCOME,
+                    summary=f"Committed outcome '{outcome_ref}' ({outcome_type.value})",
+                    details={
+                        "outcome_ref": outcome_ref,
+                        "outcome_type": outcome_type.value,
+                        "causal_entries": n_causal,
+                        "entries_updated": n_updated,
+                    },
+                ))
+            except Exception:
+                logger.debug("Failed to log outcome event", exc_info=True)
+            self._materialize_causal_edges(outcome_ref, outcome_type, causal_entry_keys)
+
+        executor.submit(_bg_log_and_edges)
 
         self._last_trace = trace
         return updated

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -875,7 +875,7 @@ class AgentMemory:
                         confidence=entry.confidence,
                         value=entry.value,
                         memory_type=entry.memory_type.value if entry.memory_type else None,
-                        written_by=entry.written_by,
+                        written_by=entry.provenance.agent_id,
                         read_at=self._read_tracker._reads.get(ek),
                     ))
 

--- a/tests/unit/test_knowledge_graph.py
+++ b/tests/unit/test_knowledge_graph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any

--- a/tests/unit/test_knowledge_graph.py
+++ b/tests/unit/test_knowledge_graph.py
@@ -94,6 +94,8 @@ class TestMaterializerCausalEdges:
 
         mem.commit_outcome("deploy-v1", OutcomeType.SUCCESS)
 
+        time.sleep(0.3)
+
         informed_calls = [
             c for c in mock_upsert.call_args_list
             if c[0][0].relation == "informed"


### PR DESCRIPTION
## Summary

- **Skip N re-reads in commit_outcome**: Uses existing `ReadTracker` snapshots instead of making N synchronous `adapter.read()` calls to rebuild causal trace entries. Falls back to adapter.read() only when no snapshot exists.
- **Background log_event + causal edge materialization**: Moves 2N+1 HTTP calls (1 log_event + 2N graph edges) to the SDK background ThreadPoolExecutor so they don't block the commit_outcome return path.
- **429 retry in HttpAdapter**: Adds exponential backoff retry (up to 4 attempts) for rate-limited requests in the HTTP adapter.

### Impact

For a causal chain of N entries, blocking HTTP calls drop from **3N+3** to **2**:

| Call | Before | After |
|------|--------|-------|
| commit_outcome (back-propagation) | 1 (blocking) | 1 (blocking) |
| Re-read causal entries | N (blocking) | 0 (use snapshots) |
| save_trace | 1 (blocking) | 1 (blocking) |
| log_event | 1 (blocking) | 1 (background) |
| upsert_graph_edge | 2N (blocking) | 2N (background) |
| **Total blocking** | **3N + 3** | **2** |

For N=5: 18 blocking calls → 2 blocking calls (9x reduction).