### PR TITLE
fix(security): apply UserVisibilityFilter to briefing + cortex endpoints

### DIFF
--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -3752,8 +3752,71 @@ async def list_connectors(
 # ──────────────────────────────────────────────────────────────────────
 
 
+def _is_agent_visible_for_entity(
+    agent_id: str,
+    entity_path: str,
+    user_agents: set[str],
+    room_map: dict[str, set[str]],
+) -> bool:
+    """Check if an agent is visible in the context of a specific entity_path.
+
+    Mirrors the logic of UserVisibilityFilter.is_entry_visible but works
+    with raw agent_id + entity_path instead of requiring a full entry object.
+    """
+    if agent_id in user_agents:
+        return True
+    room_members = room_map.get(entity_path)
+    if room_members:
+        if agent_id in room_members:
+            return True
+        if agent_id in ("amfs-server", "system", "amfs"):
+            return True
+    return False
+
+
+def _filter_briefing_digests(vis: Any, digests: list) -> list:
+    """Filter briefing digests and their hot_context through visibility.
+
+    Ensures briefing only surfaces data the user could also access via
+    amfs_read / amfs_search, maintaining consistency across all endpoints.
+    """
+    user_agents = vis.get_user_agents()
+    room_map = vis.get_room_map()
+    filtered = []
+
+    for digest in digests:
+        scope = digest.scope
+        source_agents = digest.source_agents
+
+        if "hot_context" in digest.summary:
+            digest.summary["hot_context"] = [
+                h for h in digest.summary["hot_context"]
+                if _is_agent_visible_for_entity(
+                    h.get("agent", ""), scope, user_agents, room_map,
+                )
+            ]
+
+        if source_agents:
+            has_visible = any(
+                _is_agent_visible_for_entity(a, scope, user_agents, room_map)
+                for a in source_agents
+            )
+            if not has_visible:
+                continue
+        else:
+            has_room_access = scope in room_map
+            has_visible_hot = bool(digest.summary.get("hot_context"))
+            if not has_room_access and not has_visible_hot:
+                continue
+
+        filtered.append(digest)
+
+    return filtered
+
+
 @app.get("/api/v1/briefing")
 async def get_briefing(
+    request: Request,
     entity_path: str | None = Query(None),
     agent_id: str | None = Query(None),
     limit: int = Query(10, ge=1, le=100),
@@ -3766,6 +3829,11 @@ async def get_briefing(
         agent_id=agent_id,
         limit=limit,
     )
+
+    vis = _get_visibility_filter(request)
+    if vis is not None and vis.should_filter():
+        digests = _filter_briefing_digests(vis, digests)
+
     return {
         "digests": [d.model_dump(mode="json") for d in digests],
         "total": len(digests),
@@ -3774,6 +3842,7 @@ async def get_briefing(
 
 @app.get("/api/v1/cortex/status")
 async def cortex_status(
+    request: Request,
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
     """Get Cortex worker status and digest statistics."""
@@ -3789,6 +3858,11 @@ async def cortex_status(
         adapter = mem._adapter
         if isinstance(adapter, PostgresAdapter):
             all_digests = adapter.list_digests()
+
+            vis = _get_visibility_filter(request)
+            if vis is not None and vis.should_filter():
+                all_digests = _filter_briefing_digests(vis, all_digests)
+
             return {
                 "status": "active" if all_digests else "idle",
                 "digest_count": len(all_digests),
@@ -3808,6 +3882,7 @@ async def cortex_status(
 
 @app.get("/api/v1/cortex/digests")
 async def list_cortex_digests(
+    request: Request,
     digest_type: str | None = Query(None),
     scope: str | None = Query(None),
     _auth: str | None = Depends(verify_api_key),
@@ -3825,6 +3900,11 @@ async def list_cortex_digests(
             digests = adapter.list_digests(digest_type=dt, namespace=namespace)
             if scope:
                 digests = [d for d in digests if d.scope == scope]
+
+            vis = _get_visibility_filter(request)
+            if vis is not None and vis.should_filter():
+                digests = _filter_briefing_digests(vis, digests)
+
             return {
                 "digests": [d.model_dump(mode="json") for d in digests],
                 "total": len(digests),

--- a/tests/unit/test_briefing_visibility.py
+++ b/tests/unit/test_briefing_visibility.py
@@ -13,8 +13,10 @@ from unittest.mock import MagicMock
 import pytest
 
 pytest.importorskip("amfs_core", reason="amfs_core not installed")
+amfs_http = pytest.importorskip("amfs_http", reason="amfs_http not installed")
 
 from amfs_core.models import Digest, DigestType
+from amfs_http.server import _filter_briefing_digests, _is_agent_visible_for_entity
 
 
 def _digest(
@@ -57,118 +59,97 @@ def _mock_vis(user_agents: set[str], room_map: dict[str, set[str]] | None = None
     return vis
 
 
-@pytest.fixture()
-def import_helpers():
-    from amfs_http.server import _filter_briefing_digests, _is_agent_visible_for_entity
-    return _filter_briefing_digests, _is_agent_visible_for_entity
-
-
 class TestIsAgentVisibleForEntity:
 
-    def test_own_agent_always_visible(self, import_helpers):
-        _, is_visible = import_helpers
-        assert is_visible("my-agent", "any/path", {"my-agent"}, {})
+    def test_own_agent_always_visible(self):
+        assert _is_agent_visible_for_entity("my-agent", "any/path", {"my-agent"}, {})
 
-    def test_foreign_agent_not_visible_without_room(self, import_helpers):
-        _, is_visible = import_helpers
-        assert not is_visible("other-agent", "any/path", {"my-agent"}, {})
+    def test_foreign_agent_not_visible_without_room(self):
+        assert not _is_agent_visible_for_entity("other-agent", "any/path", {"my-agent"}, {})
 
-    def test_room_co_member_visible_on_room_entity(self, import_helpers):
-        _, is_visible = import_helpers
+    def test_room_co_member_visible_on_room_entity(self):
         room_map = {"shared/project": {"other-agent", "my-agent"}}
-        assert is_visible("other-agent", "shared/project", {"my-agent"}, room_map)
+        assert _is_agent_visible_for_entity("other-agent", "shared/project", {"my-agent"}, room_map)
 
-    def test_room_co_member_not_visible_on_different_entity(self, import_helpers):
-        _, is_visible = import_helpers
+    def test_room_co_member_not_visible_on_different_entity(self):
         room_map = {"shared/project": {"other-agent", "my-agent"}}
-        assert not is_visible("other-agent", "different/path", {"my-agent"}, room_map)
+        assert not _is_agent_visible_for_entity("other-agent", "different/path", {"my-agent"}, room_map)
 
-    def test_system_agent_visible_on_room_entity(self, import_helpers):
-        _, is_visible = import_helpers
+    def test_system_agent_visible_on_room_entity(self):
         room_map = {"shared/project": {"my-agent"}}
-        assert is_visible("amfs-server", "shared/project", {"my-agent"}, room_map)
+        assert _is_agent_visible_for_entity("amfs-server", "shared/project", {"my-agent"}, room_map)
 
-    def test_system_agent_not_visible_without_room(self, import_helpers):
-        _, is_visible = import_helpers
-        assert not is_visible("amfs-server", "other/path", {"my-agent"}, {})
+    def test_system_agent_not_visible_without_room(self):
+        assert not _is_agent_visible_for_entity("amfs-server", "other/path", {"my-agent"}, {})
 
 
 class TestFilterBriefingDigests:
 
-    def test_digest_with_own_agent_source_kept(self, import_helpers):
-        filter_fn, _ = import_helpers
+    def test_digest_with_own_agent_source_kept(self):
         vis = _mock_vis({"my-agent"})
         d = _digest(source_agents=["my-agent"])
-        result = filter_fn(vis, [d])
+        result = _filter_briefing_digests(vis, [d])
         assert len(result) == 1
 
-    def test_digest_with_foreign_agent_source_removed(self, import_helpers):
-        filter_fn, _ = import_helpers
+    def test_digest_with_foreign_agent_source_removed(self):
         vis = _mock_vis({"my-agent"})
         d = _digest(source_agents=["foreign-agent"])
-        result = filter_fn(vis, [d])
+        result = _filter_briefing_digests(vis, [d])
         assert len(result) == 0
 
-    def test_digest_with_mixed_sources_kept_if_any_visible(self, import_helpers):
-        filter_fn, _ = import_helpers
+    def test_digest_with_mixed_sources_kept_if_any_visible(self):
         vis = _mock_vis({"my-agent"})
         d = _digest(source_agents=["foreign-agent", "my-agent"])
-        result = filter_fn(vis, [d])
+        result = _filter_briefing_digests(vis, [d])
         assert len(result) == 1
 
-    def test_digest_room_co_member_source_kept(self, import_helpers):
-        filter_fn, _ = import_helpers
+    def test_digest_room_co_member_source_kept(self):
         vis = _mock_vis(
             {"my-agent"},
             room_map={"myapp/auth": {"my-agent", "teammate-agent"}},
         )
         d = _digest(scope="myapp/auth", source_agents=["teammate-agent"])
-        result = filter_fn(vis, [d])
+        result = _filter_briefing_digests(vis, [d])
         assert len(result) == 1
 
-    def test_synthesized_digest_empty_sources_on_room_entity_kept(self, import_helpers):
-        filter_fn, _ = import_helpers
+    def test_synthesized_digest_empty_sources_on_room_entity_kept(self):
         vis = _mock_vis(
             {"my-agent"},
             room_map={"myapp/auth": {"my-agent"}},
         )
         d = _digest(scope="myapp/auth", source_agents=[])
-        result = filter_fn(vis, [d])
+        result = _filter_briefing_digests(vis, [d])
         assert len(result) == 1
 
-    def test_synthesized_digest_empty_sources_no_access_removed(self, import_helpers):
-        filter_fn, _ = import_helpers
+    def test_synthesized_digest_empty_sources_no_access_removed(self):
         vis = _mock_vis({"my-agent"})
         d = _digest(scope="foreign/entity", source_agents=[])
-        result = filter_fn(vis, [d])
+        result = _filter_briefing_digests(vis, [d])
         assert len(result) == 0
 
-    def test_hot_context_own_agent_entries_kept(self, import_helpers):
-        filter_fn, _ = import_helpers
+    def test_hot_context_own_agent_entries_kept(self):
         vis = _mock_vis({"my-agent"})
         d = _digest(
             source_agents=["my-agent"],
             hot_context=[_hot("my-agent", "key-1"), _hot("my-agent", "key-2")],
         )
-        result = filter_fn(vis, [d])
+        result = _filter_briefing_digests(vis, [d])
         assert len(result) == 1
         assert len(result[0].summary["hot_context"]) == 2
 
-    def test_hot_context_foreign_agent_entries_removed(self, import_helpers):
-        filter_fn, _ = import_helpers
+    def test_hot_context_foreign_agent_entries_removed(self):
         vis = _mock_vis({"my-agent"})
         d = _digest(
             source_agents=["my-agent"],
             hot_context=[_hot("my-agent", "keep"), _hot("foreign-agent", "remove")],
         )
-        result = filter_fn(vis, [d])
+        result = _filter_briefing_digests(vis, [d])
         assert len(result) == 1
         hc = result[0].summary["hot_context"]
         assert len(hc) == 1
         assert hc[0]["key"] == "keep"
 
-    def test_hot_context_room_co_member_entries_kept(self, import_helpers):
-        filter_fn, _ = import_helpers
+    def test_hot_context_room_co_member_entries_kept(self):
         vis = _mock_vis(
             {"my-agent"},
             room_map={"myapp/auth": {"my-agent", "teammate"}},
@@ -178,40 +159,34 @@ class TestFilterBriefingDigests:
             source_agents=["my-agent"],
             hot_context=[_hot("teammate", "shared-key")],
         )
-        result = filter_fn(vis, [d])
+        result = _filter_briefing_digests(vis, [d])
         assert len(result) == 1
         assert len(result[0].summary["hot_context"]) == 1
 
-    def test_multiple_digests_partially_filtered(self, import_helpers):
-        filter_fn, _ = import_helpers
+    def test_multiple_digests_partially_filtered(self):
         vis = _mock_vis({"my-agent"})
         d_visible = _digest(scope="mine/svc", source_agents=["my-agent"])
         d_hidden = _digest(scope="other/svc", source_agents=["foreign"])
-        result = filter_fn(vis, [d_visible, d_hidden])
+        result = _filter_briefing_digests(vis, [d_visible, d_hidden])
         assert len(result) == 1
         assert result[0].scope == "mine/svc"
 
-    def test_empty_digests_returns_empty(self, import_helpers):
-        filter_fn, _ = import_helpers
+    def test_empty_digests_returns_empty(self):
         vis = _mock_vis({"my-agent"})
-        assert filter_fn(vis, []) == []
+        assert _filter_briefing_digests(vis, []) == []
 
 
 class TestAdminBypass:
 
-    def test_admin_should_filter_false(self, import_helpers):
-        """When should_filter() is False (admin), the endpoint skips filtering entirely.
-        We verify the helper is never called by checking it preserves all digests."""
-        filter_fn, _ = import_helpers
+    def test_admin_should_filter_false(self):
+        """When should_filter() is False (admin), the endpoint skips filtering entirely."""
         vis = MagicMock()
         vis.should_filter.return_value = False
-        d = _digest(source_agents=["foreign-agent"])
         assert vis.should_filter() is False
 
 
 class TestOSSNoFilter:
 
-    def test_no_visibility_filter_on_request(self, import_helpers):
-        """When _get_visibility_filter returns None (OSS), no filtering occurs.
-        The helper function is never called."""
+    def test_no_visibility_filter_on_request(self):
+        """When _get_visibility_filter returns None (OSS), no filtering occurs."""
         pass

--- a/tests/unit/test_briefing_visibility.py
+++ b/tests/unit/test_briefing_visibility.py
@@ -1,0 +1,217 @@
+"""Unit tests for briefing visibility filtering.
+
+Verifies that _filter_briefing_digests and _is_agent_visible_for_entity
+correctly filter digests and hot_context entries based on user ownership
+and room membership, matching the same rules as UserVisibilityFilter.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("amfs_core", reason="amfs_core not installed")
+
+from amfs_core.models import Digest, DigestType
+
+
+def _digest(
+    scope: str = "myapp/auth",
+    source_agents: list[str] | None = None,
+    hot_context: list[dict] | None = None,
+    digest_type: DigestType = DigestType.ENTITY,
+) -> Digest:
+    summary: dict = {"narrative": "test digest"}
+    if hot_context is not None:
+        summary["hot_context"] = hot_context
+    return Digest(
+        digest_type=digest_type,
+        scope=scope,
+        summary=summary,
+        entry_count=5,
+        source_agents=source_agents or [],
+        compiled_at=datetime.now(timezone.utc),
+        namespace="default",
+        branch="main",
+    )
+
+
+def _hot(agent: str, key: str = "some-key") -> dict:
+    return {
+        "key": key,
+        "value": "some value",
+        "confidence": 0.9,
+        "agent": agent,
+        "outcome_count": 1,
+        "recall_count": 2,
+    }
+
+
+def _mock_vis(user_agents: set[str], room_map: dict[str, set[str]] | None = None):
+    vis = MagicMock()
+    vis.should_filter.return_value = True
+    vis.get_user_agents.return_value = user_agents
+    vis.get_room_map.return_value = room_map or {}
+    return vis
+
+
+@pytest.fixture()
+def import_helpers():
+    from amfs_http.server import _filter_briefing_digests, _is_agent_visible_for_entity
+    return _filter_briefing_digests, _is_agent_visible_for_entity
+
+
+class TestIsAgentVisibleForEntity:
+
+    def test_own_agent_always_visible(self, import_helpers):
+        _, is_visible = import_helpers
+        assert is_visible("my-agent", "any/path", {"my-agent"}, {})
+
+    def test_foreign_agent_not_visible_without_room(self, import_helpers):
+        _, is_visible = import_helpers
+        assert not is_visible("other-agent", "any/path", {"my-agent"}, {})
+
+    def test_room_co_member_visible_on_room_entity(self, import_helpers):
+        _, is_visible = import_helpers
+        room_map = {"shared/project": {"other-agent", "my-agent"}}
+        assert is_visible("other-agent", "shared/project", {"my-agent"}, room_map)
+
+    def test_room_co_member_not_visible_on_different_entity(self, import_helpers):
+        _, is_visible = import_helpers
+        room_map = {"shared/project": {"other-agent", "my-agent"}}
+        assert not is_visible("other-agent", "different/path", {"my-agent"}, room_map)
+
+    def test_system_agent_visible_on_room_entity(self, import_helpers):
+        _, is_visible = import_helpers
+        room_map = {"shared/project": {"my-agent"}}
+        assert is_visible("amfs-server", "shared/project", {"my-agent"}, room_map)
+
+    def test_system_agent_not_visible_without_room(self, import_helpers):
+        _, is_visible = import_helpers
+        assert not is_visible("amfs-server", "other/path", {"my-agent"}, {})
+
+
+class TestFilterBriefingDigests:
+
+    def test_digest_with_own_agent_source_kept(self, import_helpers):
+        filter_fn, _ = import_helpers
+        vis = _mock_vis({"my-agent"})
+        d = _digest(source_agents=["my-agent"])
+        result = filter_fn(vis, [d])
+        assert len(result) == 1
+
+    def test_digest_with_foreign_agent_source_removed(self, import_helpers):
+        filter_fn, _ = import_helpers
+        vis = _mock_vis({"my-agent"})
+        d = _digest(source_agents=["foreign-agent"])
+        result = filter_fn(vis, [d])
+        assert len(result) == 0
+
+    def test_digest_with_mixed_sources_kept_if_any_visible(self, import_helpers):
+        filter_fn, _ = import_helpers
+        vis = _mock_vis({"my-agent"})
+        d = _digest(source_agents=["foreign-agent", "my-agent"])
+        result = filter_fn(vis, [d])
+        assert len(result) == 1
+
+    def test_digest_room_co_member_source_kept(self, import_helpers):
+        filter_fn, _ = import_helpers
+        vis = _mock_vis(
+            {"my-agent"},
+            room_map={"myapp/auth": {"my-agent", "teammate-agent"}},
+        )
+        d = _digest(scope="myapp/auth", source_agents=["teammate-agent"])
+        result = filter_fn(vis, [d])
+        assert len(result) == 1
+
+    def test_synthesized_digest_empty_sources_on_room_entity_kept(self, import_helpers):
+        filter_fn, _ = import_helpers
+        vis = _mock_vis(
+            {"my-agent"},
+            room_map={"myapp/auth": {"my-agent"}},
+        )
+        d = _digest(scope="myapp/auth", source_agents=[])
+        result = filter_fn(vis, [d])
+        assert len(result) == 1
+
+    def test_synthesized_digest_empty_sources_no_access_removed(self, import_helpers):
+        filter_fn, _ = import_helpers
+        vis = _mock_vis({"my-agent"})
+        d = _digest(scope="foreign/entity", source_agents=[])
+        result = filter_fn(vis, [d])
+        assert len(result) == 0
+
+    def test_hot_context_own_agent_entries_kept(self, import_helpers):
+        filter_fn, _ = import_helpers
+        vis = _mock_vis({"my-agent"})
+        d = _digest(
+            source_agents=["my-agent"],
+            hot_context=[_hot("my-agent", "key-1"), _hot("my-agent", "key-2")],
+        )
+        result = filter_fn(vis, [d])
+        assert len(result) == 1
+        assert len(result[0].summary["hot_context"]) == 2
+
+    def test_hot_context_foreign_agent_entries_removed(self, import_helpers):
+        filter_fn, _ = import_helpers
+        vis = _mock_vis({"my-agent"})
+        d = _digest(
+            source_agents=["my-agent"],
+            hot_context=[_hot("my-agent", "keep"), _hot("foreign-agent", "remove")],
+        )
+        result = filter_fn(vis, [d])
+        assert len(result) == 1
+        hc = result[0].summary["hot_context"]
+        assert len(hc) == 1
+        assert hc[0]["key"] == "keep"
+
+    def test_hot_context_room_co_member_entries_kept(self, import_helpers):
+        filter_fn, _ = import_helpers
+        vis = _mock_vis(
+            {"my-agent"},
+            room_map={"myapp/auth": {"my-agent", "teammate"}},
+        )
+        d = _digest(
+            scope="myapp/auth",
+            source_agents=["my-agent"],
+            hot_context=[_hot("teammate", "shared-key")],
+        )
+        result = filter_fn(vis, [d])
+        assert len(result) == 1
+        assert len(result[0].summary["hot_context"]) == 1
+
+    def test_multiple_digests_partially_filtered(self, import_helpers):
+        filter_fn, _ = import_helpers
+        vis = _mock_vis({"my-agent"})
+        d_visible = _digest(scope="mine/svc", source_agents=["my-agent"])
+        d_hidden = _digest(scope="other/svc", source_agents=["foreign"])
+        result = filter_fn(vis, [d_visible, d_hidden])
+        assert len(result) == 1
+        assert result[0].scope == "mine/svc"
+
+    def test_empty_digests_returns_empty(self, import_helpers):
+        filter_fn, _ = import_helpers
+        vis = _mock_vis({"my-agent"})
+        assert filter_fn(vis, []) == []
+
+
+class TestAdminBypass:
+
+    def test_admin_should_filter_false(self, import_helpers):
+        """When should_filter() is False (admin), the endpoint skips filtering entirely.
+        We verify the helper is never called by checking it preserves all digests."""
+        filter_fn, _ = import_helpers
+        vis = MagicMock()
+        vis.should_filter.return_value = False
+        d = _digest(source_agents=["foreign-agent"])
+        assert vis.should_filter() is False
+
+
+class TestOSSNoFilter:
+
+    def test_no_visibility_filter_on_request(self, import_helpers):
+        """When _get_visibility_filter returns None (OSS), no filtering occurs.
+        The helper function is never called."""
+        pass


### PR DESCRIPTION
## Summary

Fixesthe briefing endpoint cross-user data that `amfs_read` then couldn't access.

- **GET /api/v1/briefing** -- now applies `UserVisibilityFilter` to filter digests and hot_context entries
- **GET /api/v1/cortex/status** -- now applies visibility to digest counts
- **GET /api/v1/cortex/digests** -- now applies visibility to digest listing

### Key implementation details

- New `_is_agent_visible_for_entity(agent_id, entity_path, user_agents, room_map)` helper mirrors `is_entry_visible` logic but works with raw IDs (no full entry object needed)
- New `_filter_briefing_digests(vis, digests)` handles digest-level filtering AND hot_context entry filtering within digests
- Handles the hot_context dict shape (`{"agent": "..."}`) without modifying `amfs-internal/amfs_rooms/visibility.py` -- normalization is done in the HTTP handler
- For synthesized digests (empty `source_agents`), keeps the digest only if user has room access to the entity_path or there are surviving hot_context entries
- Admin users bypass filtering entirely (`should_filter=False`)
- OSS deployments are completely unaffected (no `UserVisibilityFilter` present)
- Zero additional DB queries -- reuses cached `user_agents`/`room_map` from the per-request visibility filter

### Not in scope (follow-up)

A full endpoint audit found ~35 additional endpoints that may need visibility filtering (SSE stream, consolidation endpoints, history, traces, etc.). These are documented in the plan and will be addressed in a separate PR.