### PR TITLE
fix: enriched agents query falls back to session_metadata

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -2514,9 +2514,18 @@ class PostgresAdapter(AdapterABC):
                 COALESCE(s.type_dist, '{{}}'::jsonb) AS type_dist,
                 COALESCE(c.collaborators, '{{}}'::TEXT[]) AS collaborators,
                 gm.group_id::TEXT AS group_id,
-                a.profile->>'platform' AS platform,
-                a.profile->>'model' AS model,
-                a.profile->'inferred_tags' AS inferred_tags,
+                COALESCE(
+                    a.profile->>'platform',
+                    a.profile->'session_metadata'->>'platform'
+                ) AS platform,
+                COALESCE(
+                    a.profile->>'model',
+                    a.profile->'session_metadata'->>'model'
+                ) AS model,
+                COALESCE(
+                    a.profile->'inferred_tags',
+                    a.profile->'tags'
+                ) AS inferred_tags,
                 a.profile->>'description' AS description
             FROM amfs_agents a
             LEFT JOIN agent_stats s ON s.agent_id = a.agent_id


### PR DESCRIPTION
## Summary

The enriched agents SQL query only checked `profile->>'platform'` and `profile->>'model'` for grouping data. But `amfs_set_identity()` stores these fields inside `profile->'session_metadata'` (nested JSONB), not at the top level.

Added COALESCE fallbacks:
- `platform`: checks `profile->>'platform'` then `profile->'session_metadata'->>'platform'`
- `model`: checks `profile->>'model'` then `profile->'session_metadata'->>'model'`
- `inferred_tags`: checks `profile->'inferred_tags'` then `profile->'tags'`

This fixes the dashboard agent grouping showing "Unknown" for all dimensions.