### PR TITLE
Real server/deploy version on /health + auto-publish on version bump

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,77 @@
+name: Auto-publish on version bump
+
+# Publishes to PyPI/npm automatically when a package manifest changes on main —
+# so "bump version + merge" is enough, no manual `v*` tag required. Publishing is
+# idempotent: `uv publish --check-url` and `npm publish` skip versions that are
+# already published, so only newly-bumped packages are released. Unchanged
+# packages (and re-runs) are safe no-ops.
+#
+# `release.yml` (tag-triggered) is kept for explicit tagged releases; the two do
+# not overlap (this runs on branch pushes, that runs on tags).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/**/pyproject.toml"
+      - "packages/sdk-typescript/package.json"
+
+concurrency:
+  group: auto-publish
+  cancel-in-progress: false
+
+jobs:
+  publish-python:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Build packages
+        run: |
+          uv venv .venv
+          source .venv/bin/activate
+          uv pip install hatchling
+          for pkg in packages/core packages/adapters/filesystem packages/adapters/postgres packages/adapters/s3 packages/adapters/http packages/http-server packages/sdk-python packages/cli packages/mcp-server packages/integrations/strands; do
+            echo "Building $pkg..."
+            cd $pkg && python -m hatchling build && cd -
+          done
+
+      - name: Publish to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          source .venv/bin/activate
+          for pkg in packages/core packages/adapters/filesystem packages/adapters/postgres packages/adapters/s3 packages/adapters/http packages/http-server packages/sdk-python packages/cli packages/mcp-server packages/integrations/strands; do
+            uv publish --check-url https://pypi.org/simple/ $pkg/dist/* || echo "Skipping $pkg (already published or error)"
+          done
+
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install and build
+        working-directory: packages/sdk-typescript
+        run: |
+          npm install
+          npm run build
+
+      - name: Publish to npm
+        working-directory: packages/sdk-typescript
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public || echo "Skipping npm publish (already published or error)"

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-core"
-version = "0.3.6"
+version = "0.3.7"
 description = "AMFS core models, engine, and adapter ABC"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/core/src/amfs_core/models.py
+++ b/packages/core/src/amfs_core/models.py
@@ -143,7 +143,7 @@ class QualityReport(BaseModel):
 class MemoryEntry(BaseModel):
     """A single versioned memory entry within the AMFS namespace."""
 
-    amfs_version: str = "0.2.0"
+    amfs_version: str = "0.3.0"
     entity_path: str
     key: str
     version: int = 1

--- a/packages/http-server/pyproject.toml
+++ b/packages/http-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-http-server"
-version = "0.3.5"
+version = "0.3.6"
 description = "AMFS HTTP/REST API server with SSE support"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -66,6 +66,27 @@ from amfs_http.sse import SSEManager
 
 logger = logging.getLogger(__name__)
 
+
+def _server_version() -> str:
+    """Return the deployed amfs-http-server package version.
+
+    Sourced from installed package metadata so it changes on every release —
+    unlike the per-entry ``amfs_version`` schema tag. This is the value to use
+    when telling deploys/revisions apart.
+    """
+    try:
+        from importlib.metadata import version
+
+        return version("amfs-http-server")
+    except Exception:
+        return "unknown"
+
+
+# Set by the deploy pipeline (e.g. the git SHA) so a running revision is
+# identifiable even between version bumps. Empty when not provided.
+_BUILD_SHA = os.environ.get("AMFS_BUILD_SHA", "")
+_SCHEMA_VERSION = MemoryEntry.model_fields["amfs_version"].default
+
 # ── Async adapter (hot-path, non-blocking) ──────────────────────────
 _async_adapter = None  # AsyncPostgresAdapter | None, set in lifespan
 
@@ -94,7 +115,7 @@ async def _lifespan(application: FastAPI):  # noqa: ARG001
 app = FastAPI(
     title="AMFS HTTP API",
     description="Agent Memory File System — REST API with SSE support",
-    version="0.1.0",
+    version=_server_version(),
     lifespan=_lifespan,
 )
 
@@ -316,14 +337,25 @@ def _ensure_agent_owner(
 # ──────────────────────────────────────────────────────────────────────
 
 
+def _health_payload() -> dict[str, str]:
+    payload = {
+        "status": "ok",
+        "version": _server_version(),      # deploy/package version — changes per release
+        "schema_version": _SCHEMA_VERSION,  # per-entry MemoryEntry schema tag
+    }
+    if _BUILD_SHA:
+        payload["build"] = _BUILD_SHA
+    return payload
+
+
 @app.get("/health")
 async def health() -> dict[str, str]:
-    return {"status": "ok"}
+    return _health_payload()
 
 
 @app.get("/api/v1/health")
 async def health_v1() -> dict[str, str]:
-    return {"status": "ok"}
+    return _health_payload()
 
 
 @app.get("/api/v1/auth/whoami")

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -49,7 +49,7 @@ class TestMemoryEntry:
         assert entry.confidence == 1.0
         assert entry.outcome_count == 0
         assert entry.ttl_at is None
-        assert entry.amfs_version == "0.2.0"
+        assert entry.amfs_version == "0.3.0"
         assert entry.memory_type == MemoryType.FACT
 
     def test_memory_type_belief(self) -> None:


### PR DESCRIPTION
Addresses two operator-facing items the SaaS tester flagged.

## 1. Distinguish deploys (the `amfs_version: 0.2.0` confusion)
`amfs_version` is a per-entry **schema** tag (default on `MemoryEntry`), not a deploy version — that's why every response showed `0.2.0`. It shouldn't be abused for deploy tracking.
- **`/health` now returns a real version**: the deployed `amfs-http-server` package version (via `importlib.metadata`) + optional `AMFS_BUILD_SHA`, alongside `schema_version`. This changes every release, so you can tell revisions apart.
- The FastAPI app `version` now reflects the real package version instead of the stale `"0.1.0"` literal.
- Bumped the schema tag `0.2.0 → 0.3.0`, since the outcome→confidence semantics genuinely changed (no compatibility logic depends on it — only the field default + one test).

Example `/health`:
```json
{ "status": "ok", "version": "0.3.6", "schema_version": "0.3.0", "build": "<sha>" }
```
(`build` appears only if `AMFS_BUILD_SHA` is set — optional, no infra change required.)

## 2. Auto-publish on version bump
Root cause of "it didn't publish": `release.yml` only fires on a `v*` **tag**, so bumping `pyproject.toml` + merging did nothing.
- New `.github/workflows/auto-publish.yml`: on push to `main` touching a package manifest, build + publish to PyPI/npm.
- **Idempotent**: `uv publish --check-url` / `npm publish` skip already-published versions, so only newly-bumped packages release; re-runs and unchanged packages are safe no-ops.
- `release.yml` (tag-triggered) is kept for explicit tagged releases and does not overlap (branch push vs tag).

This PR **self-demonstrates** it: it bumps `amfs-core 0.3.7` and `amfs-http-server 0.3.6`, so merging should auto-publish both.

## Deployment safety
- Health/version changes are additive and read-only.
- Schema-tag bump has no consumers beyond the field default + a unit test (updated).
- No Cloud Run / deploy config changes. Merging triggers the normal source-built image deploy, which picks up the new `/health`.