### PR TITLE
fix: dedupe SaaS double-write timeline events

### DIFF
--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -48,6 +48,10 @@ class HttpAdapter(AdapterABC):
         timeout: Optional httpx Timeout override.
     """
 
+    # The server's write handler (POST /api/v1/entries) records the WRITE
+    # timeline event, so the SDK must not log it again (avoids double events).
+    server_side_write_events: bool = True
+
     def __init__(
         self,
         base_url: str,

--- a/packages/core/src/amfs_core/abc.py
+++ b/packages/core/src/amfs_core/abc.py
@@ -489,6 +489,13 @@ class AdapterABC(ABC):
 
     # ── Event log / timeline ───────────────────────────────────────────
 
+    #: When True, this adapter delegates writes to a remote AMFS server that
+    #: records the WRITE timeline event itself (in its write handler). The SDK
+    #: must then NOT also emit a WRITE event, otherwise a single write produces
+    #: two identical timeline events. Set True on HttpAdapter; False for direct
+    #: adapters (filesystem/postgres) where the SDK is the only logger.
+    server_side_write_events: bool = False
+
     def log_event(self, event: Event) -> Event:
         """Persist a timeline event. Default is a no-op."""
         return event

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -360,24 +360,28 @@ class AgentMemory:
         _prefs = pattern_refs
 
         def _bg_log_and_edges() -> None:
-            try:
-                _adapter.log_event(Event(
-                    namespace=_ns,
-                    agent_id=_aid,
-                    branch=_ev_branch,
-                    event_type=EventType.WRITE,
-                    summary=f"Wrote {_ep}/{_k} v{_entry_version}",
-                    details={
-                        "entity_path": _ep,
-                        "key": _k,
-                        "version": _entry_version,
-                        "confidence": _entry_confidence,
-                        "memory_type": _entry_mt,
-                        "shared": _entry_shared,
-                    },
-                ))
-            except Exception:
-                logger.debug("Failed to log write event", exc_info=True)
+            # Skip client-side WRITE logging when the adapter delegates to a
+            # remote server that already records the event (HttpAdapter) —
+            # otherwise a single write produces two identical timeline events.
+            if not getattr(_adapter, "server_side_write_events", False):
+                try:
+                    _adapter.log_event(Event(
+                        namespace=_ns,
+                        agent_id=_aid,
+                        branch=_ev_branch,
+                        event_type=EventType.WRITE,
+                        summary=f"Wrote {_ep}/{_k} v{_entry_version}",
+                        details={
+                            "entity_path": _ep,
+                            "key": _k,
+                            "version": _entry_version,
+                            "confidence": _entry_confidence,
+                            "memory_type": _entry_mt,
+                            "shared": _entry_shared,
+                        },
+                    ))
+                except Exception:
+                    logger.debug("Failed to log write event", exc_info=True)
             if _prefs:
                 try:
                     self._materialize_pattern_ref_edges(_ep, _k, _prefs, _ev_branch)

--- a/tests/unit/test_write_event_dedup.py
+++ b/tests/unit/test_write_event_dedup.py
@@ -1,0 +1,63 @@
+"""Regression test for the SaaS double-write timeline event.
+
+A single write must produce exactly one WRITE timeline event. On the SaaS path
+the write goes SDK -> HttpAdapter -> server, and the server's write handler logs
+the WRITE event; the SDK must therefore NOT also log it. This is signalled by the
+adapter's ``server_side_write_events`` flag.
+"""
+
+from __future__ import annotations
+
+from amfs import AgentMemory
+from amfs.memory import _get_sdk_executor
+from amfs_core.models import Event, EventType
+from amfs_filesystem.adapter import FilesystemAdapter
+
+
+class _RecordingLocalAdapter(FilesystemAdapter):
+    """Direct adapter (SDK is the only event logger)."""
+
+    server_side_write_events = False
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.events: list[Event] = []
+
+    def log_event(self, event: Event) -> Event:
+        self.events.append(event)
+        return event
+
+
+class _RecordingRemoteAdapter(_RecordingLocalAdapter):
+    """Simulates HttpAdapter: the remote server owns WRITE event logging."""
+
+    server_side_write_events = True
+
+
+def _flush_bg() -> None:
+    # Executor is max_workers=1 FIFO, so a sentinel submitted after the write's
+    # background task guarantees that task has completed once the sentinel does.
+    _get_sdk_executor().submit(lambda: None).result(timeout=5)
+
+
+def _write_events(adapter: _RecordingLocalAdapter) -> list[Event]:
+    return [e for e in adapter.events if e.event_type == EventType.WRITE]
+
+
+def test_direct_adapter_logs_one_write_event(tmp_path) -> None:
+    adapter = _RecordingLocalAdapter(root=tmp_path / ".amfs", namespace="test")
+    mem = AgentMemory(agent_id="a", adapter=adapter)
+    mem.write("svc/mod", "k", "v")
+    _flush_bg()
+
+    assert len(_write_events(adapter)) == 1
+
+
+def test_server_side_adapter_does_not_double_log(tmp_path) -> None:
+    adapter = _RecordingRemoteAdapter(root=tmp_path / ".amfs", namespace="test")
+    mem = AgentMemory(agent_id="a", adapter=adapter)
+    mem.write("svc/mod", "k", "v")
+    _flush_bg()
+
+    # Server owns the WRITE event; the SDK must not emit its own.
+    assert _write_events(adapter) == []


### PR DESCRIPTION
Two layers both emit `EventType.WRITE` for one logical write:
1. **HTTP server** `write_entry()` → `_async_adapter.log_event(WRITE)` (`amfs_http/server.py`).
2. **SDK** `Memory.write()` background task → `adapter.log_event(WRITE)`, which for the `HttpAdapter` round-trips to `POST /api/v1/timeline/events` on the same server (`amfs/memory.py`).

On the SaaS MCP path (SDK → `HttpAdapter` → server) both fire. The ~0.27–0.29s gap is the server async task vs. the client thread-pool HTTP round-trip.

## Fix
The server owns the WRITE event for HTTP-backed writes, so the SDK must not also log it.
- Add `AdapterABC.server_side_write_events` (default `False`).
- Set it `True` on `HttpAdapter`.
- Gate the SDK's `log_event(WRITE)` on the flag.
- **Preserved**: pattern-ref edge materialization (the server does not do this), so no graph regression.
