### PR TITLE
feat: semantic retrieval improvement (server embeddings + pgvector /retrieve + query-first recall)

### DIFF
--- a/packages/adapters/http/pyproject.toml
+++ b/packages/adapters/http/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-adapter-http"
-version = "0.1.2"
+version = "0.1.5"
 description = "AMFS HTTP adapter — routes memory operations through the authenticated REST API"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -183,6 +183,45 @@ class HttpAdapter(AdapterABC):
             return [_parse_entry(e) for e in data]
         return [_parse_entry(e) for e in data.get("entries", data if isinstance(data, list) else [])]
 
+    def retrieve(
+        self,
+        query: str,
+        *,
+        entity_path: str | None = None,
+        min_confidence: float = 0.0,
+        limit: int = 10,
+        semantic_weight: float = 0.5,
+        recency_weight: float = 0.3,
+        confidence_weight: float = 0.2,
+        branch: str = "main",
+    ) -> list[tuple[MemoryEntry, float, dict[str, float]]]:
+        """Server-side semantic retrieval via POST /api/v1/retrieve.
+
+        The server does the embedding + pgvector similarity + blend, so this
+        works even when the client has no embedder. Returns
+        (entry, score, breakdown) tuples; breakdown is empty on the server's
+        lexical fallback.
+        """
+        body: dict[str, Any] = {
+            "query": query,
+            "min_confidence": min_confidence,
+            "limit": limit,
+            "semantic_weight": semantic_weight,
+            "recency_weight": recency_weight,
+            "confidence_weight": confidence_weight,
+            "branch": branch,
+        }
+        if entity_path:
+            body["entity_path"] = entity_path
+        data = self._post("/api/v1/retrieve", body)
+        rows = data if isinstance(data, list) else data.get("entries", [])
+        out: list[tuple[MemoryEntry, float, dict[str, float]]] = []
+        for e in rows:
+            score = float(e.get("_score", 0.0)) if isinstance(e, dict) else 0.0
+            breakdown = e.get("_breakdown", {}) if isinstance(e, dict) else {}
+            out.append((_parse_entry(e), score, breakdown))
+        return out
+
     def stats(self) -> MemoryStats:
         data = self._get("/api/v1/stats")
         return MemoryStats.model_validate(data)

--- a/packages/adapters/postgres/pyproject.toml
+++ b/packages/adapters/postgres/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-adapter-postgres"
-version = "0.1.5"
+version = "0.1.7"
 description = "AMFS Postgres adapter with back-propagation triggers"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
@@ -29,6 +29,7 @@ from amfs_core.models import (
     MemoryType,
     Provenance,
     SearchQuery,
+    SemanticQuery,
 )
 
 from amfs_postgres.adapter import PostgresAdapter
@@ -462,6 +463,68 @@ class AsyncPostgresAdapter:
                 rows = await cur.fetchall()
 
         return [self._row_to_entry(r) for r in rows]
+
+    # ──────────────────────────────────────────────────────────────
+    # 4b. semantic_search (pgvector cosine, account-scoped via RLS pool)
+    # ──────────────────────────────────────────────────────────────
+
+    async def semantic_search(
+        self,
+        query: SemanticQuery,
+        embedder: Any,
+        *,
+        branch: str = "main",
+    ) -> list[tuple[MemoryEntry, float]]:
+        """Rank entries by pgvector cosine similarity to the query embedding.
+
+        Account isolation is enforced by the RLS pool wrapper (same as
+        ``search``), so results are already scoped to the request's account
+        before the LIMIT — never do a global top-K then filter, which would
+        both leak scan scope and drop the caller's own matches.
+
+        Returns (entry, similarity) pairs ordered by similarity desc. Empty
+        list when the pgvector column is absent (caller falls back to lexical).
+        """
+        if not self._has_embedding_col:
+            return []
+
+        query_vec = embedder.embed(query.text)
+        vec_str = f"[{','.join(str(v) for v in query_vec)}]"
+
+        conditions = [
+            "namespace = %s",
+            "branch = %s",
+            "superseded_at IS NULL",
+            "embedding IS NOT NULL",
+        ]
+        params: list[Any] = [self._namespace, branch]
+        if query.entity_path is not None:
+            conditions.append("entity_path = %s")
+            params.append(query.entity_path)
+        if query.min_confidence > 0:
+            conditions.append("confidence >= %s")
+            params.append(query.min_confidence)
+
+        where = " AND ".join(conditions)
+        sql = f"""
+            SELECT *, 1 - (embedding <=> %s::vector) AS similarity
+            FROM amfs_memory_entries
+            WHERE {where}
+            ORDER BY embedding <=> %s::vector
+            LIMIT %s
+        """
+
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(sql, [vec_str] + params + [vec_str, query.limit])
+                rows = await cur.fetchall()
+
+        results: list[tuple[MemoryEntry, float]] = []
+        for row in rows:
+            sim = float(row.get("similarity", 0) or 0)
+            if sim >= query.min_similarity:
+                results.append((self._row_to_entry(row), sim))
+        return results
 
     # ──────────────────────────────────────────────────────────────
     # 5. ensure_agent

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,11 +1,23 @@
 [project]
 name = "amfs-core"
-version = "0.3.4"
+version = "0.3.8"
 description = "AMFS core models, engine, and adapter ABC"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 dependencies = [
     "pydantic>=2.0,<3",
+]
+
+[project.optional-dependencies]
+# Real semantic embeddings. fastembed is ONNX-based (no torch) and ships the
+# retrieval-tuned BAAI/bge-small-en-v1.5 (384-dim). sentence-transformers is a
+# heavier alternative. Without either, create_default_embedder() falls back to
+# the deterministic-but-weak HashEmbedder.
+embedder = [
+    "fastembed>=0.3",
+]
+embedder-st = [
+    "sentence-transformers>=2.2",
 ]
 
 [build-system]

--- a/packages/core/src/amfs_core/default_embedder.py
+++ b/packages/core/src/amfs_core/default_embedder.py
@@ -44,20 +44,50 @@ class HashEmbedder(EmbedderABC):
         return [x / norm for x in vec]
 
 
+DEFAULT_EMBED_MODEL = "BAAI/bge-small-en-v1.5"  # 384-dim, matches the pgvector column
+
+
 def create_default_embedder() -> EmbedderABC:
     """Create the best available embedder.
 
-    Tries to load the ONNX-based sentence-transformers model first.
-    Falls back to HashEmbedder if dependencies are missing.
+    Preference order (all 384-dim, so interchangeable with the pgvector column):
+    1. ``fastembed`` ``TextEmbedding`` — ONNX, offline, no torch; fast on CPU.
+       Default ``BAAI/bge-small-en-v1.5`` (retrieval-tuned).
+    2. ``sentence-transformers`` ``all-MiniLM-L6-v2`` via ONNX.
+    3. ``HashEmbedder`` — deterministic but not semantically meaningful.
+
+    Falls back gracefully so semantic search never hard-fails; only quality
+    degrades when the optional model dependencies are missing.
     """
+    try:
+        return _create_fastembed_embedder()
+    except Exception as exc:  # noqa: BLE001 - fastembed missing/model unavailable
+        logger.info("fastembed unavailable (%s); trying sentence-transformers", exc)
+
     try:
         return _create_onnx_embedder()
     except ImportError:
-        logger.info(
-            "sentence-transformers/onnxruntime not available, "
-            "falling back to HashEmbedder. Install amfs-core[embedder] for better quality."
+        logger.warning(
+            "Neither fastembed nor sentence-transformers/onnxruntime available — "
+            "falling back to HashEmbedder (poor semantic quality). "
+            "Install amfs-core[embedder] for real embeddings."
         )
         return HashEmbedder()
+
+
+def _create_fastembed_embedder(model_name: str = DEFAULT_EMBED_MODEL) -> EmbedderABC:
+    from fastembed import TextEmbedding  # type: ignore[import-untyped]
+
+    class FastEmbedEmbedder(EmbedderABC):
+        def __init__(self) -> None:
+            self._model = TextEmbedding(model_name)
+            self.model_name = model_name
+
+        def embed(self, text: str) -> list[float]:
+            return [float(x) for x in next(iter(self._model.embed([text])))]
+
+    logger.info("Default embedder: fastembed %s", model_name)
+    return FastEmbedEmbedder()
 
 
 def _create_onnx_embedder() -> EmbedderABC:

--- a/packages/http-server/pyproject.toml
+++ b/packages/http-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-http-server"
-version = "0.3.3"
+version = "0.3.7"
 description = "AMFS HTTP/REST API server with SSE support"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/http-server/src/amfs_http/models.py
+++ b/packages/http-server/src/amfs_http/models.py
@@ -41,6 +41,24 @@ class SearchRequest(BaseModel):
     depth: int = 3
 
 
+class RetrieveRequest(BaseModel):
+    """Semantic (meaning-based) retrieval request.
+
+    Ranks entries by embedding similarity to the query, blended with recency
+    and confidence. entity_path is optional — when omitted, searches across
+    everything the caller can see.
+    """
+
+    query: str
+    entity_path: str | None = None
+    min_confidence: float = 0.0
+    limit: int = 10
+    semantic_weight: float = 0.5
+    recency_weight: float = 0.3
+    confidence_weight: float = 0.2
+    branch: str = "main"
+
+
 class ContextRequest(BaseModel):
     label: str
     summary: str

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -44,6 +44,7 @@ from amfs_core.models import (
     LayerConfig,
     MemoryEntry,
     SearchQuery,
+    SemanticQuery,
 )
 from amfs_core.quality import HeuristicQualityEvaluator
 
@@ -56,6 +57,7 @@ from amfs_http.models import (
     CreateTeamRequest,
     EventRequest,
     OutcomeRequest,
+    RetrieveRequest,
     RunPatternDetectionRequest,
     SearchRequest,
     UpdateTeamMemberRequest,
@@ -124,6 +126,47 @@ _memory: AgentMemory | None = None
 _sse_manager = SSEManager()
 _bg_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="amfs-bg")
 _known_agents: set[str] = set()
+
+# ── Semantic embedder (shared by write-time embedding + /retrieve) ──────
+# One instance for the whole process so write and query vectors come from the
+# SAME model (otherwise cosine similarity is meaningless). Env-gated and fully
+# crash-safe: if the embedder can't be built, we return None and every caller
+# falls back to lexical behaviour — a bad rollout degrades to the status quo,
+# it never breaks writes or reads.
+_UNSET_EMBEDDER: Any = object()
+_server_embedder: Any = _UNSET_EMBEDDER
+
+
+def _embeddings_enabled() -> bool:
+    return os.environ.get("AMFS_ENABLE_EMBEDDINGS", "true").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _get_server_embedder():
+    """Return the process-wide embedder, or None if disabled/unavailable."""
+    global _server_embedder
+    if _server_embedder is _UNSET_EMBEDDER:
+        _server_embedder = None
+        if _embeddings_enabled():
+            try:
+                from amfs_core.default_embedder import create_default_embedder
+
+                _server_embedder = create_default_embedder()
+                logger.info(
+                    "Semantic embedder ready: %s",
+                    type(_server_embedder).__name__,
+                )
+            except Exception:  # noqa: BLE001 - never block startup on the embedder
+                logger.warning(
+                    "Embedder init failed — semantic retrieval disabled, "
+                    "falling back to lexical search",
+                    exc_info=True,
+                )
+                _server_embedder = None
+        else:
+            logger.info("AMFS_ENABLE_EMBEDDINGS is off — semantic retrieval disabled")
+    return _server_embedder
 
 _immutable_trace_store = None
 try:
@@ -199,6 +242,18 @@ def _get_memory() -> AgentMemory:
     mem._adapter = adapter
     mem._engine._adapter = adapter
     mem._propagator._adapter = adapter
+
+    # Share the process-wide embedder so mem.write() embeds on the sync
+    # fallback path and mem.semantic_search() works. The hot async path embeds
+    # explicitly in the write endpoint. Safe no-op when embeddings are disabled.
+    embedder = _get_server_embedder()
+    if embedder is not None:
+        mem._embedder = embedder
+        try:
+            if hasattr(adapter, "_embedder") and getattr(adapter, "_embedder", None) is None:
+                adapter._embedder = embedder
+        except Exception:  # noqa: BLE001 - adapter embedding is best-effort
+            logger.debug("Could not attach embedder to adapter", exc_info=True)
 
     _memory = mem
     return _memory
@@ -498,6 +553,21 @@ async def write_entry(
                 shared=req.shared,
                 branch=req.branch,
             )
+            # Write-time embedding for semantic retrieval. The async adapter
+            # persists entry.embedding when the pgvector column exists; without
+            # this the hot write path stores no vector (embeddings never land).
+            # Crash-safe: a failure here just stores the entry without a vector.
+            _embedder = _get_server_embedder()
+            if _embedder is not None:
+                try:
+                    entry_obj = entry_obj.model_copy(
+                        update={"embedding": _embedder.embed_value(req.value)}
+                    )
+                except Exception:  # noqa: BLE001 - never fail a write on embedding
+                    logger.warning(
+                        "write-time embedding failed for %s/%s — storing without vector",
+                        req.entity_path, req.key, exc_info=True,
+                    )
             try:
                 entry = await _async_adapter.write(entry_obj)
                 _used_async = True
@@ -765,6 +835,111 @@ async def search_entries(
     if vis is not None and vis.should_filter():
         results = vis.filter_entries(results)
 
+    return [_entry_to_response(e) for e in results]
+
+
+@app.post("/api/v1/retrieve")
+async def retrieve_entries(
+    request: Request,
+    req: RetrieveRequest,
+    _auth: str | None = Depends(verify_api_key),
+) -> list[dict[str, Any]]:
+    """Semantic (meaning-based) retrieval.
+
+    Ranks entries by embedding similarity to the query, blended with recency
+    and confidence, so plain-language queries match paraphrased memories.
+    Account isolation comes from the RLS-scoped async adapter; user/room
+    visibility is then enforced by UserVisibilityFilter (same as /search).
+
+    Degrades gracefully to lexical search when the embedder or pgvector column
+    is unavailable, so this endpoint never returns worse than /search.
+    """
+    from datetime import datetime as _dt, timezone as _tz
+
+    branch = req.branch or "main"
+    vis = _get_visibility_filter(request)
+    embedder = _get_server_embedder()
+
+    pairs: list[tuple[MemoryEntry, float]] = []
+    if embedder is not None and _async_adapter is not None:
+        # Over-fetch a candidate pool so the recency/confidence blend has
+        # headroom beyond pure similarity, then trim to `limit` after scoring.
+        pool = max(req.limit * 5, 50)
+        sq = SemanticQuery(
+            text=req.query,
+            entity_path=req.entity_path,
+            min_confidence=req.min_confidence,
+            limit=pool,
+        )
+        try:
+            pairs = await _async_adapter.semantic_search(sq, embedder, branch=branch)
+        except Exception:
+            logger.warning("semantic_search failed — falling back to lexical", exc_info=True)
+            pairs = []
+
+    if pairs:
+        if vis is not None and vis.should_filter():
+            allowed = {id(e) for e in vis.filter_entries([e for e, _ in pairs])}
+            pairs = [(e, s) for e, s in pairs if id(e) in allowed]
+
+        now = _dt.now(_tz.utc)
+        half_life = 30.0
+        scored: list[tuple[MemoryEntry, float, dict[str, float]]] = []
+        for entry, sim in pairs:
+            written = getattr(entry.provenance, "written_at", None)
+            if written is not None:
+                if written.tzinfo is None:
+                    written = written.replace(tzinfo=_tz.utc)
+                age_days = max(0.0, (now - written).total_seconds() / 86400.0)
+                recency = 0.5 ** (age_days / half_life)
+            else:
+                recency = 0.0
+            conf = float(entry.confidence)
+            score = (
+                req.semantic_weight * sim
+                + req.recency_weight * recency
+                + req.confidence_weight * conf
+            )
+            scored.append((entry, score, {
+                "semantic": round(sim, 4),
+                "recency": round(recency, 4),
+                "confidence": round(conf, 4),
+            }))
+
+        scored.sort(key=lambda t: t[1], reverse=True)
+        out: list[dict[str, Any]] = []
+        for entry, score, breakdown in scored[: req.limit]:
+            data = _entry_to_response(entry)
+            data["_score"] = round(score, 4)
+            data["_breakdown"] = breakdown
+            out.append(data)
+        return out
+
+    # ── Lexical fallback (embedder/pgvector unavailable, or no vector hits) ──
+    sq_lex = SearchQuery(
+        query=req.query,
+        entity_path=req.entity_path,
+        min_confidence=req.min_confidence,
+        limit=req.limit,
+        sort_by="confidence",
+        depth=3,
+    )
+    mem = _get_memory()
+    results: list[MemoryEntry] = []
+    if _async_adapter is not None:
+        try:
+            results = await _async_adapter.search(sq_lex, branch=branch)
+        except Exception:
+            results = []
+    if not results:
+        try:
+            results = mem._adapter.search(sq_lex, branch=branch)
+        except TypeError:
+            results = mem._adapter.search(sq_lex)
+        except Exception:
+            results = []
+    if vis is not None and vis.should_filter():
+        results = vis.filter_entries(results)
     return [_entry_to_response(e) for e in results]
 
 

--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-mcp-server"
-version = "0.7.4"
+version = "0.7.5"
 description = "AMFS MCP Server — expose Agent Memory as MCP tools for Cursor and Claude Code"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -70,10 +70,25 @@ Every operation has a cost — be deliberate:
 - **Write** (2 ops): `amfs_write`, `amfs_record_context`
 - **Commit** (FREE): `amfs_commit_outcome` — always commit, never skip
 
+## Finding / recalling memories (READ THIS)
+
+When the user asks you to find, recall, look up, remember, or check what's stored
+about ANYTHING — or you just want to see if relevant memory exists — call
+`amfs_retrieve(query="<the user's words>")`. That's it. You do NOT need to know
+where it's stored: **entity_path and key are optional**. `amfs_retrieve` searches
+by meaning across everything you can see (all of your agents, all entities), so a
+plain phrase like "my favorite ice cream" or "the deploy runbook" is enough.
+
+- Reach for `amfs_retrieve` FIRST for any natural-language lookup.
+- Only use `amfs_read(entity_path, key)` when you ALREADY know the exact path AND
+  key — never guess them. If you're guessing, use `amfs_retrieve` instead.
+- Use `amfs_search` when you want structured filters (by agent, confidence, date,
+  pattern) or an exact keyword; it also accepts a bare `query`.
+
 ## Workflow
 
 1. **Get briefed**: `amfs_briefing(entity_path="<repo>/<module>")` — one briefing (1 op) replaces many individual reads. Always start here.
-2. **Read & explore**: `amfs_read` for known keys, `amfs_search(query="...")` for text search, `amfs_retrieve` for semantic retrieval, `amfs_graph_neighbors` for related entities.
+2. **Recall**: `amfs_retrieve(query="...")` to find anything by meaning (no path/key needed); `amfs_search(query="...")` for filtered/keyword search; `amfs_read(path, key)` only when you know the exact coordinates; `amfs_graph_neighbors` for related entities.
 3. **Record decisions as they happen**: `amfs_record_context("user-decision", "User chose X over Y", source="chat")`. Only record meaningful decisions — not every micro-step.
 4. **Write knowledge**: `amfs_write("<repo>/<module>", "task-summary-<desc>", "<what and why>")`. Use `memory_type="belief"` for hypotheses, `"experience"` for actions taken.
 5. **Commit outcomes**: `amfs_commit_outcome("<ref>", "success")` after completing significant work. This is FREE and snapshots the full decision trace.
@@ -570,10 +585,15 @@ def amfs_reset_identity() -> str:
 
 @mcp.tool(tags={"core"}, annotations={"readOnlyHint": True})
 def amfs_read(entity_path: str, key: str) -> str:
-    """Read a memory entry by entity path and key.
+    """Read a single memory entry when you ALREADY know its exact path and key.
+
+    Only use this when you have the exact entity_path AND key (e.g. from a prior
+    search/retrieve result). Do NOT guess coordinates — if you're trying to find
+    something by meaning or the user gave you a plain phrase, use `amfs_retrieve`
+    instead (it needs no path/key).
 
     Returns the full entry as JSON including value, confidence, provenance,
-    and version. Returns a message if the entry does not exist.
+    and version. Returns a not_found message if the entry does not exist.
 
     Example: amfs_read("checkout-service", "retry-pattern")
     """
@@ -694,10 +714,14 @@ def amfs_search(
     limit: int = 20,
     depth: int = 3,
 ) -> str:
-    """Search across all memory entries with filters.
+    """Search across all memory entries with structured filters or exact keywords.
 
     Use this before starting work to find context about the entity you're
     modifying, or to check if another agent already solved a similar problem.
+    For plain natural-language recall ("what's my favorite ice cream?"), prefer
+    `amfs_retrieve` — it ranks by meaning and needs no filters. Reach for this
+    tool when you want to filter by agent/confidence/date/pattern or match an
+    exact keyword. `query`, `entity_path`, and all filters are optional.
 
     When a Postgres adapter with tsvector support is configured, the query
     text is used for full-text search.  Otherwise falls back to Python
@@ -767,14 +791,21 @@ def amfs_retrieve(
     confidence_weight: float = 0.2,
     depth: int = 3,
 ) -> str:
-    """Find the most relevant memories for a natural language query.
+    """Find memories by meaning — the default tool for any recall/lookup.
 
-    Blends semantic similarity, recency, and confidence into a single
-    ranked list.  Use this when you need to find memories by meaning,
-    not exact key/value match.  Use amfs_search for structured filtering.
+    Use this FIRST whenever the user asks you to find, recall, look up, or
+    remember something, or when you want to check whether relevant memory
+    exists. Just pass the user's own words as `query`. You do NOT need to know
+    where it's stored: `entity_path` is optional and, when omitted, this searches
+    across everything you can see (all your agents and all entities).
+
+    It blends semantic similarity, recency, and confidence into one ranked list,
+    so paraphrases and synonyms match even without exact keywords. Prefer this
+    over `amfs_read` (which needs exact coordinates) and over `amfs_search`
+    (which is for structured filtering / exact keywords).
 
     Args:
-        query: Natural language query describing what you're looking for
+        query: Natural language query in the user's own words (e.g. "my favorite ice cream")
         entity_path: Optional entity path filter
         min_confidence: Minimum confidence threshold (0.0-1.0)
         limit: Maximum results to return
@@ -795,13 +826,14 @@ def amfs_retrieve(
         confidence_weight=confidence_weight,
     )
 
-    results = mem.search(
+    # Prefer server-side semantic retrieval (embedder + pgvector live on the
+    # server); falls back to client-side composite scoring for local adapters.
+    results = mem.retrieve(
         query=query,
         entity_path=entity_path,
         min_confidence=min_confidence,
         limit=limit,
         recall_config=recall_config,
-        depth=depth,
     )
 
     serialized = []

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs"
-version = "0.5.2"
+version = "0.5.4"
 description = "AMFS Python SDK — Agent Memory File System"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -595,6 +595,52 @@ class AgentMemory:
         )
         return self._adapter.semantic_search(query, self._embedder)
 
+    def retrieve(
+        self,
+        query: str,
+        *,
+        entity_path: str | None = None,
+        min_confidence: float = 0.0,
+        limit: int = 10,
+        recall_config: RecallConfig | None = None,
+    ) -> list[ScoredEntry]:
+        """Rank memories by meaning for a natural-language query.
+
+        Prefers server-side retrieval when the adapter supports it (e.g. the
+        HTTP adapter, where the server owns the embedder + pgvector index), so
+        semantic recall works even when this client has no local embedder.
+        Otherwise falls back to client-side composite scoring via ``search``.
+        """
+        cfg = recall_config or RecallConfig()
+
+        adapter_retrieve = getattr(self._adapter, "retrieve", None)
+        if callable(adapter_retrieve):
+            try:
+                rows = adapter_retrieve(
+                    query,
+                    entity_path=entity_path,
+                    min_confidence=min_confidence,
+                    limit=limit,
+                    semantic_weight=cfg.semantic_weight,
+                    recency_weight=cfg.recency_weight,
+                    confidence_weight=cfg.confidence_weight,
+                )
+                return [
+                    ScoredEntry(entry=entry, score=score, breakdown=breakdown or {})
+                    for entry, score, breakdown in rows
+                ]
+            except Exception:  # noqa: BLE001 - fall back to local scoring
+                logger.debug("Adapter server-side retrieve failed; using local scoring", exc_info=True)
+
+        result = self.search(
+            query=query,
+            entity_path=entity_path,
+            min_confidence=min_confidence,
+            limit=limit,
+            recall_config=cfg,
+        )
+        return result  # type: ignore[return-value]
+
     def stats(self) -> MemoryStats:
         """Aggregate statistics about current memory state."""
         return self._adapter.stats()


### PR DESCRIPTION
## Summary
Improves natural-language recall: writes now compute + store 384-dim embeddings (fastembed bge-small), a new `POST /api/v1/retrieve` does pgvector cosine + recency/confidence blend with the same `UserVisibilityFilter` as `/search`, and MCP `amfs_retrieve` is the default recall tool (no path/key needed). Everything is `AMFS_ENABLE_EMBEDDINGS`-gated (default on) with graceful lexical fallback.

See #238 for full details. Isolation (account RLS + UserVisibilityFilter) unchanged.