### PR TITLE
fix: surface set_identity agents on dashboard + add Codex MCP

### DIFF
--- a/install-mcp.sh
+++ b/install-mcp.sh
@@ -53,7 +53,7 @@ Usage:
 
 Options:
   --client <name|all>   Configure a specific client: claude-desktop, cursor,
-                        claude-code, windsurf, vscode, or "all"
+                        claude-code, codex, windsurf, vscode, or "all"
   --api-key <key>       Connect to AMFS SaaS with this API key
   --api-url <url>       SaaS API URL (default: https://amfs-login.sense-lab.ai)
   --uninstall           Remove AMFS MCP config from clients
@@ -281,6 +281,10 @@ detect_clients() {
         DETECTED_CLIENTS+=("claude-code")
     fi
 
+    if command -v codex &>/dev/null; then
+        DETECTED_CLIENTS+=("codex")
+    fi
+
     local windsurf_dir
     windsurf_dir="$(dirname "$(windsurf_config_path)")"
     if [[ -d "$windsurf_dir" ]]; then
@@ -341,6 +345,32 @@ configure_client() {
                 fi
                 claude "${args[@]}"
                 success "Configured Claude Code"
+            fi
+            ;;
+        codex)
+            if $UNINSTALL; then
+                if command -v codex &>/dev/null; then
+                    codex mcp remove senselab 2>/dev/null || true
+                    success "Removed AMFS from Codex"
+                fi
+            else
+                if ! command -v codex &>/dev/null; then
+                    warn "Codex CLI (codex) not found on PATH — skipping"
+                    return 1
+                fi
+                resolve_uvx_path
+                local pkg="amfs-mcp-server"
+                if [[ -n "$API_KEY" ]]; then pkg="amfs-mcp-server-pro"; fi
+                # codex mcp add <name> [--env KEY=VAL]... -- <command> [args...]
+                local args=("mcp" "add" "senselab" "--" "$UVX_PATH" "$pkg")
+                if [[ -n "$API_KEY" ]]; then
+                    local url="${API_URL:-$AMFS_DEFAULT_API_URL}"
+                    args=("mcp" "add" "senselab" "--env" "AMFS_HTTP_URL=$url" "--env" "AMFS_API_KEY=$API_KEY" "--" "$UVX_PATH" "$pkg")
+                fi
+                # Replace any existing entry so re-runs stay idempotent.
+                codex mcp remove senselab 2>/dev/null || true
+                codex "${args[@]}"
+                success "Configured Codex"
             fi
             ;;
         windsurf)

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -1918,6 +1918,31 @@ class PostgresAdapter(AdapterABC):
                 row = cur.fetchone()
         return self._row_to_agent(row)
 
+    def register_agent(self, agent_id: str, namespace: str = "default") -> Agent:
+        """Ensure an agent row exists WITHOUT counting it as a memory write.
+
+        Unlike ``ensure_agent`` this does not increment ``entry_count`` — it is
+        used when an agent announces itself (e.g. via set_identity / profile
+        update) so the agent appears on the dashboard before it writes any
+        memory. Idempotent: refreshes ``last_active_at`` on conflict.
+        """
+        account_id = self._get_current_account_id()
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    INSERT INTO amfs_agents (namespace, agent_id, account_id)
+                    VALUES (%s, %s, %s)
+                    ON CONFLICT ON CONSTRAINT uq_agent DO UPDATE
+                        SET last_active_at = NOW(),
+                            account_id = COALESCE(amfs_agents.account_id, EXCLUDED.account_id)
+                    RETURNING {self._AGENT_COLUMNS}
+                    """,
+                    (namespace, agent_id, account_id),
+                )
+                row = cur.fetchone()
+        return self._row_to_agent(row)
+
     def get_agent(self, agent_id: str, namespace: str = "default") -> Agent | None:
         account_id = self._get_current_account_id()
         if account_id:
@@ -1993,7 +2018,9 @@ class PostgresAdapter(AdapterABC):
         profile: Any,
         namespace: str = "default",
     ) -> Agent:
-        self.ensure_agent(agent_id, namespace)
+        # register (not ensure) — announcing a profile is not a memory write,
+        # so it must not inflate entry_count.
+        self.register_agent(agent_id, namespace)
         with self._pool.connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(

--- a/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
@@ -486,6 +486,30 @@ class AsyncPostgresAdapter:
                 row = await cur.fetchone()
         return self._row_to_agent(row)
 
+    async def register_agent(self, agent_id: str, namespace: str = "default") -> Agent:
+        """Ensure an agent row exists WITHOUT counting it as a memory write.
+
+        Mirrors :meth:`PostgresAdapter.register_agent` — used when an agent
+        announces itself (set_identity / profile update) so it appears on the
+        dashboard before writing any memory. Does not inflate ``entry_count``.
+        """
+        account_id = self._get_current_account_id()
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    f"""
+                    INSERT INTO amfs_agents (namespace, agent_id, account_id)
+                    VALUES (%s, %s, %s)
+                    ON CONFLICT ON CONSTRAINT uq_agent DO UPDATE
+                        SET last_active_at = NOW(),
+                            account_id = COALESCE(amfs_agents.account_id, EXCLUDED.account_id)
+                    RETURNING {self._AGENT_COLUMNS}
+                    """,
+                    (namespace, agent_id, account_id),
+                )
+                row = await cur.fetchone()
+        return self._row_to_agent(row)
+
     # ──────────────────────────────────────────────────────────────
     # 6. log_event
     # ──────────────────────────────────────────────────────────────

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -1027,6 +1027,7 @@ def _infer_tags(
 
 @app.put("/api/v1/agents/{agent_id:path}/profile")
 async def update_agent_profile(
+    request: Request,
     agent_id: str,
     body: dict[str, Any],
     _auth: str | None = Depends(verify_api_key),
@@ -1036,6 +1037,10 @@ async def update_agent_profile(
     mem = _get_memory()
     profile = AgentProfile.model_validate(body)
     agent = mem._adapter.update_agent_profile(agent_id, profile)
+    # Link the agent to the API key's owner so it shows on the user's dashboard
+    # immediately — set_identity announces through this endpoint before the
+    # agent has written any memory, so the write-path owner link never fires.
+    _ensure_agent_owner(request, agent_id, mem.namespace)
     return json.loads(json.dumps(agent.model_dump(mode="json"), default=str))
 
 
@@ -1694,6 +1699,18 @@ async def list_agents(
         own = vis.get_user_agents()
         before_own_filter = list(agent_data.keys())
         agent_data = {aid: d for aid, d in agent_data.items() if aid in own}
+        # Include owner-linked agents that have written zero entries (e.g. an
+        # agent that called set_identity over MCP but hasn't written memory
+        # yet). Without this they never appear on the dashboard.
+        for aid in own:
+            if aid not in agent_data:
+                agent_data[aid] = {
+                    "agent_id": aid,
+                    "entries_written": 0,
+                    "entities_touched": set(),
+                    "last_active": None,
+                    "first_seen": None,
+                }
         logger.warning(
             "[AGENTS] own_filter: before=%s after=%s own_set=%s",
             sorted(before_own_filter), sorted(agent_data.keys()), sorted(own),
@@ -1710,12 +1727,17 @@ async def list_agents(
                     with conn.cursor() as cur:
                         placeholders = ", ".join(["%s"] * len(known_agent_ids))
                         cur.execute(
-                            f"SELECT agent_id, created_at FROM amfs_agents "
+                            f"SELECT agent_id, created_at, last_active_at, profile "
+                            f"FROM amfs_agents "
                             f"WHERE namespace = %s AND agent_id IN ({placeholders})",
                             [adapter._namespace, *known_agent_ids],
                         )
                         for row in cur.fetchall():
-                            agent_registration[row["agent_id"]] = {"created_at": row["created_at"]}
+                            agent_registration[row["agent_id"]] = {
+                                "created_at": row["created_at"],
+                                "last_active_at": row.get("last_active_at"),
+                                "profile": row.get("profile"),
+                            }
         except (ImportError, Exception):
             pass
 
@@ -1736,14 +1758,27 @@ async def list_agents(
         desc_info = agent_descriptions.get(ad["agent_id"], {})
         reg = agent_registration.get(ad["agent_id"], {})
         created = reg.get("created_at") or ad.get("first_seen")
+        # Zero-write agents have no entry-derived activity; fall back to the
+        # registration row (set via set_identity / profile update).
+        last_active = ad["last_active"] or reg.get("last_active_at")
+        description = desc_info.get("description", "")
+        platform = desc_info.get("platform", "")
+        prof = reg.get("profile")
+        if isinstance(prof, dict):
+            if not description:
+                description = prof.get("description", "") or ""
+            if not platform:
+                sm = prof.get("session_metadata")
+                if isinstance(sm, dict):
+                    platform = sm.get("platform", "") or ""
         agents.append({
             "agentId": ad["agent_id"],
             "entriesWritten": ad["entries_written"],
             "entitiesTouched": len(ad["entities_touched"]),
-            "lastActive": ad["last_active"].isoformat() if ad["last_active"] else None,
+            "lastActive": last_active.isoformat() if last_active else None,
             "createdAt": created.isoformat() if created else None,
-            "description": desc_info.get("description", ""),
-            "platform": desc_info.get("platform", ""),
+            "description": description,
+            "platform": platform,
         })
     return {"agents": agents}
 


### PR DESCRIPTION
## Summary
Fixes the OSS/server-side half of the onboarding: agents that connect and call `amfs_set_identity` now appear on the dashboard immediately, and the installer/onboarding support Codex.

- **Dashboard showed "0 total agents"**: an agent that only set its identity (no memory writes) was never linked to its owner. The owner link was created only on the write path, and `list_agents` was derived purely from written entries.
  - `update_agent_profile` endpoint now calls `_ensure_agent_owner` — `set_identity` announces through this endpoint before any write, so the link now fires on connect.
  - `list_agents` now includes owner-linked **zero-write** agents, pulling `lastActive` / `description` / `platform` from the registration row.
  - Added `register_agent()` to the sync + async Postgres adapters: upserts an `amfs_agents` row **without** inflating `entry_count`; `update_agent_profile` uses it instead of `ensure_agent` (announcing a profile is not a memory write).
- **Codex support**: `install-mcp.sh` now detects and configures a `codex` client via `codex mcp add/remove` (uses `amfs-mcp-server-pro` when an API key is provided).
