### PR TITLE
Memory-augmenting proxy, write-time embeddings, TTL enforcement

### DIFF
--- a/packages/adapters/filesystem/src/amfs_filesystem/adapter.py
+++ b/packages/adapters/filesystem/src/amfs_filesystem/adapter.py
@@ -59,6 +59,8 @@ class FilesystemAdapter(AdapterABC):
         entry = self._read_entry(current_file)
         if entry.confidence < min_confidence:
             return None
+        if entry.is_expired():
+            return None
         return entry
 
     # ------------------------------------------------------------------

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -775,6 +775,8 @@ class PostgresAdapter(AdapterABC):
         entry = self._row_to_entry(row)
         if entry.confidence < min_confidence:
             return None
+        if entry.is_expired():
+            return None
         return entry
 
     # ------------------------------------------------------------------

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -172,11 +172,19 @@ class PostgresAdapter(AdapterABC):
         auto_schema: bool = True,
         min_pool_size: int = 2,
         max_pool_size: int = 10,
+        embedder: EmbedderABC | None = None,
+        embedding_dim: int = 384,
     ) -> None:
         self._dsn = dsn
         self._namespace = namespace
         self._has_embedding_col = False
         self._has_search_tsv = False
+        # When an embedder is provided, embeddings are computed at write time and
+        # persisted, so ANN retrieval (semantic_search / pgvector HNSW) works
+        # without a separate backfill pass. embedding_dim must match the column
+        # dimension (see ensure_embedding_column). None => write-time embedding off.
+        self._embedder = embedder
+        self._embedding_dim = embedding_dim
         pool_kwargs: dict[str, Any] = {
             "kwargs": {"row_factory": dict_row, "autocommit": True},
         }
@@ -870,10 +878,25 @@ class PostgresAdapter(AdapterABC):
                         branch,
                     ]
 
-                    if self._has_embedding_col and entry.embedding:
+                    # Write-time embedding: compute and persist an embedding when
+                    # the caller did not supply one and an embedder is configured.
+                    # Guarded so an embedder failure never blocks a write.
+                    embedding = entry.embedding
+                    if (embedding is None and self._embedder is not None
+                            and self._has_embedding_col):
+                        try:
+                            embedding = self._embedder.embed_value(entry.value)
+                        except Exception:  # noqa: BLE001
+                            logger.warning(
+                                "write-time embedding failed for %s/%s; storing without vector",
+                                entry.entity_path, entry.key, exc_info=True,
+                            )
+                            embedding = None
+
+                    if self._has_embedding_col and embedding:
                         columns.append("embedding")
                         params.append(
-                            f"[{','.join(str(v) for v in entry.embedding)}]"
+                            f"[{','.join(str(v) for v in embedding)}]"
                         )
 
                     cols_sql = ", ".join(columns)
@@ -886,7 +909,73 @@ class PostgresAdapter(AdapterABC):
                         params,
                     )
 
-        return entry.model_copy(update={"version": new_version})
+        return entry.model_copy(update={"version": new_version, "embedding": embedding})
+
+    def ensure_embedding_column(self, dim: int | None = None) -> None:
+        """Create the pgvector embedding column + HNSW index at a given dimension.
+
+        Idempotent when the column already exists at the right dimension. Use
+        this to provision a store for a larger embedder (e.g. bge-large at 1024)
+        instead of the default vector(384) from migration 002.
+
+        Requires the pgvector extension (``CREATE EXTENSION IF NOT EXISTS vector``).
+        This alters schema and, if the column exists at a different dimension,
+        does nothing (Postgres cannot change a vector column's dimension in
+        place — drop it first, see migration 005). Not called automatically.
+
+        TODO(integration-test): covered by tests/integration/test_postgres_embeddings.py
+        which requires AMFS_TEST_PG_DSN + pgvector; unvalidated in unit CI.
+        """
+        target = dim or self._embedding_dim
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
+                cur.execute(
+                    f"ALTER TABLE amfs_memory_entries "
+                    f"ADD COLUMN IF NOT EXISTS embedding vector({int(target)})"
+                )
+                cur.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_entries_embedding "
+                    "ON amfs_memory_entries USING hnsw (embedding vector_cosine_ops) "
+                    "WITH (m = 16, ef_construction = 64)"
+                )
+        self._detect_optional_columns()
+
+    def backfill_embeddings(self, *, batch_size: int = 200) -> int:
+        """Compute and store embeddings for existing rows that lack one.
+
+        Returns the number of rows updated. Requires a configured embedder and
+        the embedding column. Intended as a one-off migration step after
+        enabling write-time embeddings on an existing store.
+
+        TODO(integration-test): covered by tests/integration/test_postgres_embeddings.py
+        (needs AMFS_TEST_PG_DSN + pgvector); unvalidated in unit CI.
+        """
+        if self._embedder is None or not self._has_embedding_col:
+            return 0
+        updated = 0
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT id, value FROM amfs_memory_entries "
+                    "WHERE namespace = %s AND embedding IS NULL "
+                    "ORDER BY written_at LIMIT %s",
+                    (self._namespace, batch_size),
+                )
+                rows = cur.fetchall()
+                for r in rows:
+                    try:
+                        value = json.loads(r["value"]) if isinstance(r["value"], str) else r["value"]
+                        vec = self._embedder.embed_value(value)
+                    except Exception:  # noqa: BLE001
+                        logger.warning("backfill embedding failed for row %s", r["id"], exc_info=True)
+                        continue
+                    cur.execute(
+                        "UPDATE amfs_memory_entries SET embedding = %s WHERE id = %s",
+                        (f"[{','.join(str(v) for v in vec)}]", r["id"]),
+                    )
+                    updated += 1
+        return updated
 
     # ------------------------------------------------------------------
     # list

--- a/packages/adapters/postgres/src/amfs_postgres/migrations/005_configurable_embedding_dim.sql
+++ b/packages/adapters/postgres/src/amfs_postgres/migrations/005_configurable_embedding_dim.sql
@@ -1,0 +1,38 @@
+-- Migration 005: configurable embedding dimension
+--
+-- Migration 002 hardcodes `embedding vector(384)`, which pins the store to a
+-- 384-dim embedder (e.g. all-MiniLM / bge-small). To use a larger/stronger
+-- embedder (e.g. bge-large at 1024 dims) the column must be provisioned at the
+-- matching dimension. pgvector cannot change a vector column's dimension in
+-- place, so switching dimensions requires dropping and recreating the column
+-- (and re-embedding existing rows).
+--
+-- This file is parameterized via a psql variable. Apply with, e.g.:
+--     psql "$DSN" -v embedding_dim=1024 -f 005_configurable_embedding_dim.sql
+--
+-- Prefer the programmatic path in application code:
+--     PostgresAdapter(dsn, embedder=<embedder>, embedding_dim=1024)
+--         .ensure_embedding_column()   -- creates column + HNSW index if absent
+--     adapter.backfill_embeddings()    -- fills embeddings for existing rows
+--
+-- WARNING: the DROP below destroys existing vectors. Only run it when
+-- intentionally changing dimension; you must re-embed afterwards (backfill).
+
+\set embedding_dim :embedding_dim
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Recreate the embedding column at the requested dimension.
+-- (Commented DROP is intentional — uncomment only when changing dimension.)
+-- DROP INDEX IF EXISTS idx_entries_embedding;
+-- ALTER TABLE amfs_memory_entries DROP COLUMN IF EXISTS embedding;
+
+ALTER TABLE amfs_memory_entries
+    ADD COLUMN IF NOT EXISTS embedding vector(:embedding_dim);
+
+CREATE INDEX IF NOT EXISTS idx_entries_embedding
+    ON amfs_memory_entries USING hnsw (embedding vector_cosine_ops)
+    WITH (m = 16, ef_construction = 64);
+
+-- After (re)creating the column, backfill embeddings from application code:
+--   adapter.backfill_embeddings()

--- a/packages/core/src/amfs_core/models.py
+++ b/packages/core/src/amfs_core/models.py
@@ -149,6 +149,20 @@ class MemoryEntry(BaseModel):
     integrity_chain: str | None = None
     commit_id: str | None = None
 
+    def is_expired(self, *, now: datetime | None = None) -> bool:
+        """True when a TTL is set and has elapsed.
+
+        Read paths use this to enforce ``ttl_at`` immediately, without waiting
+        for the background ``LifecycleManager`` sweep to archive the entry.
+        """
+        if self.ttl_at is None:
+            return False
+        reference = now or datetime.now(timezone.utc)
+        ttl = self.ttl_at
+        if ttl.tzinfo is None:
+            ttl = ttl.replace(tzinfo=timezone.utc)
+        return ttl <= reference
+
     def effective_confidence(self, *, decay_half_life_days: float | None = None) -> float:
         """Confidence adjusted for four-signal decay: time, memory type, outcomes, and access frequency.
 

--- a/packages/http-server/src/amfs_http/openrouter_proxy.py
+++ b/packages/http-server/src/amfs_http/openrouter_proxy.py
@@ -20,6 +20,8 @@ Configuration (env):
 - OPENROUTER_BASE_URL        default https://openrouter.ai/api/v1
 - AMFS_PROXY_INJECT_LIMIT    max memory facts injected (default 5)
 - AMFS_PROXY_WRITE_BACK      "true" to enable fact write-back (default false)
+- AMFS_PROXY_SAFETY_GATE     "false" to disable the Pro SafetyGate on write-back
+                             (default true; no-op when amfs_safety is absent)
 
 TODO(integration-test): tests/integration/test_openrouter_proxy.py exercises the
 inject/forward/write-back path against a mocked upstream; it is skipped in unit
@@ -40,6 +42,54 @@ BASE_URL = os.environ.get("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
 API_KEY = os.environ.get("OPENROUTER_API_KEY", "")
 INJECT_LIMIT = int(os.environ.get("AMFS_PROXY_INJECT_LIMIT", "5"))
 WRITE_BACK = os.environ.get("AMFS_PROXY_WRITE_BACK", "false").lower() == "true"
+# Auto-run the Pro SafetyGate on write-back when available (secret block + PII
+# redact). Disabled explicitly with AMFS_PROXY_SAFETY_GATE=false. Soft/optional:
+# the gate lives in the Pro ``amfs_safety`` package; OSS-only deployments skip it.
+SAFETY_GATE = os.environ.get("AMFS_PROXY_SAFETY_GATE", "true").lower() == "true"
+
+_SAFETY_GATE_CACHE: dict[str, Any] = {}
+
+
+def _gate_value(mem: Any, scope: str, key: str, value: Any) -> tuple[bool, Any]:
+    """Run the optional Pro SafetyGate over a proposed write-back value.
+
+    Returns ``(allowed, value_to_write)`` — the value is redacted when the gate
+    masks sensitive content. Fail-open: any import/build/scan error allows the
+    original value through (the LLM exchange must never be lost to a gate bug).
+    """
+    if not SAFETY_GATE:
+        return True, value
+    try:
+        if "gate" not in _SAFETY_GATE_CACHE:
+            from amfs_safety import SafetyGate  # Pro package, optional
+
+            adapter = getattr(mem, "_adapter", None)
+            _SAFETY_GATE_CACHE["gate"] = SafetyGate(adapter=adapter)
+        gate = _SAFETY_GATE_CACHE["gate"]
+
+        from datetime import datetime, timezone
+
+        from amfs_core.models import MemoryEntry, Provenance
+
+        entry = MemoryEntry(
+            entity_path=scope,
+            key=key,
+            value=value,
+            provenance=Provenance(
+                agent_id="openrouter-proxy",
+                session_id="proxy",
+                written_at=datetime.now(timezone.utc),
+            ),
+            confidence=0.5,
+        )
+        decision = gate.check_write(entry)
+        if not decision.allowed:
+            logger.info("proxy: write-back blocked by SafetyGate (%s)", decision.max_severity)
+            return False, value
+        return True, decision.entry.value
+    except Exception:  # noqa: BLE001 - fail-open
+        logger.debug("proxy: SafetyGate unavailable/failed; allowing write", exc_info=True)
+        return True, value
 
 _MEMORY_HEADER = (
     "You have access to the following facts from persistent memory. "
@@ -71,6 +121,23 @@ def _retrieve_facts(get_memory: Callable[[], Any], scope: str | None, query: str
     except Exception:  # noqa: BLE001
         logger.debug("proxy: get_memory failed", exc_info=True)
         return []
+    # Prefer the Pro MultiStrategyRetriever (adaptive RRF + rerank) when the
+    # amfs_retrieval package is installed; otherwise SDK full-text/semantic
+    # search; otherwise list the scope. All fail-open.
+    try:
+        from amfs_http.pro_provider import build_pro_retriever, pro_retrieve_values
+
+        adapter = getattr(mem, "_adapter", None)
+        retriever = build_pro_retriever(adapter)
+        pro_values = pro_retrieve_values(retriever, scope, query, INJECT_LIMIT)
+        if pro_values is not None:
+            return [
+                v if isinstance(v, str) else json.dumps(v, default=str)
+                for v in pro_values
+            ][:INJECT_LIMIT]
+    except Exception:  # noqa: BLE001 - Pro path optional, fall through to OSS
+        logger.debug("proxy: pro retrieval skipped", exc_info=True)
+
     # Prefer full-text/semantic search; fall back to listing the scope.
     try:
         search = getattr(mem, "search", None)
@@ -107,8 +174,11 @@ def _write_back(get_memory: Callable[[], Any], scope: str | None,
     try:
         mem = get_memory()
         key = f"proxy-exchange-{abs(hash(query)) % 10_000_000}"
-        mem.write(scope, key, {"q": query[:500], "a": answer[:1500]},
-                  confidence=0.5)
+        value = {"q": query[:500], "a": answer[:1500]}
+        allowed, value = _gate_value(mem, scope, key, value)
+        if not allowed:
+            return
+        mem.write(scope, key, value, confidence=0.5)
         commit = getattr(mem, "commit_outcome", None)
         if callable(commit):
             commit("proxy-exchange", "success")

--- a/packages/http-server/src/amfs_http/openrouter_proxy.py
+++ b/packages/http-server/src/amfs_http/openrouter_proxy.py
@@ -1,0 +1,197 @@
+"""Memory-augmenting OpenRouter proxy (OpenAI-compatible chat completions).
+
+This is the "Option C" proxy: a drop-in replacement for the OpenRouter chat
+completions endpoint that (1) retrieves relevant memory for the caller's scope
+and injects it as context, (2) forwards the request to OpenRouter unchanged
+otherwise, and (3) writes salient facts from the exchange back to memory and
+seals a decision trace — all without the client changing anything but the base
+URL.
+
+Design principles:
+- Fail-open: any memory error (retrieval, injection, write-back) must never
+  break the LLM call. On failure we forward the original request untouched.
+- Non-blocking: memory retrieval and write-back are synchronous SDK calls, so
+  they run in a threadpool (``asyncio.to_thread``) to keep the event loop free.
+  Write-back and trace sealing are fire-and-forget background tasks.
+- Streaming: ``stream: true`` is passed through as an SSE byte stream.
+
+Configuration (env):
+- OPENROUTER_API_KEY         upstream key (required to enable the route)
+- OPENROUTER_BASE_URL        default https://openrouter.ai/api/v1
+- AMFS_PROXY_INJECT_LIMIT    max memory facts injected (default 5)
+- AMFS_PROXY_WRITE_BACK      "true" to enable fact write-back (default false)
+
+TODO(integration-test): tests/integration/test_openrouter_proxy.py exercises the
+inject/forward/write-back path against a mocked upstream; it is skipped in unit
+CI (requires fastapi TestClient + httpx-mock) and is unvalidated here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = os.environ.get("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1").rstrip("/")
+API_KEY = os.environ.get("OPENROUTER_API_KEY", "")
+INJECT_LIMIT = int(os.environ.get("AMFS_PROXY_INJECT_LIMIT", "5"))
+WRITE_BACK = os.environ.get("AMFS_PROXY_WRITE_BACK", "false").lower() == "true"
+
+_MEMORY_HEADER = (
+    "You have access to the following facts from persistent memory. "
+    "Treat them as authoritative context; if none are relevant, ignore them.\n"
+)
+
+
+def is_configured() -> bool:
+    return bool(API_KEY)
+
+
+def _last_user_text(messages: list[dict[str, Any]]) -> str:
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            content = msg.get("content")
+            if isinstance(content, str):
+                return content
+            if isinstance(content, list):  # OpenAI content-parts form
+                return " ".join(p.get("text", "") for p in content if isinstance(p, dict))
+    return ""
+
+
+def _retrieve_facts(get_memory: Callable[[], Any], scope: str | None, query: str) -> list[str]:
+    """Best-effort memory retrieval. Returns formatted fact strings (fail-open)."""
+    if not query:
+        return []
+    try:
+        mem = get_memory()
+    except Exception:  # noqa: BLE001
+        logger.debug("proxy: get_memory failed", exc_info=True)
+        return []
+    # Prefer full-text/semantic search; fall back to listing the scope.
+    try:
+        search = getattr(mem, "search", None)
+        if callable(search):
+            results = search(query=query, entity_path=scope, limit=INJECT_LIMIT)
+        else:
+            results = mem._adapter.list(scope)[:INJECT_LIMIT]
+    except Exception:  # noqa: BLE001
+        logger.debug("proxy: memory search failed", exc_info=True)
+        return []
+    facts: list[str] = []
+    for r in results or []:
+        value = getattr(r, "value", None)
+        if value is None and isinstance(r, dict):
+            value = r.get("value")
+        if value is not None:
+            facts.append(value if isinstance(value, str) else json.dumps(value, default=str))
+    return facts[:INJECT_LIMIT]
+
+
+def _inject(messages: list[dict[str, Any]], facts: list[str]) -> list[dict[str, Any]]:
+    if not facts:
+        return messages
+    block = _MEMORY_HEADER + "\n".join(f"- {f}" for f in facts)
+    # Prepend as a system message so it does not overwrite the caller's system prompt.
+    return [{"role": "system", "content": block}, *messages]
+
+
+def _write_back(get_memory: Callable[[], Any], scope: str | None,
+                query: str, answer: str) -> None:
+    """Persist a salient fact from the exchange + seal a trace (best-effort)."""
+    if not WRITE_BACK or not scope or not answer:
+        return
+    try:
+        mem = get_memory()
+        key = f"proxy-exchange-{abs(hash(query)) % 10_000_000}"
+        mem.write(scope, key, {"q": query[:500], "a": answer[:1500]},
+                  confidence=0.5)
+        commit = getattr(mem, "commit_outcome", None)
+        if callable(commit):
+            commit("proxy-exchange", "success")
+    except Exception:  # noqa: BLE001
+        logger.debug("proxy: write-back failed", exc_info=True)
+
+
+def mount_openrouter_proxy(app, *, get_memory: Callable[[], Any]) -> None:
+    """Mount POST /api/v1/proxy/chat/completions if OpenRouter is configured."""
+    if not is_configured():
+        logger.info("OpenRouter proxy disabled (OPENROUTER_API_KEY not set)")
+        return
+
+    import httpx
+    from fastapi import Request
+    from fastapi.responses import JSONResponse, StreamingResponse
+
+    client = httpx.AsyncClient(timeout=httpx.Timeout(60.0, connect=10.0))
+
+    def _scope_of(request: Request, body: dict[str, Any]) -> str | None:
+        return (body.get("amfs_scope")
+                or request.headers.get("X-AMFS-Scope")
+                or os.environ.get("AMFS_PROXY_DEFAULT_SCOPE"))
+
+    def _upstream_headers(request: Request) -> dict[str, str]:
+        headers = {"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"}
+        # Pass through OpenRouter attribution headers when present.
+        for h in ("HTTP-Referer", "X-Title"):
+            if h in request.headers:
+                headers[h] = request.headers[h]
+        return headers
+
+    @app.post("/api/v1/proxy/chat/completions")
+    async def proxy_chat_completions(request: Request):
+        raw = await request.body()
+        try:
+            body = json.loads(raw)
+        except Exception:
+            return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+
+        scope = _scope_of(request, body)
+        messages = body.get("messages") or []
+        query = _last_user_text(messages)
+
+        # 1) Retrieve + inject memory (fail-open, off the event loop).
+        try:
+            facts = await asyncio.to_thread(_retrieve_facts, get_memory, scope, query)
+            if facts:
+                body = {**body, "messages": _inject(messages, facts)}
+        except Exception:  # noqa: BLE001
+            logger.debug("proxy: injection skipped", exc_info=True)
+
+        body.pop("amfs_scope", None)
+        url = f"{BASE_URL}/chat/completions"
+        headers = _upstream_headers(request)
+
+        # 2a) Streaming: pass the SSE stream straight through.
+        if body.get("stream"):
+            async def _iter():
+                async with client.stream("POST", url, headers=headers, json=body) as resp:
+                    async for chunk in resp.aiter_raw():
+                        yield chunk
+            # NOTE: write-back on streamed responses requires accumulating the
+            # SSE deltas; deferred (TODO) to keep streaming zero-overhead.
+            return StreamingResponse(_iter(), media_type="text/event-stream")
+
+        # 2b) Non-streaming: forward, then schedule background write-back.
+        try:
+            resp = await client.post(url, headers=headers, json=body)
+        except Exception:  # noqa: BLE001
+            logger.warning("proxy: upstream request failed", exc_info=True)
+            return JSONResponse({"error": "upstream unavailable"}, status_code=502)
+
+        data = resp.json() if resp.content else {}
+        try:
+            answer = data["choices"][0]["message"]["content"]
+        except Exception:  # noqa: BLE001
+            answer = ""
+
+        if WRITE_BACK and answer:
+            asyncio.create_task(
+                asyncio.to_thread(_write_back, get_memory, scope, query, answer))
+
+        return JSONResponse(data, status_code=resp.status_code)
+
+    logger.info("OpenRouter memory proxy mounted → POST /api/v1/proxy/chat/completions")

--- a/packages/http-server/src/amfs_http/pro_provider.py
+++ b/packages/http-server/src/amfs_http/pro_provider.py
@@ -1,0 +1,94 @@
+"""Optional Pro retrieval/sealing provider for the OpenRouter proxy.
+
+The OSS proxy retrieves memory with the plain SDK ``search`` (full-text / list).
+When the Pro ``amfs_retrieval`` package is installed, this module upgrades that to
+the ``MultiStrategyRetriever`` (adaptive-weighted RRF + optional cross-encoder
+rerank over a real default embedder), which is what wins the precision/adversarial
+benchmarks. When ``amfs_traces`` is installed and sealing is enabled, write-backs
+can be sealed into a signed ``ImmutableDecisionTrace``.
+
+Everything here is soft/optional and fail-open:
+- OSS-only deployments (no Pro packages) get ``None`` and the proxy falls back to
+  SDK search — no error, no behaviour change.
+- Any construction/among failure degrades to the OSS path.
+
+Env:
+- AMFS_PROXY_PRO_RETRIEVAL   "false" to force the OSS search path (default true)
+- AMFS_PROXY_PRO_RERANK      "false" to skip cross-encoder rerank (default true)
+
+NOTE(integration-test): the Pro retrieval path requires the amfs-internal packages
+and a populated adapter; it is exercised in the amfs-internal retrieval eval, not
+in OSS unit CI. The unit test here only covers graceful absence + value extraction.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+PRO_RETRIEVAL = os.environ.get("AMFS_PROXY_PRO_RETRIEVAL", "true").lower() == "true"
+PRO_RERANK = os.environ.get("AMFS_PROXY_PRO_RERANK", "true").lower() == "true"
+
+_cache: dict[str, Any] = {}
+
+
+def build_pro_retriever(adapter: Any) -> Any | None:
+    """Build a Pro MultiStrategyRetriever over ``adapter``, or None if unavailable.
+
+    Cached on the adapter identity so the embedder/reranker are loaded once.
+    """
+    if not PRO_RETRIEVAL or adapter is None:
+        return None
+    cache_key = f"retriever:{id(adapter)}"
+    if cache_key in _cache:
+        return _cache[cache_key]
+    try:
+        from amfs_retrieval import MultiStrategyRetriever, create_pro_embedder
+
+        reranker = None
+        if PRO_RERANK:
+            try:
+                from amfs_retrieval import CrossEncoderReranker
+
+                reranker = CrossEncoderReranker()
+            except Exception:  # noqa: BLE001 - rerank optional
+                logger.debug("pro_provider: reranker unavailable", exc_info=True)
+
+        retriever = MultiStrategyRetriever(
+            adapter, embedder=create_pro_embedder(), reranker=reranker
+        )
+        _cache[cache_key] = retriever
+        logger.info("pro_provider: Pro MultiStrategyRetriever enabled for proxy")
+        return retriever
+    except Exception:  # noqa: BLE001 - Pro package absent or failed to build
+        logger.debug("pro_provider: Pro retrieval unavailable", exc_info=True)
+        _cache[cache_key] = None
+        return None
+
+
+def _result_value(result: Any) -> Any:
+    """Extract the stored value from a RetrievalResult-like object or dict."""
+    entry = getattr(result, "entry", None)
+    if entry is None and isinstance(result, dict):
+        entry = result.get("entry", result)
+    if isinstance(entry, dict):
+        return entry.get("value")
+    return getattr(entry, "value", None)
+
+
+def pro_retrieve_values(
+    retriever: Any, scope: str | None, query: str, limit: int
+) -> list[Any] | None:
+    """Run Pro retrieval and return raw stored values (fail-open -> None)."""
+    if retriever is None or not query:
+        return None
+    try:
+        results = retriever.retrieve(query, entity_path=scope, limit=limit)
+    except Exception:  # noqa: BLE001
+        logger.debug("pro_provider: retrieve failed", exc_info=True)
+        return None
+    values = [v for v in (_result_value(r) for r in results or []) if v is not None]
+    return values or None

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -219,6 +219,12 @@ except ImportError:
     pass
 
 try:
+    from amfs_http.openrouter_proxy import mount_openrouter_proxy
+    mount_openrouter_proxy(app, get_memory=_get_memory)
+except Exception:  # noqa: BLE001 - proxy is optional; never block startup
+    logger.debug("OpenRouter proxy not mounted", exc_info=True)
+
+try:
     from amfs_tenant.http_deps import mount_scope_enforcement
     mount_scope_enforcement(app)
 except ImportError:

--- a/tests/integration/test_openrouter_proxy.py
+++ b/tests/integration/test_openrouter_proxy.py
@@ -1,0 +1,83 @@
+"""Integration test for the memory-augmenting OpenRouter proxy route.
+
+Exercises the full mount → inject → forward → return path against a mocked
+upstream (no real OpenRouter call). Skipped unless AMFS_TEST_PROXY=1 and both
+fastapi + httpx are importable, so unit CI stays green.
+
+Run:
+    AMFS_TEST_PROXY=1 OPENROUTER_API_KEY=test \
+        pytest tests/integration/test_openrouter_proxy.py
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("AMFS_TEST_PROXY") != "1",
+    reason="AMFS_TEST_PROXY!=1 — skipping OpenRouter proxy integration test",
+)
+
+
+def _build_app(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    # Reload module so is_configured() picks up the env var.
+    import importlib
+
+    from amfs_http import openrouter_proxy as P
+    importlib.reload(P)
+
+    import httpx
+    from fastapi import FastAPI
+
+    captured: dict = {}
+
+    class _Resp:
+        status_code = 200
+        content = b"{}"
+
+        def json(self):
+            return {"choices": [{"message": {"role": "assistant",
+                                             "content": "PostgreSQL 15."}}]}
+
+    class _FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def post(self, url, headers=None, json=None):
+            captured["url"] = url
+            captured["json"] = json
+            return _Resp()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeClient)
+
+    class _Mem:
+        def search(self, *, query, entity_path, limit):
+            class R:
+                value = "The billing service runs on PostgreSQL 15."
+            return [R()]
+
+    app = FastAPI()
+    P.mount_openrouter_proxy(app, get_memory=lambda: _Mem())
+    return app, captured
+
+
+def test_proxy_injects_memory_and_forwards(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    app, captured = _build_app(monkeypatch)
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/proxy/chat/completions", json={
+            "model": "openai/gpt-4o-mini",
+            "amfs_scope": "svc/db",
+            "messages": [{"role": "user", "content": "which db does billing use?"}],
+        })
+    assert resp.status_code == 200
+    # Upstream received an injected system message with the retrieved fact.
+    fwd_messages = captured["json"]["messages"]
+    assert fwd_messages[0]["role"] == "system"
+    assert "PostgreSQL 15" in fwd_messages[0]["content"]
+    # The internal amfs_scope hint was stripped before forwarding upstream.
+    assert "amfs_scope" not in captured["json"]

--- a/tests/integration/test_postgres_embeddings.py
+++ b/tests/integration/test_postgres_embeddings.py
@@ -1,0 +1,100 @@
+"""Integration tests for write-time embeddings on the Postgres adapter.
+
+Requires a running Postgres with the pgvector extension available. Set
+AMFS_TEST_PG_DSN to enable; skipped otherwise (so unit CI stays green).
+
+Example:
+    AMFS_TEST_PG_DSN=postgresql://localhost/amfs_test \
+        pytest tests/integration/test_postgres_embeddings.py
+
+These validate the unvalidated-in-unit-CI paths added for configurable-dimension
+embeddings: PostgresAdapter(embedder=..., embedding_dim=...),
+ensure_embedding_column(), write-time embedding, backfill_embeddings(), and that
+semantic_search returns the stored vectors.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+from amfs_core.models import MemoryEntry, Provenance, SemanticQuery
+
+PG_DSN = os.environ.get("AMFS_TEST_PG_DSN")
+
+pytestmark = pytest.mark.skipif(
+    PG_DSN is None,
+    reason="AMFS_TEST_PG_DSN not set — skipping Postgres embedding tests",
+)
+
+_DIM = 8
+
+
+class FixedEmbedder:
+    """Deterministic embedder (no model download): hashes tokens into _DIM bins."""
+
+    def embed(self, text: str) -> list[float]:
+        vec = [0.0] * _DIM
+        for tok in str(text).lower().split():
+            vec[hash(tok) % _DIM] += 1.0
+        norm = sum(v * v for v in vec) ** 0.5 or 1.0
+        return [v / norm for v in vec]
+
+    def embed_value(self, value) -> list[float]:
+        return self.embed(value if isinstance(value, str) else str(value))
+
+
+def _entry(key: str, value: str) -> MemoryEntry:
+    return MemoryEntry(
+        entity_path="svc/db", key=key, version=1, value=value,
+        provenance=Provenance(agent_id="a", session_id="s",
+                              written_at=datetime.now(timezone.utc)),
+        confidence=0.9,
+    )
+
+
+@pytest.fixture
+def adapter():
+    import psycopg
+    from amfs_postgres.adapter import PostgresAdapter
+
+    conn = psycopg.connect(PG_DSN, autocommit=True)
+    conn.execute("DROP TABLE IF EXISTS amfs_outcomes CASCADE")
+    conn.execute("DROP TABLE IF EXISTS amfs_memory_entries CASCADE")
+    conn.close()
+
+    a = PostgresAdapter(dsn=PG_DSN, namespace="emb-test", auto_schema=True,
+                        embedder=FixedEmbedder(), embedding_dim=_DIM)
+    a.ensure_embedding_column()
+    yield a
+    a.close()
+
+
+def test_write_time_embedding_is_persisted(adapter):
+    adapter.write(_entry("db-billing", "billing runs on postgres"))
+    results = adapter.semantic_search(
+        SemanticQuery(text="billing runs on postgres", entity_path="svc/db", limit=5),
+        FixedEmbedder(),
+    )
+    assert results, "expected a semantic hit from a write-time embedding"
+    top_entry, sim = results[0]
+    assert top_entry.key == "db-billing"
+    assert sim > 0.5
+
+
+def test_backfill_embeddings_fills_missing(adapter):
+    # Write without an embedder to leave embedding NULL, then backfill.
+    from amfs_postgres.adapter import PostgresAdapter
+    no_embed = PostgresAdapter(dsn=PG_DSN, namespace="emb-test", auto_schema=False)
+    no_embed.write(_entry("db-analytics", "analytics runs on clickhouse"))
+    no_embed.close()
+
+    filled = adapter.backfill_embeddings()
+    assert filled >= 1
+    results = adapter.semantic_search(
+        SemanticQuery(text="analytics runs on clickhouse", entity_path="svc/db", limit=5),
+        FixedEmbedder(),
+    )
+    assert any(e.key == "db-analytics" for e, _ in results)

--- a/tests/unit/test_openrouter_proxy.py
+++ b/tests/unit/test_openrouter_proxy.py
@@ -1,0 +1,75 @@
+"""Unit tests for the memory-augmenting OpenRouter proxy helpers (offline).
+
+These cover the pure logic (message parsing, injection, fail-open retrieval)
+without FastAPI/httpx. The full inject/forward/write-back route is covered by
+tests/integration/test_openrouter_proxy.py (skipped in unit CI).
+"""
+
+from __future__ import annotations
+
+from amfs_http import openrouter_proxy as P
+
+
+def test_last_user_text_string_content():
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "what db does billing use?"},
+        {"role": "assistant", "content": "..."},
+        {"role": "user", "content": "and analytics?"},
+    ]
+    assert P._last_user_text(messages) == "and analytics?"
+
+
+def test_last_user_text_content_parts():
+    messages = [{"role": "user", "content": [{"type": "text", "text": "hello"},
+                                             {"type": "text", "text": "world"}]}]
+    assert P._last_user_text(messages) == "hello world"
+
+
+def test_last_user_text_none_when_absent():
+    assert P._last_user_text([{"role": "system", "content": "x"}]) == ""
+
+
+def test_inject_prepends_system_message():
+    messages = [{"role": "user", "content": "q"}]
+    out = P._inject(messages, ["fact A", "fact B"])
+    assert out[0]["role"] == "system"
+    assert "fact A" in out[0]["content"] and "fact B" in out[0]["content"]
+    assert out[1:] == messages  # original messages preserved after the injected block
+
+
+def test_inject_noop_without_facts():
+    messages = [{"role": "user", "content": "q"}]
+    assert P._inject(messages, []) is messages
+
+
+def test_retrieve_facts_fail_open_on_get_memory_error():
+    def _boom():
+        raise RuntimeError("no memory")
+    assert P._retrieve_facts(_boom, "svc/db", "query") == []
+
+
+def test_retrieve_facts_empty_query_returns_empty():
+    called = False
+
+    def _get():
+        nonlocal called
+        called = True
+        return object()
+    assert P._retrieve_facts(_get, "svc/db", "") == []
+    assert called is False
+
+
+def test_retrieve_facts_uses_search_and_formats_values():
+    class _Row:
+        def __init__(self, value):
+            self.value = value
+
+    class _Mem:
+        def search(self, *, query, entity_path, limit):
+            return [_Row("The billing service runs on PostgreSQL 15."),
+                    _Row({"db": "clickhouse"})]
+
+    facts = P._retrieve_facts(lambda: _Mem(), "svc/db", "which db?")
+    assert facts[0] == "The billing service runs on PostgreSQL 15."
+    assert "clickhouse" in facts[1]

--- a/tests/unit/test_pro_provider.py
+++ b/tests/unit/test_pro_provider.py
@@ -1,0 +1,55 @@
+"""Unit tests for the optional Pro retrieval provider (graceful absence + extraction).
+
+The live Pro retrieval path needs the amfs-internal packages and a populated
+adapter (covered by the amfs-internal retrieval eval). Here we only assert the
+OSS-safe behaviour: no adapter / disabled / None retriever all degrade cleanly,
+and value extraction handles both object and dict shapes.
+"""
+
+from __future__ import annotations
+
+from amfs_http import pro_provider
+
+
+def test_build_returns_none_without_adapter() -> None:
+    assert pro_provider.build_pro_retriever(None) is None
+
+
+def test_build_returns_none_when_disabled(monkeypatch) -> None:
+    monkeypatch.setattr(pro_provider, "PRO_RETRIEVAL", False)
+    assert pro_provider.build_pro_retriever(object()) is None
+
+
+def test_retrieve_values_none_retriever() -> None:
+    assert pro_provider.pro_retrieve_values(None, "scope", "q", 5) is None
+
+
+def test_result_value_extraction_dict_and_object() -> None:
+    class _Result:
+        def __init__(self, value):
+            self.entry = {"value": value}
+
+    assert pro_provider._result_value(_Result("postgres")) == "postgres"
+    assert pro_provider._result_value({"entry": {"value": 42}}) == 42
+    assert pro_provider._result_value({"value": "x"}) == "x"
+
+
+def test_retrieve_values_filters_none_and_empty() -> None:
+    class _Retriever:
+        def retrieve(self, query, *, entity_path=None, limit=10):
+            return [
+                type("R", (), {"entry": {"value": "a"}})(),
+                type("R", (), {"entry": {"value": None}})(),
+                type("R", (), {"entry": {"value": "b"}})(),
+            ]
+
+    vals = pro_provider.pro_retrieve_values(_Retriever(), "scope", "q", 5)
+    assert vals == ["a", "b"]
+
+
+def test_retrieve_values_empty_returns_none() -> None:
+    class _Retriever:
+        def retrieve(self, query, *, entity_path=None, limit=10):
+            return []
+
+    assert pro_provider.pro_retrieve_values(_Retriever(), "scope", "q", 5) is None

--- a/tests/unit/test_ttl_read_enforcement.py
+++ b/tests/unit/test_ttl_read_enforcement.py
@@ -1,0 +1,63 @@
+"""Read-time TTL enforcement: expired entries must not be returned by read().
+
+Complements test_lifecycle.py (which covers the background archive sweep). Here
+we assert that read() hides an expired entry immediately, without waiting for a
+sweep, so a stale/expired fact can never be surfaced to an agent.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from amfs_core.models import MemoryEntry, Provenance
+from amfs_filesystem.adapter import FilesystemAdapter
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _entry(key: str, ttl_at: datetime | None) -> MemoryEntry:
+    return MemoryEntry(
+        entity_path="svc/mod",
+        key=key,
+        value="secret-token",
+        provenance=Provenance(agent_id="a", session_id="s", written_at=_now()),
+        confidence=1.0,
+        ttl_at=ttl_at,
+    )
+
+
+def test_read_hides_expired_entry(tmp_path) -> None:
+    adapter = FilesystemAdapter(root=tmp_path / ".amfs", namespace="test")
+    adapter.write(_entry("expired", ttl_at=_now() - timedelta(hours=1)))
+
+    assert adapter.read("svc/mod", "expired") is None
+
+
+def test_read_returns_future_ttl_entry(tmp_path) -> None:
+    adapter = FilesystemAdapter(root=tmp_path / ".amfs", namespace="test")
+    adapter.write(_entry("future", ttl_at=_now() + timedelta(hours=1)))
+
+    got = adapter.read("svc/mod", "future")
+    assert got is not None and got.key == "future"
+
+
+def test_read_returns_entry_without_ttl(tmp_path) -> None:
+    adapter = FilesystemAdapter(root=tmp_path / ".amfs", namespace="test")
+    adapter.write(_entry("no-ttl", ttl_at=None))
+
+    got = adapter.read("svc/mod", "no-ttl")
+    assert got is not None and got.key == "no-ttl"
+
+
+def test_is_expired_handles_naive_datetime() -> None:
+    naive_past = datetime.utcnow() - timedelta(hours=1)
+    entry = MemoryEntry(
+        entity_path="svc/mod",
+        key="k",
+        value="v",
+        provenance=Provenance(agent_id="a", session_id="s", written_at=_now()),
+        ttl_at=naive_past,
+    )
+    assert entry.is_expired() is True


### PR DESCRIPTION
## Summary
OSS-side deliverables from the roadmap. Targeting `dev` for staging before `main`.

- **Memory-augmenting OpenRouter proxy** (`amfs_http.openrouter_proxy`) + Postgres write-time embeddings (from an earlier roadmap commit).
- **Read-time TTL enforcement**: `MemoryEntry.is_expired()`, and filesystem + Postgres `read()` now hide expired entries immediately instead of waiting for the `LifecycleManager` sweep. `list()` is intentionally left unfiltered (the sweep depends on listing expired entries).
- **Optional, fail-open Pro upgrades in the proxy** (`amfs_http.pro_provider`): `MultiStrategyRetriever` (adaptive RRF + rerank over a real embedder) for retrieval and the Pro `SafetyGate` on write-back (secret block / PII redact). Both are soft imports — OSS-only deployments are unaffected.

Pro-side counterpart (embedder, SafetyGate, SemanticConsolidator, provenance API) is in the corresponding `amfs-internal` PR.
