### PR TITLE
fix(sdk): forward agent_id in HttpAdapter writeAsync

### DIFF
--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senselab-ai/amfs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "AMFS TypeScript SDK — Agent Memory File System",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk-typescript/src/adapters/http.ts
+++ b/packages/sdk-typescript/src/adapters/http.ts
@@ -9,15 +9,18 @@ import { createWatchHandle } from "../adapter.js";
 export interface HttpAdapterOptions {
   url: string;
   apiKey?: string;
+  agentId?: string;
   headers?: Record<string, string>;
 }
 
 export class HttpAdapter implements AmfsAdapter {
   private readonly baseUrl: string;
   private readonly headers: Record<string, string>;
+  private readonly agentId: string | undefined;
 
   constructor(opts: HttpAdapterOptions) {
     this.baseUrl = opts.url.replace(/\/+$/, "");
+    this.agentId = opts.agentId;
     this.headers = {
       "Content-Type": "application/json",
       ...opts.headers,
@@ -75,7 +78,12 @@ export class HttpAdapter implements AmfsAdapter {
     value: unknown;
     confidence?: number;
     memoryType?: string;
+    agentId?: string;
+    shared?: boolean;
+    patternRefs?: string[];
+    branch?: string;
   }): Promise<MemoryEntry> {
+    const agentId = entry.agentId ?? this.agentId;
     return this.fetch<MemoryEntry>("/api/v1/entries", {
       method: "POST",
       body: JSON.stringify({
@@ -84,6 +92,10 @@ export class HttpAdapter implements AmfsAdapter {
         value: entry.value,
         confidence: entry.confidence ?? 1.0,
         memory_type: entry.memoryType ?? "fact",
+        ...(agentId ? { agent_id: agentId } : {}),
+        ...(entry.shared != null ? { shared: entry.shared } : {}),
+        ...(entry.patternRefs?.length ? { pattern_refs: entry.patternRefs } : {}),
+        ...(entry.branch ? { branch: entry.branch } : {}),
       }),
     });
   }
@@ -111,6 +123,8 @@ export class HttpAdapter implements AmfsAdapter {
     query?: string;
     entityPath?: string;
     minConfidence?: number;
+    agentId?: string;
+    sortBy?: string;
     limit?: number;
   }): Promise<MemoryEntry[]> {
     return this.fetch<MemoryEntry[]>("/api/v1/search", {
@@ -120,6 +134,8 @@ export class HttpAdapter implements AmfsAdapter {
         entity_path: query.entityPath,
         min_confidence: query.minConfidence ?? 0.0,
         limit: query.limit ?? 100,
+        ...(query.agentId ? { agent_id: query.agentId } : {}),
+        ...(query.sortBy ? { sort_by: query.sortBy } : {}),
       }),
     });
   }
@@ -181,12 +197,16 @@ export class HttpAdapter implements AmfsAdapter {
   async commitOutcomeAsync(record: {
     outcomeRef: string;
     outcomeType: string;
+    entityPath?: string;
+    causalEntryKeys?: string[];
   }): Promise<unknown> {
     return this.fetch("/api/v1/outcomes", {
       method: "POST",
       body: JSON.stringify({
         outcome_ref: record.outcomeRef,
         outcome_type: record.outcomeType,
+        ...(record.entityPath ? { entity_path: record.entityPath } : {}),
+        ...(record.causalEntryKeys?.length ? { causal_entry_keys: record.causalEntryKeys } : {}),
       }),
     });
   }


### PR DESCRIPTION
## Summary

The TypeScript SDK's `HttpAdapter.writeAsync()` was not including `agent_id` in the request body. This caused all entries written through the SDK to be attributed to the default server agent (`amfs-server`), which is not in any user's `visible_agents` list. With the `UserVisibilityFilter` active, these entries become completely invisible to reads, lists, and searches — appearing as if writes silently fail.

This was the **root cause** of the customer's reported issue: writes returned 200 but data appeared to not persist. In reality, the data was persisting (confirmed via sync adapter endpoints like `/quality` and `/history`), but it was hidden by the visibility filter because it lacked a proper `agent_id` linkage.

### Changes

- Add `agentId` to `HttpAdapterOptions` — set once at adapter construction
- Forward `agent_id` in `writeAsync` (supports per-call override or constructor default)
- Add missing params to `writeAsync`: `shared`, `patternRefs`, `branch`
- Add `agentId`, `sortBy` to `searchAsync`
- Add `entityPath`, `causalEntryKeys` to `commitOutcomeAsync`
- Bump version to `0.3.1`

### Usage after fix

```typescript
import { AgentMemory, HttpAdapter } from "@senselab-ai/amfs";

const adapter = new HttpAdapter({
  url: "https://amfs-login.sense-lab.ai",
  apiKey: "amfs_b-...",
  agentId: "my-agent",  // <-- entries are now linked to this agent
});

const mem = new AgentMemory("my-agent", { adapter });

// All writes through the adapter now include agent_id
await adapter.writeAsync({
  entityPath: "myapp/auth",
  key: "session-config",
  value: "JWT with 24h expiry",
  confidence: 0.9,
});
```