### PR TITLE
fix: add sync fallback for async adapter reads (read/list/search)

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
@@ -65,16 +65,23 @@ class _AsyncTenantRLSConnection:
         team_id = get_request_tenant_team_id()
         is_admin = get_request_is_account_admin()
 
+        guc_account = tid if tid else ""
+        guc_team = team_id if team_id else ""
+        guc_admin = "true" if is_admin else "false"
+
+        if not tid:
+            logger.warning(
+                "async pool checkout: tenant account_id is EMPTY "
+                "(tid=%r, team=%r, admin=%r) — RLS reads will return no rows",
+                tid, team_id, is_admin,
+            )
+
         async with conn.cursor() as cur:
             await cur.execute(
                 "SELECT set_config('amfs.current_account_id', %s, false),"
                 "       set_config('amfs.current_team_id', %s, false),"
                 "       set_config('amfs.is_account_admin', %s, false)",
-                (
-                    tid if tid else "",
-                    team_id if team_id else "",
-                    "true" if is_admin else "false",
-                ),
+                (guc_account, guc_team, guc_admin),
             )
         return conn
 

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -380,12 +380,23 @@ async def read_entry(
     branch: str = Query("main"),
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
+    mem = _get_memory()
     if _async_adapter is not None:
-        entry = await _async_adapter.read(entity_path, key, branch=branch)
+        try:
+            entry = await _async_adapter.read(entity_path, key, branch=branch)
+        except Exception:
+            logger.warning("Async read failed for %s/%s — falling back to sync", entity_path, key, exc_info=True)
+            entry = None
+        if entry is None:
+            entry = mem.read(entity_path, key, branch=branch)
+            if entry is not None:
+                logger.warning(
+                    "Async adapter missed entry %s/%s but sync found it — RLS context mismatch",
+                    entity_path, key,
+                )
         if entry is not None:
             asyncio.create_task(_async_adapter.increment_recall_count(entity_path, key, branch=branch))
     else:
-        mem = _get_memory()
         entry = mem.read(entity_path, key, branch=branch)
     if entry is None:
         return {"status": "not_found", "entity_path": entity_path, "key": key}
@@ -659,10 +670,22 @@ async def list_entries(
         "[TLS-DIAG] /entries tls_account=%s state_account=%s state_user=%s has_tenant_ctx=%s",
         _tls_acct, _state_acct, _state_user, _has_ctx,
     )
+    mem = _get_memory()
     if _async_adapter is not None:
-        entries = await _async_adapter.list(entity_path, branch=branch, include_superseded=include_superseded)
+        try:
+            entries = await _async_adapter.list(entity_path, branch=branch, include_superseded=include_superseded)
+        except Exception:
+            logger.warning("Async list failed for %s — falling back to sync", entity_path, exc_info=True)
+            entries = []
+        if not entries:
+            sync_entries = mem.list(entity_path, branch=branch, include_superseded=include_superseded)
+            if sync_entries:
+                logger.warning(
+                    "Async adapter returned 0 entries for %s but sync found %d — RLS context mismatch",
+                    entity_path, len(sync_entries),
+                )
+                entries = sync_entries
     else:
-        mem = _get_memory()
         entries = mem.list(entity_path, branch=branch, include_superseded=include_superseded)
     total_before = len(entries)
 
@@ -707,10 +730,25 @@ async def search_entries(
         limit=req.limit,
         depth=req.depth,
     )
+    mem = _get_memory()
     if _async_adapter is not None:
-        results = await _async_adapter.search(sq, branch=branch)
+        try:
+            results = await _async_adapter.search(sq, branch=branch)
+        except Exception:
+            logger.warning("Async search failed — falling back to sync", exc_info=True)
+            results = []
+        if not results:
+            try:
+                sync_results = mem._adapter.search(sq, branch=branch)
+            except TypeError:
+                sync_results = mem._adapter.search(sq)
+            if sync_results:
+                logger.warning(
+                    "Async search returned 0 results but sync found %d — RLS context mismatch",
+                    len(sync_results),
+                )
+                results = sync_results
     else:
-        mem = _get_memory()
         try:
             results = mem._adapter.search(sq, branch=branch)
         except TypeError:


### PR DESCRIPTION
## Summary

Follow-up to #216 (async write persistence fix). After deploying the write fix, testing revealed:

- **Writes now persist correctly** — the async adapter's RETURNING check + sync fallback works
- **Reads are still broken** — the async adapter's `read()`, `list()`, and `search()` methods return empty results for entries that ARE committed in the database
- **Sync adapter reads work fine** — the `quality` and `history` endpoints (which use the sync adapter) correctly return all entries

This confirms the issue is specifically in the **async adapter's RLS GUC context during reads** — the `amfs.current_account_id` session variable is likely empty when the async pool checks out connections for read operations, causing RLS policies to hide all entries.

### Changes

1. **`server.py` — read/list/search sync fallbacks**: Each endpoint now tries the async adapter first, and if it returns empty/None, transparently falls back to the sync adapter. A warning is logged when the sync adapter finds data the async adapter missed, confirming the RLS context mismatch.

2. **`async_adapter.py` — GUC diagnostic logging**: The `_AsyncTenantRLSConnection.__aenter__` now logs a warning when the tenant `account_id` contextvar is empty at pool checkout, which directly causes the RLS read failure.

## Evidence from production testing

```
Write: version=1 → HTTP 200 ✓
Read: {"status":"not_found"} ✗ (async adapter)
Quality: returns entry correctly ✓ (sync adapter)
History: returns all 4 versions ✓ (sync adapter)
Stats: unchanged at 1038 ✓ (sync adapter)
```