### PR TITLE
release: bump amfs-core + adapters + http-server for PyPI republish

### DIFF
--- a/packages/adapters/filesystem/pyproject.toml
+++ b/packages/adapters/filesystem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-adapter-filesystem"
-version = "0.1.1"
+version = "0.1.2"
 description = "AMFS filesystem adapter with CoW via atomic rename"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/adapters/postgres/pyproject.toml
+++ b/packages/adapters/postgres/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-adapter-postgres"
-version = "0.1.5"
+version = "0.1.6"
 description = "AMFS Postgres adapter with back-propagation triggers"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/adapters/s3/pyproject.toml
+++ b/packages/adapters/s3/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-adapter-s3"
-version = "0.1.1"
+version = "0.1.2"
 description = "AMFS adapter for S3-compatible object storage"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-core"
-version = "0.3.5"
+version = "0.3.6"
 description = "AMFS core models, engine, and adapter ABC"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/http-server/pyproject.toml
+++ b/packages/http-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-http-server"
-version = "0.3.4"
+version = "0.3.5"
 description = "AMFS HTTP/REST API server with SSE support"
 requires-python = ">=3.11"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Bumps versions so the merged confidence-semantics fix (invert outcome→confidence direction + clamp to [0,1]) and the http-server LLM-rerank proxy wiring get **republished to PyPI** for self-hosted users on local (filesystem/S3) and Postgres adapters.
- `release.yml` publishes on a `v*` tag; `uv publish` skips already-published versions, so only these bumped packages will re-publish.