### PR TITLE
fix: eliminate double WRITE timeline events (server guard + SDK PyPI release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           uv venv .venv
           source .venv/bin/activate
           uv pip install hatchling
-          for pkg in packages/core packages/adapters/filesystem packages/adapters/postgres packages/adapters/s3 packages/http-server packages/sdk-python packages/cli packages/mcp-server packages/integrations/strands; do
+          for pkg in packages/core packages/adapters/filesystem packages/adapters/postgres packages/adapters/s3 packages/adapters/http packages/http-server packages/sdk-python packages/cli packages/mcp-server packages/integrations/strands; do
             echo "Building $pkg..."
             cd $pkg && python -m hatchling build && cd -
           done
@@ -34,7 +34,7 @@ jobs:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
           source .venv/bin/activate
-          for pkg in packages/core packages/adapters/filesystem packages/adapters/postgres packages/adapters/s3 packages/http-server packages/sdk-python packages/cli packages/mcp-server packages/integrations/strands; do
+          for pkg in packages/core packages/adapters/filesystem packages/adapters/postgres packages/adapters/s3 packages/adapters/http packages/http-server packages/sdk-python packages/cli packages/mcp-server packages/integrations/strands; do
             uv publish --check-url https://pypi.org/simple/ $pkg/dist/* || echo "Skipping $pkg (already published or error)"
           done
 

--- a/packages/adapters/http/pyproject.toml
+++ b/packages/adapters/http/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-adapter-http"
-version = "0.1.2"
+version = "0.1.4"
 description = "AMFS HTTP adapter — routes memory operations through the authenticated REST API"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-core"
-version = "0.3.4"
+version = "0.3.5"
 description = "AMFS core models, engine, and adapter ABC"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/http-server/pyproject.toml
+++ b/packages/http-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-http-server"
-version = "0.3.3"
+version = "0.3.4"
 description = "AMFS HTTP/REST API server with SSE support"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -2137,6 +2137,17 @@ async def log_timeline_event(
         details=body.details,
         actor_agent_id=body.actor_agent_id,
     )
+    # WRITE events are authoritatively logged by the write handler
+    # (POST /api/v1/entries). HTTP-backed SDK clients ALSO emit a WRITE event
+    # here from their background log path, which produced two identical WRITE
+    # events per write (the "double-write" bug). The server is the single
+    # source of truth for WRITE timeline events, so drop client-originated
+    # ones here. This is version-agnostic: it fixes every client regardless of
+    # which SDK version they run via `uvx`, without waiting on a PyPI release.
+    # We still return a well-formed (but unpersisted) event so clients that
+    # parse the response don't error.
+    if event_type_enum is EventType.WRITE:
+        return event.model_dump(mode="json")
     saved = mem._adapter.log_event(event)
     return saved.model_dump(mode="json")
 

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs"
-version = "0.5.2"
+version = "0.5.3"
 description = "AMFS Python SDK — Agent Memory File System"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/tests/unit/test_timeline_write_dedup.py
+++ b/tests/unit/test_timeline_write_dedup.py
@@ -1,0 +1,87 @@
+"""Server-side guard against duplicate WRITE timeline events.
+
+The SaaS MCP runs client-side via ``uvx amfs-mcp-server-pro`` with an
+``HttpAdapter`` pointed at the hosted HTTP API. Both the server's write handler
+(``POST /api/v1/entries``) and the client SDK's background log path emitted a
+``WRITE`` event, producing two identical timeline events per write.
+
+The write handler is the single source of truth for WRITE events, so the
+generic timeline endpoint must drop client-originated WRITE events. This is
+version-agnostic — it fixes every client regardless of the SDK version pulled
+from PyPI, and takes effect the moment the hosted server is redeployed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+from fastapi.testclient import TestClient  # noqa: E402
+
+import amfs_http.server as server  # noqa: E402
+
+
+@pytest.fixture()
+def spy_memory(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Install a mock AgentMemory so we can spy on adapter.log_event."""
+    mem = MagicMock()
+    mem.namespace = "test-ns"
+
+    def _echo_log_event(event):
+        return event
+
+    mem._adapter.log_event.side_effect = _echo_log_event
+    monkeypatch.setattr(server, "_memory", mem)
+    monkeypatch.setattr(server, "_get_memory", lambda: mem)
+    return mem
+
+
+@pytest.fixture()
+def client(spy_memory: MagicMock) -> TestClient:
+    return TestClient(server.app)
+
+
+def test_write_event_is_not_persisted(client: TestClient, spy_memory: MagicMock) -> None:
+    resp = client.post(
+        "/api/v1/timeline/events",
+        json={
+            "agent_id": "agent-1",
+            "event_type": "write",
+            "summary": "wrote bruno/senselab/foo",
+            "details": {"entity_path": "bruno/senselab", "key": "foo", "version": 1},
+        },
+    )
+    assert resp.status_code == 200
+    # The write handler owns WRITE events — the client's redundant one is dropped.
+    spy_memory._adapter.log_event.assert_not_called()
+    # A well-formed event is still echoed back so clients don't error.
+    body = resp.json()
+    assert body["event_type"] == "write"
+    assert body["agent_id"] == "agent-1"
+
+
+def test_non_write_event_is_persisted(client: TestClient, spy_memory: MagicMock) -> None:
+    resp = client.post(
+        "/api/v1/timeline/events",
+        json={
+            "agent_id": "agent-1",
+            "event_type": "read",
+            "summary": "read bruno/senselab/foo",
+            "details": {"entity_path": "bruno/senselab", "key": "foo"},
+        },
+    )
+    assert resp.status_code == 200
+    spy_memory._adapter.log_event.assert_called_once()
+    logged_event = spy_memory._adapter.log_event.call_args.args[0]
+    assert logged_event.event_type.value == "read"
+
+
+def test_outcome_event_is_persisted(client: TestClient, spy_memory: MagicMock) -> None:
+    resp = client.post(
+        "/api/v1/timeline/events",
+        json={"agent_id": "agent-1", "event_type": "outcome", "summary": "ok"},
+    )
+    assert resp.status_code == 200
+    spy_memory._adapter.log_event.assert_called_once()


### PR DESCRIPTION
Two emitters produce the WRITE event:
1. **Server:** `write_entry` → `_bg_async_side_effects` logs `EventType.WRITE` (authoritative).
2. **Client SDK:** `Memory.write`'s background path POSTs a second WRITE to `/api/v1/timeline/events` via `HttpAdapter`.

> Note: `amfs_version: 0.2.0` reported by the server is the hardcoded `MemoryEntry.amfs_version` schema constant, **not** a deployed package version — it can't confirm/deny a rollout.

Ruled out: room propagation, Cortex digest, DB triggers, and `async_adapter.write` self-logging.

## Fix (two layers)
1. **Server-side guard (immediate, version-agnostic):** the generic timeline endpoint now drops client-originated `WRITE` events since the write handler owns them. Fixes every client the moment the hosted server redeploys, regardless of SDK version. `READ`/`OUTCOME`/etc. unaffected.
2. **PyPI release of the SDK fix:** bump `amfs-core` 0.3.5, `amfs` 0.5.3, `amfs-adapter-http` 0.1.4 (0.1.3 already on PyPI), `amfs-http-server` 0.3.4 so the merged `server_side_write_events` fix reaches `uvx` clients and stops the redundant round-trip entirely.