### PR TITLE
fix: align MCP server + Python SDK + TypeScript SDK with backend features

### DIFF
--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "amfs-mcp-server"
-version = "0.7.2"
+version = "0.7.3"
 description = "AMFS MCP Server — expose Agent Memory as MCP tools for Cursor and Claude Code"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 dependencies = [
     "amfs",
-    "amfs-adapter-http>=0.1.3",
+    "amfs-adapter-http>=0.1.2",
     "fastmcp>=2.0",
 ]
 

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -574,6 +574,7 @@ def amfs_write(
     memory_type: str = "fact",
     artifact_refs: list[dict[str, Any]] | None = None,
     shared: bool = True,
+    branch: str | None = None,
 ) -> str:
     """Write a memory entry with automatic provenance tracking.
 
@@ -600,6 +601,7 @@ def amfs_write(
         shared: If True (default), other agents can read this entry. If False,
             only the writing agent can access it — useful for internal reasoning,
             scratchpad notes, or sensitive context.
+        branch: Optional branch name to write to (defaults to "main").
 
     Example: amfs_write("checkout-service", "retry-pattern", '{"max_retries": 3}')
     Example private: amfs_write("checkout-service", "internal-notes", "...", shared=False)
@@ -621,16 +623,17 @@ def amfs_write(
         ArtifactRef.model_validate(r) for r in (artifact_refs or [])
     ]
 
-    entry = mem.write(
-        entity_path,
-        key,
-        parsed_value,
+    write_kwargs: dict[str, Any] = dict(
         confidence=confidence,
         pattern_refs=pattern_refs,
         memory_type=mt,
         artifact_refs=parsed_artifact_refs,
         shared=shared,
     )
+    if branch:
+        write_kwargs["branch"] = branch
+
+    entry = mem.write(entity_path, key, parsed_value, **write_kwargs)
 
     evaluator = _get_quality_evaluator()
     quality_report = None
@@ -688,7 +691,7 @@ def amfs_search(
         agent_id: Filter to entries from a specific agent
         since: Optional ISO timestamp to filter entries written after this time
         pattern_ref: Filter to entries tagged with this pattern reference
-        sort_by: Sort order — "confidence", "recency", or "version"
+        sort_by: Sort order — "confidence", "recency", "version", or "priority"
         limit: Maximum results to return
         depth: Tier depth (1=hot only, 2=hot+warm, 3=all tiers)
 
@@ -697,7 +700,10 @@ def amfs_search(
     from datetime import datetime as dt
 
     mem = _get_memory()
-    since_dt = dt.fromisoformat(since) if since else None
+    try:
+        since_dt = dt.fromisoformat(since) if since else None
+    except (ValueError, TypeError) as e:
+        return json.dumps({"error": f"Invalid 'since' timestamp: {e}"})
 
     results = mem.search(
         query=query,
@@ -904,7 +910,8 @@ def amfs_commit_outcome(
 
     Args:
         outcome_ref: Reference identifier (e.g. "INC-2047", "task-42", "PR-456")
-        outcome_type: One of "success", "minor_failure", "failure", "critical_failure"
+        outcome_type: One of "success", "minor_failure", "failure", "critical_failure",
+            "clean_deploy", "regression", "p2_incident", "p1_incident"
 
     Example: amfs_commit_outcome("task-42", "success")
     Example: amfs_commit_outcome("deploy-v2", "failure")
@@ -968,8 +975,11 @@ def amfs_history(
     from datetime import datetime as dt
 
     mem = _get_memory()
-    since_dt = dt.fromisoformat(since) if since else None
-    until_dt = dt.fromisoformat(until) if until else None
+    try:
+        since_dt = dt.fromisoformat(since) if since else None
+        until_dt = dt.fromisoformat(until) if until else None
+    except (ValueError, TypeError) as e:
+        return json.dumps({"error": f"Invalid timestamp: {e}"})
 
     versions = mem.history(entity_path, key, since=since_dt, until=until_dt)
     return json.dumps(
@@ -1156,12 +1166,15 @@ def amfs_list_traces(
     Example: amfs_list_traces(entity_path="checkout-service", limit=5)
     """
     mem = _get_memory()
-    traces = mem._adapter.list_traces(
-        entity_path=entity_path,
-        agent_id=agent_id,
-        outcome_type=outcome_type,
-        limit=limit,
-    )
+    try:
+        traces = mem._adapter.list_traces(
+            entity_path=entity_path,
+            agent_id=agent_id,
+            outcome_type=outcome_type,
+            limit=limit,
+        )
+    except Exception as e:
+        return json.dumps({"error": f"Could not list traces: {e}"})
     return json.dumps(
         [
             {
@@ -1195,7 +1208,10 @@ def amfs_get_trace(trace_id: str) -> str:
     Example: amfs_get_trace("abc123-def456")
     """
     mem = _get_memory()
-    trace = mem._adapter.get_trace(trace_id)
+    try:
+        trace = mem._adapter.get_trace(trace_id)
+    except Exception as e:
+        return json.dumps({"error": f"Could not retrieve trace: {e}"})
     if trace is None:
         return json.dumps({"status": "not_found", "trace_id": trace_id})
     return json.dumps(trace.model_dump(mode="json"), default=str)
@@ -1259,9 +1275,8 @@ def amfs_briefing(
 
     hint = (
         "No compiled briefings yet. "
-        "Try amfs_my_rooms() to check for shared rooms with team knowledge, "
-        "or use amfs_search() / amfs_recall() to find existing memories. "
-        "Use amfs_write() to start building knowledge."
+        "Use amfs_search() or amfs_recall() to find existing memories, "
+        "or amfs_write() to start building knowledge."
     )
     return json.dumps({"status": "empty", "message": hint})
 
@@ -1291,18 +1306,24 @@ def amfs_timeline(
     """
     from datetime import datetime as dt
     mem = _get_memory()
-    since_dt = dt.fromisoformat(since) if since else None
-    events = mem._adapter.list_events(
-        mem.agent_id,
-        mem._config.namespace,
-        event_type=event_type,
-        since=since_dt,
-        limit=limit,
-    )
-    return json.dumps({
-        "events": [e.model_dump(mode="json") for e in events],
-        "count": len(events),
-    }, default=str)
+    try:
+        since_dt = dt.fromisoformat(since) if since else None
+    except (ValueError, TypeError) as e:
+        return json.dumps({"error": f"Invalid 'since' timestamp: {e}"})
+    try:
+        events = mem._adapter.list_events(
+            mem.agent_id,
+            mem._config.namespace,
+            event_type=event_type,
+            since=since_dt,
+            limit=limit,
+        )
+        return json.dumps({
+            "events": [e.model_dump(mode="json") for e in events],
+            "count": len(events),
+        }, default=str)
+    except Exception as e:
+        return json.dumps({"error": f"Timeline unavailable: {e}"})
 
 
 @mcp.tool
@@ -1540,18 +1561,21 @@ def amfs_diff(
     return json.dumps(result, default=str)
 
 
-@mcp.tool()
+@mcp.tool
 def amfs_export_training_data(
     entity_paths: list[str] | None = None,
     min_confidence: float = 0.7,
     format: str = "sft",
     limit: int = 100,
-) -> dict:
+) -> str:
     """Export outcome-validated knowledge as a fine-tuning dataset.
 
     Generates training examples from decision traces in SFT, DPO, or
     Reward Model format. Only includes entries meeting the confidence
     threshold and linked to production outcomes.
+
+    Requires AMFS_HTTP_URL to be set and the amfs-pro-api package
+    installed on the server.
 
     Args:
         entity_paths: Filter to specific entities (exports all if omitted).
@@ -1559,23 +1583,127 @@ def amfs_export_training_data(
         format: Export format — "sft", "dpo", or "reward_model".
         limit: Maximum examples to generate.
 
-    Returns a dict with format, num_examples, and examples array.
+    Returns JSON with format, num_examples, and examples array.
     """
-    mem = _get_memory()
+    base_url = os.environ.get("AMFS_HTTP_URL")
+    if not base_url:
+        return json.dumps({"error": "AMFS_HTTP_URL not set — export requires an HTTP API connection"})
     try:
         import httpx
-        base_url = os.environ.get("AMFS_HTTP_URL", "http://localhost:8741")
-        params = {"format": format, "min_confidence": min_confidence, "limit": limit}
+        headers = {}
+        api_key = os.environ.get("AMFS_API_KEY", "")
+        if api_key:
+            headers["X-AMFS-API-Key"] = api_key
+        params: dict[str, Any] = {"format": format, "min_confidence": min_confidence, "limit": limit}
         if entity_paths:
             params["entity_path"] = entity_paths[0]
-        resp = httpx.get(f"{base_url}/api/v1/pro/export", params=params, timeout=30.0)
+        resp = httpx.get(f"{base_url}/api/v1/pro/export", params=params, headers=headers, timeout=30.0)
         if resp.status_code == 200:
-            return resp.json()
-        return {"error": f"Export endpoint returned {resp.status_code}", "detail": resp.text}
+            return json.dumps(resp.json(), default=str)
+        return json.dumps({"error": f"Export endpoint returned {resp.status_code}", "detail": resp.text})
     except ImportError:
-        return {"error": "httpx not installed — install it for export support"}
+        return json.dumps({"error": "httpx not installed — install it for export support"})
     except Exception as e:
-        return {"error": str(e)}
+        return json.dumps({"error": str(e)})
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Consolidation tools
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _http_api_call(method: str, path: str, *, params: dict | None = None, body: dict | None = None) -> str:
+    """Shared helper for tools that proxy to the AMFS HTTP API."""
+    base_url = os.environ.get("AMFS_HTTP_URL")
+    if not base_url:
+        return json.dumps({"error": "AMFS_HTTP_URL not set — this feature requires an HTTP API connection"})
+    try:
+        import httpx
+        headers: dict[str, str] = {}
+        api_key = os.environ.get("AMFS_API_KEY", "")
+        if api_key:
+            headers["X-AMFS-API-Key"] = api_key
+        if method == "GET":
+            resp = httpx.get(f"{base_url}{path}", params=params, headers=headers, timeout=30.0)
+        else:
+            resp = httpx.post(f"{base_url}{path}", params=params, json=body or {}, headers=headers, timeout=30.0)
+        if resp.status_code == 200:
+            return json.dumps(resp.json(), default=str)
+        return json.dumps({"error": f"API returned {resp.status_code}", "detail": resp.text})
+    except ImportError:
+        return json.dumps({"error": "httpx not installed — required for HTTP API features"})
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool
+def amfs_consolidation_status() -> str:
+    """Check the current memory consolidation status.
+
+    Returns metrics about automatic memory consolidation: how many entries
+    have been auto-archived, how many proposals are pending review, and
+    the overall health of the consolidation system.
+    """
+    return _http_api_call("GET", "/api/v1/cortex/consolidation/status")
+
+
+@mcp.tool
+def amfs_consolidation_proposals(
+    status: str = "pending",
+    limit: int = 20,
+) -> str:
+    """List memory consolidation proposals.
+
+    Consolidation proposals are created by the Cortex when it detects
+    opportunities to compress, merge, or archive memory entries. Tier B
+    proposals require human/agent review before merging.
+
+    Args:
+        status: Filter by proposal status — "pending", "approved", "rejected"
+        limit: Maximum proposals to return
+
+    Example: amfs_consolidation_proposals(status="pending")
+    """
+    return _http_api_call("GET", "/api/v1/cortex/consolidation/proposals",
+                          params={"status": status, "limit": limit})
+
+
+@mcp.tool
+def amfs_consolidation_candidates(
+    limit: int = 20,
+) -> str:
+    """List entries that are candidates for consolidation.
+
+    These are entries the Cortex has identified as potentially redundant,
+    superseded, or compressible. Review these to understand what the
+    consolidation system would act on.
+
+    Args:
+        limit: Maximum candidates to return
+    """
+    return _http_api_call("GET", "/api/v1/cortex/consolidation/candidates",
+                          params={"limit": limit})
+
+
+@mcp.tool
+def amfs_consolidate(
+    dry_run: bool = True,
+) -> str:
+    """Trigger a memory consolidation cycle.
+
+    Runs the Cortex consolidation strategy which:
+    - Tier A (automatic): archives superseded beliefs, prunes stale entries
+    - Tier B (proposals): creates consolidation proposals for convergent
+      knowledge and outcome rollups that need review
+
+    Args:
+        dry_run: If True (default), shows what would happen without making
+            changes. Set to False to actually run consolidation.
+
+    Example: amfs_consolidate(dry_run=True)
+    """
+    return _http_api_call("POST", "/api/v1/cortex/consolidate",
+                          body={"dry_run": dry_run})
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs"
-version = "0.5.1"
+version = "0.5.2"
 description = "AMFS Python SDK — Agent Memory File System"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/sdk-python/src/amfs/__init__.py
+++ b/packages/sdk-python/src/amfs/__init__.py
@@ -2,9 +2,14 @@
 
 from amfs_core.embedder import EmbedderABC
 from amfs_core.models import (
+    AMFSConfig,
     ConflictPolicy,
+    ConsolidationProposal,
+    ConsolidationReport,
     DecisionTrace,
+    DigestType,
     Event,
+    LayerConfig,
     MemoryEntry,
     MemoryStats,
     MemoryType,
@@ -20,15 +25,21 @@ from amfs_core.models import (
     SemanticQuery,
     SessionMetadata,
 )
+from amfs_core.exceptions import StaleWriteError
 
 from amfs.memory import AgentMemory, MemoryScope
 
 __all__ = [
     "AgentMemory",
+    "AMFSConfig",
     "ConflictPolicy",
+    "ConsolidationProposal",
+    "ConsolidationReport",
     "DecisionTrace",
+    "DigestType",
     "EmbedderABC",
     "Event",
+    "LayerConfig",
     "MemoryEntry",
     "MemoryScope",
     "MemoryStats",
@@ -44,4 +55,5 @@ __all__ = [
     "SearchQuery",
     "SemanticQuery",
     "SessionMetadata",
+    "StaleWriteError",
 ]

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -512,14 +512,15 @@ class AgentMemory:
                     seen_keys.add(entry.entry_key)
                     merged.append(entry)
 
-        sort_key: Callable[[MemoryEntry], Any]
-        if sort_by == "recency":
-            sort_key = lambda e: e.provenance.written_at
-        elif sort_by == "version":
-            sort_key = lambda e: e.version
-        else:
-            sort_key = lambda e: e.confidence
-        merged.sort(key=sort_key, reverse=True)
+        if sort_by != "priority":
+            sort_key: Callable[[MemoryEntry], Any]
+            if sort_by == "recency":
+                sort_key = lambda e: e.provenance.written_at
+            elif sort_by == "version":
+                sort_key = lambda e: e.version
+            else:
+                sort_key = lambda e: e.confidence
+            merged.sort(key=sort_key, reverse=True)
         entries = merged[:limit]
 
         self._read_tracker.record_query(

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senselab-ai/amfs",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "AMFS TypeScript SDK — Agent Memory File System",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk-typescript/src/adapters/http.ts
+++ b/packages/sdk-typescript/src/adapters/http.ts
@@ -13,6 +13,23 @@ export interface HttpAdapterOptions {
   headers?: Record<string, string>;
 }
 
+function snakeToCamel(str: string): string {
+  return str.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+function convertKeys(obj: unknown): unknown {
+  if (obj === null || obj === undefined) return obj;
+  if (Array.isArray(obj)) return obj.map(convertKeys);
+  if (typeof obj === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+      result[snakeToCamel(k)] = convertKeys(v);
+    }
+    return result;
+  }
+  return obj;
+}
+
 export class HttpAdapter implements AmfsAdapter {
   private readonly baseUrl: string;
   private readonly headers: Record<string, string>;
@@ -42,7 +59,8 @@ export class HttpAdapter implements AmfsAdapter {
       const body = await resp.text().catch(() => "");
       throw new Error(`AMFS API ${resp.status}: ${body}`);
     }
-    return resp.json() as Promise<T>;
+    const raw = await resp.json();
+    return convertKeys(raw) as T;
   }
 
   read(
@@ -50,7 +68,6 @@ export class HttpAdapter implements AmfsAdapter {
     key: string,
     options?: { minConfidence?: number }
   ): MemoryEntry | null {
-    // Synchronous interface — return null and let callers use readAsync
     return null;
   }
 
@@ -68,7 +85,6 @@ export class HttpAdapter implements AmfsAdapter {
   }
 
   write(entry: MemoryEntry): MemoryEntry {
-    // Synchronous interface — callers should use writeAsync for HTTP
     return entry;
   }
 
@@ -104,7 +120,6 @@ export class HttpAdapter implements AmfsAdapter {
     entityPath?: string,
     options?: { includeSuperseded?: boolean }
   ): MemoryEntry[] {
-    // Synchronous interface — return empty, callers should use listAsync
     return [];
   }
 
@@ -116,16 +131,25 @@ export class HttpAdapter implements AmfsAdapter {
     if (entityPath) params.set("entity_path", entityPath);
     if (options?.includeSuperseded) params.set("include_superseded", "true");
     const qs = params.toString();
-    return this.fetch<MemoryEntry[]>(`/api/v1/entries${qs ? `?${qs}` : ""}`);
+    const data = await this.fetch<{ entries: MemoryEntry[] } | MemoryEntry[]>(
+      `/api/v1/entries${qs ? `?${qs}` : ""}`
+    );
+    if (Array.isArray(data)) return data;
+    return data.entries ?? [];
   }
 
   async searchAsync(query: {
     query?: string;
     entityPath?: string;
     minConfidence?: number;
+    maxConfidence?: number;
     agentId?: string;
+    since?: string;
+    patternRef?: string;
     sortBy?: string;
     limit?: number;
+    depth?: number;
+    branch?: string;
   }): Promise<MemoryEntry[]> {
     return this.fetch<MemoryEntry[]>("/api/v1/search", {
       method: "POST",
@@ -134,8 +158,13 @@ export class HttpAdapter implements AmfsAdapter {
         entity_path: query.entityPath,
         min_confidence: query.minConfidence ?? 0.0,
         limit: query.limit ?? 100,
+        ...(query.maxConfidence != null ? { max_confidence: query.maxConfidence } : {}),
         ...(query.agentId ? { agent_id: query.agentId } : {}),
+        ...(query.since ? { since: query.since } : {}),
+        ...(query.patternRef ? { pattern_ref: query.patternRef } : {}),
         ...(query.sortBy ? { sort_by: query.sortBy } : {}),
+        ...(query.depth != null ? { depth: query.depth } : {}),
+        ...(query.branch ? { branch: query.branch } : {}),
       }),
     });
   }
@@ -172,7 +201,7 @@ export class HttpAdapter implements AmfsAdapter {
                 const raw = line.slice(5).trim();
                 if (raw) {
                   try {
-                    callback(JSON.parse(raw) as MemoryEntry);
+                    callback(convertKeys(JSON.parse(raw)) as MemoryEntry);
                   } catch { /* skip malformed */ }
                 }
               }
@@ -190,7 +219,6 @@ export class HttpAdapter implements AmfsAdapter {
   }
 
   commitOutcome(record: OutcomeRecord): MemoryEntry[] {
-    // Synchronous interface — return empty, callers should use commitOutcomeAsync
     return [];
   }
 
@@ -199,7 +227,10 @@ export class HttpAdapter implements AmfsAdapter {
     outcomeType: string;
     entityPath?: string;
     causalEntryKeys?: string[];
+    causalConfidence?: number;
+    agentId?: string;
   }): Promise<unknown> {
+    const agentId = record.agentId ?? this.agentId;
     return this.fetch("/api/v1/outcomes", {
       method: "POST",
       body: JSON.stringify({
@@ -207,6 +238,8 @@ export class HttpAdapter implements AmfsAdapter {
         outcome_type: record.outcomeType,
         ...(record.entityPath ? { entity_path: record.entityPath } : {}),
         ...(record.causalEntryKeys?.length ? { causal_entry_keys: record.causalEntryKeys } : {}),
+        ...(record.causalConfidence != null ? { causal_confidence: record.causalConfidence } : {}),
+        ...(agentId ? { agent_id: agentId } : {}),
       }),
     });
   }
@@ -217,6 +250,50 @@ export class HttpAdapter implements AmfsAdapter {
 
   async healthAsync(): Promise<Record<string, unknown>> {
     return this.fetch<Record<string, unknown>>("/api/v1/health");
+  }
+
+  async briefingAsync(options?: {
+    entityPath?: string;
+    limit?: number;
+  }): Promise<unknown> {
+    const params = new URLSearchParams();
+    if (options?.entityPath) params.set("entity_path", options.entityPath);
+    if (options?.limit) params.set("limit", String(options.limit));
+    const qs = params.toString();
+    return this.fetch(`/api/v1/briefing${qs ? `?${qs}` : ""}`);
+  }
+
+  async consolidationStatusAsync(): Promise<unknown> {
+    return this.fetch("/api/v1/cortex/consolidation/status");
+  }
+
+  async consolidationProposalsAsync(options?: {
+    status?: string;
+    limit?: number;
+  }): Promise<unknown> {
+    const params = new URLSearchParams();
+    if (options?.status) params.set("status", options.status);
+    if (options?.limit) params.set("limit", String(options.limit));
+    const qs = params.toString();
+    return this.fetch(`/api/v1/cortex/consolidation/proposals${qs ? `?${qs}` : ""}`);
+  }
+
+  async consolidationCandidatesAsync(options?: {
+    limit?: number;
+  }): Promise<unknown> {
+    const params = new URLSearchParams();
+    if (options?.limit) params.set("limit", String(options.limit));
+    const qs = params.toString();
+    return this.fetch(`/api/v1/cortex/consolidation/candidates${qs ? `?${qs}` : ""}`);
+  }
+
+  async consolidateAsync(options?: {
+    dryRun?: boolean;
+  }): Promise<unknown> {
+    return this.fetch("/api/v1/cortex/consolidate", {
+      method: "POST",
+      body: JSON.stringify({ dry_run: options?.dryRun ?? true }),
+    });
   }
 
   async listTracesAsync(options?: {
@@ -231,9 +308,10 @@ export class HttpAdapter implements AmfsAdapter {
     if (options?.outcomeType) params.set("outcome_type", options.outcomeType);
     if (options?.limit) params.set("limit", String(options.limit));
     const qs = params.toString();
-    const data = await this.fetch<{ traces: DecisionTraceSummary[] }>(
+    const data = await this.fetch<{ traces: DecisionTraceSummary[] } | DecisionTraceSummary[]>(
       `/api/v1/traces${qs ? `?${qs}` : ""}`
     );
+    if (Array.isArray(data)) return data;
     return data.traces ?? [];
   }
 
@@ -248,59 +326,59 @@ export class HttpAdapter implements AmfsAdapter {
 
 export interface DecisionTraceSummary {
   id: string;
-  agent_id: string;
-  outcome_ref: string;
-  outcome_type: string;
-  decision_summary?: string;
-  causal_entries: number;
-  external_contexts: number;
-  session_duration_ms?: number;
-  created_at: string;
+  agentId: string;
+  outcomeRef: string;
+  outcomeType: string;
+  decisionSummary?: string;
+  causalEntries: number;
+  externalContexts: number;
+  sessionDurationMs?: number;
+  createdAt: string;
 }
 
 export interface DecisionTrace {
   id: string;
-  agent_id: string;
-  session_id: string;
-  outcome_ref: string;
-  outcome_type: string;
-  decision_summary?: string;
-  causal_entries: Array<{
-    entity_path: string;
+  agentId: string;
+  sessionId: string;
+  outcomeRef: string;
+  outcomeType: string;
+  decisionSummary?: string;
+  causalEntries: Array<{
+    entityPath: string;
     key: string;
     version: number;
     confidence: number;
     value?: unknown;
-    memory_type?: string;
-    written_by?: string;
-    read_at?: string;
+    memoryType?: string;
+    writtenBy?: string;
+    readAt?: string;
   }>;
-  external_contexts: Array<{
+  externalContexts: Array<{
     label: string;
     summary: string;
     source?: string;
-    recorded_at?: string;
+    recordedAt?: string;
   }>;
-  query_events: Array<{
+  queryEvents: Array<{
     operation: string;
     parameters: Record<string, unknown>;
-    result_count: number;
-    duration_ms?: number;
-    occurred_at?: string;
+    resultCount: number;
+    durationMs?: number;
+    occurredAt?: string;
   }>;
-  error_events: Array<{
+  errorEvents: Array<{
     operation: string;
-    error_type: string;
+    errorType: string;
     message: string;
-    stack_trace?: string;
-    occurred_at?: string;
+    stackTrace?: string;
+    occurredAt?: string;
   }>;
-  state_diff?: {
-    entries_created: number;
-    entries_updated: number;
+  stateDiff?: {
+    entriesCreated: number;
+    entriesUpdated: number;
   };
-  session_started_at?: string;
-  session_ended_at?: string;
-  session_duration_ms?: number;
-  created_at: string;
+  sessionStartedAt?: string;
+  sessionEndedAt?: string;
+  sessionDurationMs?: number;
+  createdAt: string;
 }

--- a/packages/sdk-typescript/src/memory.ts
+++ b/packages/sdk-typescript/src/memory.ts
@@ -27,7 +27,7 @@ export interface SearchOptions {
   since?: string;
   patternRef?: string;
   limit?: number;
-  sortBy?: "confidence" | "recency" | "version";
+  sortBy?: "confidence" | "recency" | "version" | "priority";
   recallConfig?: RecallConfig;
 }
 

--- a/packages/sdk-typescript/src/models.ts
+++ b/packages/sdk-typescript/src/models.ts
@@ -53,6 +53,11 @@ export interface MemoryEntry {
   contentHash: string | null;
   integrityChain: string | null;
   commitId: string | null;
+  memoryType?: string;
+  branch?: string;
+  recallCount?: number;
+  priorityScore?: number;
+  tier?: string;
 }
 
 export interface CommitEntry {


### PR DESCRIPTION
## Summary

Comprehensive alignment of all three public packages with the latest backend features from the continual learning infrastructure.

### MCP Server (0.7.2 -> 0.7.3)
- **Fix briefing empty-state hint** — removed `amfs_my_rooms()` reference that only exists in Pro MCP
- **Add `branch` parameter** to `amfs_write` tool for writing to non-default branches
- **Add 4 consolidation tools**: `amfs_consolidation_status`, `amfs_consolidation_proposals`, `amfs_consolidation_candidates`, `amfs_consolidate`
- **Fix `amfs_export_training_data`** — return `str` (not dict), send auth headers, guard against missing `AMFS_HTTP_URL`
- **Update docstrings** — `amfs_search` now documents `priority` sort, `amfs_commit_outcome` now lists all 8 outcome types
- **Add error handling** — ISO timestamp parsing and trace retrieval now return graceful JSON errors instead of crashing the MCP process
- **Fix dependency pin** — `amfs-adapter-http>=0.1.2` (was pinned too high)

### Python SDK (0.5.1 -> 0.5.2)
- **Fix `search()` priority sort** — when `sort_by="priority"`, skip the default confidence re-sort that was overriding the adapter's priority-scored ordering
- **Export new models** — `ConsolidationProposal`, `ConsolidationReport`, `DigestType`, `StaleWriteError`, `AMFSConfig`, `LayerConfig`

### TypeScript SDK (0.3.1 -> 0.3.2)
- **Add snake_case -> camelCase response parsing** — all API responses are now automatically converted to match TS conventions
- **Fix `listAsync`** — unwraps `{ entries: [...] }` response wrapper from the API
- **Fix `commitOutcomeAsync`** — now sends `causal_confidence` and `agent_id`
- **Add missing `searchAsync` params** — `maxConfidence`, `since`, `patternRef`, `depth`, `branch`
- **Add `briefingAsync`** to HttpAdapter
- **Add consolidation methods** — `consolidationStatusAsync`, `consolidationProposalsAsync`, `consolidationCandidatesAsync`, `consolidateAsync`
- **Add `priority` to `SearchOptions.sortBy`** type
- **Add missing fields to `MemoryEntry`** — `memoryType`, `branch`, `recallCount`, `priorityScore`, `tier`

## Test plan
- [ ] Verify MCP server starts and all new tools are registered
- [ ] Test briefing with empty entity shows updated hint (no rooms reference)
- [ ] Test `amfs_write` with `branch` parameter
- [ ] Test consolidation tools return graceful errors when AMFS_HTTP_URL not set
- [ ] Verify Python SDK `search(sort_by="priority")` preserves adapter ordering
- [ ] Verify new Python SDK exports import cleanly
- [ ] Build TS SDK (`npm run build`) — verified clean
- [ ] Test TS HttpAdapter response key conversion (snake_case -> camelCase)