### PR TITLE
fix(mcp): position SenseLab as general-purpose memory (personal + work)

### DIFF
--- a/install-mcp.sh
+++ b/install-mcp.sh
@@ -640,11 +640,14 @@ main() {
     # Claude Desktop has no writable instructions file — surface the one manual
     # step so it recalls proactively like the file-based clients now do.
     if [[ -d "$(dirname "$(claude_desktop_config_path)")" ]]; then
-        warn "Claude Desktop: add this to Settings → Profile (personal preferences) for proactive recall:"
-        echo "  Always use SenseLab as your memory. When I ask what you know, remember, or"
-        echo "  have saved about anything — including my personal preferences — call amfs_retrieve"
-        echo "  before answering, and never say you have no memory without checking. When I share"
-        echo "  a durable fact or say \"remember\", save it with amfs_write."
+        warn "Claude Desktop: paste this into Settings → General → \"Instructions for Claude\" for proactive recall:"
+        echo "  SenseLab is my personal + work memory, connected as the \"senselab\" MCP connector"
+        echo "  (tools start with amfs_). It stores everything I ask it to remember — personal facts,"
+        echo "  preferences, people, plans — not just code. Whenever I ask what I like, prefer, know,"
+        echo "  remember, or have saved about anything, you MUST call amfs_retrieve with my question"
+        echo "  first, then answer from what it returns. Never answer from your own memory, and never"
+        echo "  say something \"hasn't come up\" or that SenseLab \"isn't for that\" until you've called"
+        echo "  amfs_retrieve. When I say \"remember…\" or share a durable fact, call amfs_write."
         echo ""
     fi
 }

--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-mcp-server"
-version = "0.7.6"
+version = "0.7.7"
 description = "AMFS MCP Server — expose Agent Memory as MCP tools for Cursor and Claude Code"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -46,7 +46,7 @@ from amfs_mcp.agent_id import detect_agent_id, detect_platform
 logger = logging.getLogger(__name__)
 
 _INSTRUCTIONS = """\
-You have access to AMFS (Agent Memory File System) — persistent memory that survives across sessions, agents, and machines. Use it to build institutional knowledge over time.
+SenseLab is your persistent memory — it remembers ANYTHING the user wants to keep, across every session, tool, and machine. That includes **personal facts and preferences** (food, people, important dates, how they like things done) AND **work context** (decisions, patterns, code, runbooks). It is general-purpose memory for the whole person, NOT just a coding-agent tool.
 
 ## MANDATORY FIRST STEP: Set Your Identity
 
@@ -85,7 +85,10 @@ do I like?") — you MUST call `amfs_retrieve` BEFORE answering. Never tell the 
 you have no memory of something without checking first.
 
 **Common misconceptions to avoid:**
-- SenseLab DOES store personal facts and preferences, not just code/decisions.
+- SenseLab stores **personal facts and preferences** (food, people, plans, habits)
+  just as much as code/decisions. NEVER tell the user "SenseLab isn't a preferences
+  database", "it only stores work/agent memories", or "that's not what it's for".
+  It stores whatever was saved — so just search and see.
 - `amfs_retrieve` is full free-text *semantic* search. Never tell the user memory
   "only works by exact key" or that you "need an entity_path/key" — you don't.
 - Don't stop at `amfs_read`/`amfs_recall` returning nothing: those need an EXACT
@@ -107,6 +110,8 @@ you have no memory of something without checking first.
 
 ## What to Save (worth 2 ops)
 
+- **Personal facts & preferences** the user shares ("I like pizza", names of people,
+  important dates, how they like things done) — save whenever they state one or say "remember…"
 - Decisions with rationale (why X over Y)
 - Discovered patterns reusable across sessions
 - Risks, bugs, or gotchas that would trip up future agents
@@ -116,12 +121,12 @@ you have no memory of something without checking first.
 ## What NOT to Save (waste of ops)
 
 - Trivial changes the IDE/VCS already tracks ("added a comment", "renamed variable")
-- Anything recomputable from the current codebase in under 5 seconds
+- Anything trivially recomputable from the current context in under 5 seconds
 - Transient debug output or one-sentence entries (too low signal for 2 ops)
 
 ## Entity Naming
 
-Use `{repo}/{service-or-module}` paths (e.g. `myapp/auth`, `amfs/core-engine`). Avoid generic paths like `project` or `code`.
+Use short hierarchical paths. For work: `{repo}/{service-or-module}` (e.g. `myapp/auth`, `amfs/core-engine`). For personal memory: `user/preferences`, `user/people`, `user/plans`, etc. Avoid generic paths like `project` or `code`. When recalling you never need to remember the path — `amfs_retrieve` searches across all of them by meaning.
 
 ## Key Patterns
 


### PR DESCRIPTION
## Why
A user on Claude Desktop asked "what food do I like?" and got refusals: *"SenseLab isn't really a food-preferences database… it stores your agent/work memories."* Claude wasn't hallucinating — it read that from **our** MCP instructions, which frame SenseLab entirely around code/agent memory:
- What to Save = decisions / patterns / risks / task-summaries
- What NOT to Save = "recomputable from the codebase"
- Entity naming = `repo/service`

The single "stores personal facts too" line was drowned out.

## What (OSS `amfs-mcp-server`)
- Lead the instructions with: general-purpose memory for **personal facts + preferences AND work context**, explicitly "not just a coding-agent tool".
- Strengthen the misconceptions list: never tell the user SenseLab "isn't a preferences database" / "only stores work memories" / "isn't for that" — just search.
- Add personal facts/preferences to **What to Save**; generalize codebase-only wording; add personal entity-path examples (`user/preferences`, `user/people`).
- Fix the Claude Desktop setup hint in `install-mcp.sh`: correct field is **Settings → General → "Instructions for Claude"** (was "Profile"), with a sharper instruction that names the `senselab` connector and forbids answering from the model's own memory.

Companion Pro-server + dashboard changes in amfs-internal. Bumps `amfs-mcp-server` 0.7.6 → 0.7.7.