### PR TITLE
chore: bump stale package versions (core, http-server, adapter-postgres)

### DIFF
--- a/packages/adapters/postgres/pyproject.toml
+++ b/packages/adapters/postgres/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-adapter-postgres"
-version = "0.1.4"
+version = "0.1.5"
 description = "AMFS Postgres adapter with back-propagation triggers"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-core"
-version = "0.3.3"
+version = "0.3.4"
 description = "AMFS core models, engine, and adapter ABC"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/http-server/pyproject.toml
+++ b/packages/http-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-http-server"
-version = "0.3.2"
+version = "0.3.3"
 description = "AMFS HTTP/REST API server with SSE support"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/integrations/crewai/pyproject.toml
+++ b/packages/integrations/crewai/pyproject.toml
@@ -3,6 +3,7 @@ name = "amfs-crewai"
 version = "0.1.0"
 description = "Use AMFS as CrewAI Memory storage backend"
 requires-python = ">=3.11"
+license = "Apache-2.0"
 dependencies = [
     "amfs",
     "amfs-core",


### PR DESCRIPTION
## Summary

- **amfs-core** 0.3.3 → 0.3.4 — continual learning infrastructure, commit_outcome perf
- **amfs-http-server** 0.3.2 → 0.3.3 — briefing visibility fix, async adapter, perf fixes, tenant isolation
- **amfs-adapter-postgres** 0.1.4 → 0.1.5 — async psycopg, sync fallbacks, write latency fix, multi-tenant
- **amfs-crewai** — add missing license field

All 7 packages already published to PyPI:
- `amfs-core` 0.3.4, `amfs-http-server` 0.3.3, `amfs-adapter-postgres` 0.1.5
- `amfs-crewai` 0.1.0, `amfs-langgraph` 0.1.0, `amfs-langchain` 0.1.0, `amfs-autogen` 0.1.0