### PR TITLE
feat(http): dashboard aggregate endpoints — /entities, extended /stats, share-stats, paged /entries

### DIFF
--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -230,6 +230,50 @@ class HttpAdapter(AdapterABC):
         data = self._get("/api/v1/stats")
         return MemoryStats.model_validate(data)
 
+    def stats_extended(self, *, agent_ids: list[str] | None = None) -> dict:
+        # The server applies its own visibility scoping; a local agent_ids
+        # restriction can't be forwarded, so fall back to the list() scan.
+        if agent_ids is not None:
+            return super().stats_extended(agent_ids=agent_ids)
+        data = self._get("/api/v1/stats")
+        if "total_recalls" not in data:
+            # Older server without extended stats — compute locally.
+            return super().stats_extended()
+        return data
+
+    def entity_summaries(self, *, agent_ids: list[str] | None = None) -> list[dict]:
+        if agent_ids is not None:
+            return super().entity_summaries(agent_ids=agent_ids)
+        try:
+            data = self._get("/api/v1/entities")
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                return super().entity_summaries()
+            raise
+        return data.get("entities", [])
+
+    def share_stats(
+        self,
+        *,
+        since: datetime | None = None,
+        pair_limit: int = 20,
+        agent_ids: list[str] | None = None,
+    ) -> dict:
+        if agent_ids is not None:
+            return super().share_stats(
+                since=since, pair_limit=pair_limit, agent_ids=agent_ids
+            )
+        params: dict[str, Any] = {"pair_limit": pair_limit}
+        if since:
+            params["since"] = since.isoformat()
+        try:
+            return self._get("/api/v1/traces/share-stats", **params)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                # Older server routes this to /traces/{trace_id} → 404.
+                return super().share_stats(since=since, pair_limit=pair_limit)
+            raise
+
     def list_outcomes(
         self,
         *,

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -1567,6 +1567,184 @@ class PostgresAdapter(AdapterABC):
             newest_entry_at=row["newest_entry_at"],
         )
 
+    def entity_summaries(
+        self,
+        *,
+        agent_ids: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Per-entity aggregates via GROUP BY — never loads entry values."""
+        conditions = ["namespace = %s", "branch = 'main'", "superseded_at IS NULL"]
+        params: list[Any] = [self._namespace]
+        if agent_ids is not None:
+            conditions.append("agent_id = ANY(%s)")
+            params.append(list(agent_ids))
+        where = " AND ".join(conditions)
+
+        sql = f"""
+            SELECT entity_path,
+                   COUNT(*) AS entry_count,
+                   AVG(confidence) AS avg_confidence,
+                   MAX(written_at) AS last_updated,
+                   (ARRAY_AGG(agent_id ORDER BY written_at DESC))[1] AS last_agent,
+                   ARRAY_AGG(DISTINCT agent_id) AS agents,
+                   COUNT(*) FILTER (WHERE content_hash IS NOT NULL) AS hashed_count
+            FROM amfs_memory_entries
+            WHERE {where}
+            GROUP BY entity_path
+            ORDER BY MAX(written_at) DESC
+        """
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+                rows = cur.fetchall()
+
+        return [
+            {
+                "entity_path": r["entity_path"],
+                "entry_count": r["entry_count"],
+                "avg_confidence": float(r["avg_confidence"] or 0),
+                "last_updated": r["last_updated"],
+                "last_agent": r["last_agent"],
+                "agents": sorted(r["agents"] or []),
+                "hashed_count": r["hashed_count"],
+            }
+            for r in rows
+        ]
+
+    def stats_extended(
+        self,
+        *,
+        agent_ids: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Extended aggregate stats in SQL (recalls, weekly deltas, types)."""
+        conditions = ["namespace = %s", "superseded_at IS NULL"]
+        params: list[Any] = [self._namespace]
+        if agent_ids is not None:
+            conditions.append("agent_id = ANY(%s)")
+            params.append(list(agent_ids))
+        where = " AND ".join(conditions)
+
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    SELECT
+                        COUNT(*) AS total_entries,
+                        COUNT(DISTINCT entity_path) AS total_entities,
+                        COUNT(DISTINCT agent_id) AS total_agents,
+                        AVG(confidence) AS confidence_avg,
+                        MIN(confidence) AS confidence_min,
+                        MAX(confidence) AS confidence_max,
+                        COUNT(*) FILTER (WHERE outcome_count > 0) AS outcome_linked_count,
+                        MIN(written_at) AS oldest_entry_at,
+                        MAX(written_at) AS newest_entry_at,
+                        COALESCE(SUM(recall_count), 0) AS total_recalls,
+                        COUNT(*) FILTER (WHERE written_at >= NOW() - INTERVAL '7 days')
+                            AS entries_this_week,
+                        COUNT(*) FILTER (
+                            WHERE written_at >= NOW() - INTERVAL '14 days'
+                              AND written_at < NOW() - INTERVAL '7 days'
+                        ) AS entries_last_week
+                    FROM amfs_memory_entries
+                    WHERE {where}
+                    """,
+                    params,
+                )
+                row = cur.fetchone()
+
+                cur.execute(
+                    f"""
+                    SELECT agent_id, COUNT(*) AS cnt
+                    FROM amfs_memory_entries WHERE {where} GROUP BY agent_id
+                    """,
+                    params,
+                )
+                agent_rows = cur.fetchall()
+
+                cur.execute(
+                    f"""
+                    SELECT entity_path, COUNT(*) AS cnt
+                    FROM amfs_memory_entries WHERE {where} GROUP BY entity_path
+                    """,
+                    params,
+                )
+                entity_rows = cur.fetchall()
+
+                cur.execute(
+                    f"""
+                    SELECT memory_type, COUNT(*) AS cnt
+                    FROM amfs_memory_entries WHERE {where} GROUP BY memory_type
+                    """,
+                    params,
+                )
+                type_rows = cur.fetchall()
+
+        return {
+            "total_entries": row["total_entries"] if row else 0,
+            "total_entities": row["total_entities"] if row else 0,
+            "total_agents": row["total_agents"] if row else 0,
+            "agents": {r["agent_id"]: r["cnt"] for r in agent_rows},
+            "entities": {r["entity_path"]: r["cnt"] for r in entity_rows},
+            "confidence_avg": float(row["confidence_avg"] or 0) if row else 0.0,
+            "confidence_min": float(row["confidence_min"] or 0) if row else 0.0,
+            "confidence_max": float(row["confidence_max"] or 0) if row else 0.0,
+            "outcome_linked_count": row["outcome_linked_count"] if row else 0,
+            "oldest_entry_at": row["oldest_entry_at"] if row else None,
+            "newest_entry_at": row["newest_entry_at"] if row else None,
+            "total_recalls": int(row["total_recalls"]) if row else 0,
+            "entries_this_week": row["entries_this_week"] if row else 0,
+            "entries_last_week": row["entries_last_week"] if row else 0,
+            "memory_type_counts": {
+                (r["memory_type"] or "fact"): r["cnt"] for r in type_rows
+            },
+        }
+
+    def share_stats(
+        self,
+        *,
+        since: datetime | None = None,
+        pair_limit: int = 20,
+        agent_ids: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Cross-agent share aggregate via JSONB unnest — full traces never
+        leave the database."""
+        conditions = [
+            "t.namespace = %s",
+            "NULLIF(ce->>'written_by', '') IS NOT NULL",
+            "ce->>'written_by' <> t.agent_id",
+        ]
+        params: list[Any] = [self._namespace]
+        if since is not None:
+            conditions.append("t.created_at >= %s")
+            params.append(since)
+        if agent_ids is not None:
+            conditions.append("t.agent_id = ANY(%s)")
+            params.append(list(agent_ids))
+            conditions.append("ce->>'written_by' = ANY(%s)")
+            params.append(list(agent_ids))
+        where = " AND ".join(conditions)
+
+        sql = f"""
+            SELECT t.agent_id AS reader, ce->>'written_by' AS author,
+                   COUNT(*) AS cnt
+            FROM amfs_decision_traces t
+            CROSS JOIN LATERAL jsonb_array_elements(t.causal_entries) AS ce
+            WHERE {where}
+            GROUP BY t.agent_id, ce->>'written_by'
+            ORDER BY cnt DESC
+        """
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+                rows = cur.fetchall()
+
+        total = sum(r["cnt"] for r in rows)
+        pairs = [
+            {"reader": r["reader"], "author": r["author"], "count": r["cnt"]}
+            for r in rows[:pair_limit]
+        ]
+        return {"total": total, "pairs": pairs}
+
     # ------------------------------------------------------------------
     # watch
     # ------------------------------------------------------------------

--- a/packages/core/src/amfs_core/abc.py
+++ b/packages/core/src/amfs_core/abc.py
@@ -265,6 +265,78 @@ class AdapterABC(ABC):
             newest_entry_at=newest,
         )
 
+    def entity_summaries(
+        self,
+        *,
+        agent_ids: list[str] | None = None,
+    ) -> list[dict]:
+        """Per-entity aggregates (count, avg confidence, last write, agents).
+
+        Returns a list of dicts sorted by most recently updated:
+        ``{entity_path, entry_count, avg_confidence, last_updated,
+        last_agent, agents, hashed_count}``.
+
+        *agent_ids*, when given, restricts aggregation to entries written by
+        those agents (used by per-user visibility layers).
+
+        Default implementation groups over ``list()``; adapters with SQL
+        storage should override with GROUP BY aggregates.
+        """
+        from amfs_core.aggregates import entity_summaries_from_entries
+
+        entries = self.list()
+        if agent_ids is not None:
+            allowed = set(agent_ids)
+            entries = [e for e in entries if e.provenance.agent_id in allowed]
+        return entity_summaries_from_entries(entries)
+
+    def stats_extended(
+        self,
+        *,
+        agent_ids: list[str] | None = None,
+    ) -> dict:
+        """Aggregate stats with value/ROI extras beyond ``stats()``.
+
+        Returns the ``MemoryStats`` fields plus ``total_recalls``,
+        ``entries_this_week``, ``entries_last_week``, and
+        ``memory_type_counts``. *agent_ids* restricts to those writers.
+
+        Default implementation iterates over ``list()``; adapters with SQL
+        storage should override with aggregates.
+        """
+        from amfs_core.aggregates import extended_stats_from_entries
+
+        entries = self.list()
+        if agent_ids is not None:
+            allowed = set(agent_ids)
+            entries = [e for e in entries if e.provenance.agent_id in allowed]
+        return extended_stats_from_entries(entries)
+
+    def share_stats(
+        self,
+        *,
+        since: datetime | None = None,
+        pair_limit: int = 20,
+        agent_ids: list[str] | None = None,
+    ) -> dict:
+        """Cross-agent knowledge-share aggregate from decision traces.
+
+        A "share" is a trace causal entry written by a different agent than
+        the trace's own agent. Returns ``{total, pairs}`` where pairs are
+        ``{reader, author, count}`` sorted by count (capped at *pair_limit*).
+
+        Default implementation scans ``list_traces()``; SQL adapters should
+        override with a JSONB aggregate so full traces never leave the DB.
+        """
+        from amfs_core.aggregates import share_stats_from_traces
+
+        return share_stats_from_traces(
+            self.list_traces(limit=10_000),
+            since=since,
+            pair_limit=pair_limit,
+            agent_ids=agent_ids,
+        )
+
     # ── Content integrity ────────────────────────────────────────────────
 
     def verify_integrity(

--- a/packages/core/src/amfs_core/aggregates.py
+++ b/packages/core/src/amfs_core/aggregates.py
@@ -1,0 +1,133 @@
+"""Pure aggregate computations over in-memory entries/traces.
+
+Shared by AdapterABC default implementations and by HTTP handlers that must
+aggregate over an already visibility-filtered list (where SQL can't express
+the per-user room semantics). Keeping one implementation guarantees the
+Python fallback and the filtered path always agree.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from amfs_core.models import DecisionTrace, MemoryEntry
+
+
+def entity_summaries_from_entries(entries: "list[MemoryEntry]") -> list[dict]:
+    """Group entries per entity path: count, avg confidence, last write, agents."""
+    grouped: dict[str, list] = {}
+    for entry in entries:
+        grouped.setdefault(entry.entity_path, []).append(entry)
+
+    summaries: list[dict] = []
+    for entity_path, group in grouped.items():
+        group_sorted = sorted(
+            group, key=lambda e: e.provenance.written_at, reverse=True
+        )
+        summaries.append(
+            {
+                "entity_path": entity_path,
+                "entry_count": len(group),
+                "avg_confidence": sum(e.confidence for e in group) / len(group),
+                "last_updated": group_sorted[0].provenance.written_at,
+                "last_agent": group_sorted[0].provenance.agent_id,
+                "agents": sorted({e.provenance.agent_id for e in group}),
+                "hashed_count": sum(1 for e in group if e.content_hash),
+            }
+        )
+    summaries.sort(key=lambda s: s["last_updated"], reverse=True)
+    return summaries
+
+
+def extended_stats_from_entries(entries: "list[MemoryEntry]") -> dict:
+    """MemoryStats fields plus recall totals, weekly deltas, and type counts."""
+    now = datetime.now(timezone.utc)
+    week_ago = now - timedelta(days=7)
+    two_weeks_ago = now - timedelta(days=14)
+
+    agents: dict[str, int] = {}
+    entities: dict[str, int] = {}
+    memory_type_counts: dict[str, int] = {}
+    confidences: list[float] = []
+    outcome_linked = 0
+    total_recalls = 0
+    this_week = 0
+    last_week = 0
+    oldest: datetime | None = None
+    newest: datetime | None = None
+
+    for entry in entries:
+        aid = entry.provenance.agent_id
+        agents[aid] = agents.get(aid, 0) + 1
+        entities[entry.entity_path] = entities.get(entry.entity_path, 0) + 1
+        mt = str(getattr(entry.memory_type, "value", entry.memory_type))
+        memory_type_counts[mt] = memory_type_counts.get(mt, 0) + 1
+        confidences.append(entry.confidence)
+        if entry.outcome_count > 0:
+            outcome_linked += 1
+        total_recalls += entry.recall_count
+        written = entry.provenance.written_at
+        if written >= week_ago:
+            this_week += 1
+        elif written >= two_weeks_ago:
+            last_week += 1
+        if oldest is None or written < oldest:
+            oldest = written
+        if newest is None or written > newest:
+            newest = written
+
+    return {
+        "total_entries": len(entries),
+        "total_entities": len(entities),
+        "total_agents": len(agents),
+        "agents": agents,
+        "entities": entities,
+        "confidence_avg": (sum(confidences) / len(confidences)) if confidences else 0.0,
+        "confidence_min": min(confidences) if confidences else 0.0,
+        "confidence_max": max(confidences) if confidences else 0.0,
+        "outcome_linked_count": outcome_linked,
+        "oldest_entry_at": oldest,
+        "newest_entry_at": newest,
+        "total_recalls": total_recalls,
+        "entries_this_week": this_week,
+        "entries_last_week": last_week,
+        "memory_type_counts": memory_type_counts,
+    }
+
+
+def share_stats_from_traces(
+    traces: "list[DecisionTrace]",
+    *,
+    since: datetime | None = None,
+    pair_limit: int = 20,
+    agent_ids: list[str] | None = None,
+) -> dict:
+    """Cross-agent share counts: causal entries authored by a different agent."""
+    allowed = set(agent_ids) if agent_ids is not None else None
+
+    pair_counts: dict[tuple[str, str], int] = {}
+    total = 0
+    for trace in traces:
+        if since is not None and trace.created_at < since:
+            continue
+        if allowed is not None and trace.agent_id not in allowed:
+            continue
+        for ce in trace.causal_entries:
+            author = ce.written_by
+            if not author or author == trace.agent_id:
+                continue
+            if allowed is not None and author not in allowed:
+                continue
+            total += 1
+            key = (trace.agent_id, author)
+            pair_counts[key] = pair_counts.get(key, 0) + 1
+
+    pairs = [
+        {"reader": reader, "author": author, "count": count}
+        for (reader, author), count in sorted(
+            pair_counts.items(), key=lambda kv: kv[1], reverse=True
+        )
+    ]
+    return {"total": total, "pairs": pairs[:pair_limit]}

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -765,6 +765,10 @@ async def list_entries(
     entity_path: str | None = Query(None),
     branch: str = Query("main"),
     include_superseded: bool = Query(False),
+    limit: int | None = Query(None, ge=1, le=10_000),
+    offset: int = Query(0, ge=0),
+    sort: str | None = Query(None, pattern="^(written_at|recall_count)$"),
+    fields: str | None = Query(None, pattern="^meta$"),
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
     try:
@@ -812,7 +816,50 @@ async def list_entries(
             entity_path, total_before, vis,
         )
 
-    return {"entries": [_entry_to_response(e) for e in entries]}
+    # Sorting/pagination/meta happen after the visibility filter so callers
+    # can never page past entries they aren't allowed to see. Defaults keep
+    # the historical behavior (full list, full fields) intact.
+    if sort == "written_at":
+        entries = sorted(entries, key=lambda e: e.provenance.written_at, reverse=True)
+    elif sort == "recall_count":
+        entries = sorted(entries, key=lambda e: e.recall_count, reverse=True)
+
+    total = len(entries)
+    if offset:
+        entries = entries[offset:]
+    if limit is not None:
+        entries = entries[:limit]
+
+    payload = [_entry_to_response(e) for e in entries]
+    if fields == "meta":
+        for item in payload:
+            item.pop("value", None)
+            item.pop("artifact_refs", None)
+
+    return {"entries": payload, "total": total}
+
+
+@app.get("/api/v1/entities")
+async def list_entity_summaries(
+    request: Request,
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    """Per-entity aggregates without entry values — a few KB instead of the
+    multi-MB /entries payload. Dashboards should prefer this endpoint."""
+    mem = _get_memory()
+
+    vis = _get_visibility_filter(request)
+    if vis is not None and vis.should_filter():
+        # Room visibility can't be expressed as a per-agent SQL filter, so
+        # filter entries in Python and aggregate with the shared helper.
+        from amfs_core.aggregates import entity_summaries_from_entries
+
+        entries = vis.filter_entries(mem.list())
+        summaries = entity_summaries_from_entries(entries)
+    else:
+        summaries = mem._adapter.entity_summaries()
+
+    return json.loads(json.dumps({"entities": summaries}, default=str))
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -989,51 +1036,23 @@ async def get_stats(
 
     vis = _get_visibility_filter(request)
     if vis is not None and vis.should_filter():
-        # Visibility-scoped stats. This branch must return the SAME shape as
-        # MemoryStats (which mem.stats() below produces), because the client
-        # parses /stats via MemoryStats.model_validate — any missing field
-        # silently defaults (confidence→0.0, outcome→0) and any mis-named key
-        # (e.g. "oldest_entry" vs "oldest_entry_at") is dropped to None. The
-        # earlier partial dict caused exactly that: correct counts but zeroed
-        # confidence/outcome and null timestamps.
-        from amfs_core.models import MemoryStats
+        # Visibility-scoped stats. This branch must return a SUPERSET of the
+        # MemoryStats shape (which the unfiltered branch below produces),
+        # because the client parses /stats via MemoryStats.model_validate —
+        # any missing field silently defaults (confidence→0.0, outcome→0) and
+        # any mis-named key (e.g. "oldest_entry" vs "oldest_entry_at") is
+        # dropped to None. Room visibility semantics (co-member entries on
+        # shared entity paths) can't be expressed as a plain agent_id filter,
+        # so this path filters in Python and aggregates via the same shared
+        # helper the adapter defaults use.
+        from amfs_core.aggregates import extended_stats_from_entries
 
-        entries = mem.list()
-        entries = vis.filter_entries(entries)
+        entries = vis.filter_entries(mem.list())
+        scoped = extended_stats_from_entries(entries)
+        return json.loads(json.dumps(scoped, default=str))
 
-        agents: dict[str, int] = {}
-        entities: dict[str, int] = {}
-        confidences: list[float] = []
-        written_ats: list[Any] = []
-        outcome_linked = 0
-        for e in entries:
-            entities[e.entity_path] = entities.get(e.entity_path, 0) + 1
-            aid = e.provenance.agent_id
-            agents[aid] = agents.get(aid, 0) + 1
-            confidences.append(float(e.confidence))
-            if getattr(e, "outcome_count", 0):
-                outcome_linked += 1
-            wa = getattr(e.provenance, "written_at", None)
-            if wa is not None:
-                written_ats.append(wa)
-
-        scoped = MemoryStats(
-            total_entries=len(entries),
-            total_entities=len(entities),
-            total_agents=len(agents),
-            agents=agents,
-            entities=entities,
-            confidence_avg=(sum(confidences) / len(confidences)) if confidences else 0.0,
-            confidence_min=min(confidences) if confidences else 0.0,
-            confidence_max=max(confidences) if confidences else 0.0,
-            outcome_linked_count=outcome_linked,
-            oldest_entry_at=min(written_ats) if written_ats else None,
-            newest_entry_at=max(written_ats) if written_ats else None,
-        )
-        return json.loads(json.dumps(scoped.model_dump(mode="json"), default=str))
-
-    stats = mem.stats()
-    return json.loads(json.dumps(stats.model_dump(mode="json"), default=str))
+    stats = mem._adapter.stats_extended()
+    return json.loads(json.dumps(stats, default=str))
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -1632,6 +1651,30 @@ async def save_trace(
     mem = _get_memory()
     saved = mem._adapter.save_trace(trace)
     return saved.model_dump(mode="json")
+
+
+# NOTE: must be registered before /api/v1/traces/{trace_id} so "share-stats"
+# isn't captured as a trace_id.
+@app.get("/api/v1/traces/share-stats")
+async def get_share_stats(
+    request: Request,
+    since: datetime | None = Query(None),
+    pair_limit: int = Query(20, ge=1, le=100),
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    """Cross-agent knowledge-share totals and top reader/author pairs,
+    aggregated server-side so full traces never cross the wire."""
+    mem = _get_memory()
+
+    vis = _get_visibility_filter(request)
+    agent_ids: list[str] | None = None
+    if vis is not None and vis.should_filter():
+        agent_ids = sorted(vis.get_visible_agent_ids())
+
+    stats = mem._adapter.share_stats(
+        since=since, pair_limit=pair_limit, agent_ids=agent_ids
+    )
+    return json.loads(json.dumps(stats, default=str))
 
 
 @app.get("/api/v1/traces/{trace_id}")

--- a/tests/unit/test_aggregate_endpoints.py
+++ b/tests/unit/test_aggregate_endpoints.py
@@ -1,0 +1,402 @@
+"""Tests for the dashboard aggregate endpoints and shared aggregate helpers.
+
+Covers:
+- amfs_core.aggregates pure functions (entity summaries, extended stats,
+  cross-agent share stats)
+- AdapterABC default implementations of entity_summaries / stats_extended /
+  share_stats
+- HTTP handlers: /api/v1/entries pagination + meta fields, /api/v1/entities,
+  extended /api/v1/stats, and /api/v1/traces/share-stats (including route
+  precedence over /traces/{trace_id}).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from amfs_core.aggregates import (
+    entity_summaries_from_entries,
+    extended_stats_from_entries,
+    share_stats_from_traces,
+)
+from amfs_core.models import (
+    DecisionTrace,
+    MemoryEntry,
+    Provenance,
+    TraceEntry,
+)
+
+NOW = datetime.now(timezone.utc)
+
+
+def _entry(
+    entity_path: str = "repo/module",
+    key: str = "k",
+    agent_id: str = "agent-a",
+    confidence: float = 0.8,
+    written_at: datetime | None = None,
+    recall_count: int = 0,
+    outcome_count: int = 0,
+    content_hash: str | None = None,
+    memory_type: str = "fact",
+) -> MemoryEntry:
+    return MemoryEntry(
+        entity_path=entity_path,
+        key=key,
+        value={"v": 1},
+        provenance=Provenance(
+            agent_id=agent_id,
+            session_id="s1",
+            written_at=written_at or NOW,
+        ),
+        confidence=confidence,
+        recall_count=recall_count,
+        outcome_count=outcome_count,
+        content_hash=content_hash,
+        memory_type=memory_type,
+    )
+
+
+def _trace(
+    reader: str,
+    authors: list[str | None],
+    created_at: datetime | None = None,
+) -> DecisionTrace:
+    return DecisionTrace(
+        id=f"tr-{reader}-{len(authors)}",
+        agent_id=reader,
+        session_id="s1",
+        causal_entries=[
+            TraceEntry(
+                entity_path="repo/module",
+                key=f"k{i}",
+                version=1,
+                confidence=0.9,
+                written_by=a,
+            )
+            for i, a in enumerate(authors)
+        ],
+        created_at=created_at or NOW,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure aggregate helpers
+# ---------------------------------------------------------------------------
+
+
+class TestEntitySummaries:
+    def test_groups_and_sorts_by_last_updated(self) -> None:
+        old = NOW - timedelta(days=3)
+        entries = [
+            _entry("repo/a", "k1", "agent-a", 0.6, old),
+            _entry("repo/a", "k2", "agent-b", 1.0, NOW, content_hash="abc"),
+            _entry("repo/b", "k1", "agent-a", 0.9, old),
+        ]
+        summaries = entity_summaries_from_entries(entries)
+
+        assert [s["entity_path"] for s in summaries] == ["repo/a", "repo/b"]
+        a = summaries[0]
+        assert a["entry_count"] == 2
+        assert a["avg_confidence"] == pytest.approx(0.8)
+        assert a["last_agent"] == "agent-b"
+        assert a["agents"] == ["agent-a", "agent-b"]
+        assert a["hashed_count"] == 1
+
+    def test_empty(self) -> None:
+        assert entity_summaries_from_entries([]) == []
+
+
+class TestExtendedStats:
+    def test_counts_recalls_and_weekly_delta(self) -> None:
+        entries = [
+            _entry("repo/a", "k1", "agent-a", recall_count=5, written_at=NOW),
+            _entry(
+                "repo/a",
+                "k2",
+                "agent-b",
+                recall_count=2,
+                written_at=NOW - timedelta(days=10),
+                memory_type="belief",
+            ),
+            _entry(
+                "repo/b",
+                "k1",
+                "agent-a",
+                outcome_count=1,
+                written_at=NOW - timedelta(days=30),
+            ),
+        ]
+        stats = extended_stats_from_entries(entries)
+
+        assert stats["total_entries"] == 3
+        assert stats["total_entities"] == 2
+        assert stats["total_agents"] == 2
+        assert stats["total_recalls"] == 7
+        assert stats["entries_this_week"] == 1
+        assert stats["entries_last_week"] == 1
+        assert stats["outcome_linked_count"] == 1
+        assert stats["memory_type_counts"] == {"fact": 2, "belief": 1}
+        assert stats["oldest_entry_at"] == NOW - timedelta(days=30)
+        assert stats["newest_entry_at"] == NOW
+
+    def test_empty(self) -> None:
+        stats = extended_stats_from_entries([])
+        assert stats["total_entries"] == 0
+        assert stats["total_recalls"] == 0
+        assert stats["confidence_avg"] == 0.0
+        assert stats["oldest_entry_at"] is None
+
+
+class TestShareStats:
+    def test_counts_cross_agent_pairs_only(self) -> None:
+        traces = [
+            # reader-a used writer-b's knowledge twice, own knowledge once
+            _trace("reader-a", ["writer-b", "writer-b", "reader-a"]),
+            _trace("reader-c", ["writer-b", None]),
+        ]
+        stats = share_stats_from_traces(traces)
+
+        assert stats["total"] == 3
+        assert stats["pairs"][0] == {
+            "reader": "reader-a",
+            "author": "writer-b",
+            "count": 2,
+        }
+        assert {"reader": "reader-c", "author": "writer-b", "count": 1} in stats["pairs"]
+
+    def test_since_filter(self) -> None:
+        old = NOW - timedelta(days=60)
+        traces = [
+            _trace("reader-a", ["writer-b"], created_at=old),
+            _trace("reader-a", ["writer-b"], created_at=NOW),
+        ]
+        stats = share_stats_from_traces(traces, since=NOW - timedelta(days=30))
+        assert stats["total"] == 1
+
+    def test_agent_ids_restricts_both_sides(self) -> None:
+        traces = [
+            _trace("reader-a", ["writer-b"]),
+            _trace("reader-a", ["hidden-agent"]),
+            _trace("hidden-agent", ["writer-b"]),
+        ]
+        stats = share_stats_from_traces(traces, agent_ids=["reader-a", "writer-b"])
+        assert stats["total"] == 1
+        assert stats["pairs"] == [
+            {"reader": "reader-a", "author": "writer-b", "count": 1}
+        ]
+
+    def test_pair_limit_caps_pairs_not_total(self) -> None:
+        traces = [
+            _trace("r1", ["w1", "w1"]),
+            _trace("r2", ["w2"]),
+            _trace("r3", ["w3"]),
+        ]
+        stats = share_stats_from_traces(traces, pair_limit=1)
+        assert stats["total"] == 4
+        assert len(stats["pairs"]) == 1
+        assert stats["pairs"][0]["count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# AdapterABC default implementations
+# ---------------------------------------------------------------------------
+
+
+def _fake_adapter(entries: list[MemoryEntry], traces: list[DecisionTrace]):
+    from amfs_core.abc import AdapterABC
+
+    class FakeAdapter(AdapterABC):
+        def read(self, entity_path, key, *, min_confidence=0.0):
+            return None
+
+        def write(self, entry):
+            return entry
+
+        def list(self, entity_path=None, *, include_superseded=False):
+            return entries
+
+        def watch(self, entity_path, callback):
+            raise NotImplementedError
+
+        def commit_outcome(self, record):
+            return []
+
+        def list_traces(self, **kwargs):
+            return traces
+
+    return FakeAdapter()
+
+
+class TestAdapterDefaults:
+    def test_entity_summaries_with_agent_filter(self) -> None:
+        adapter = _fake_adapter(
+            [
+                _entry("repo/a", "k1", "agent-a"),
+                _entry("repo/a", "k2", "agent-b"),
+            ],
+            [],
+        )
+        summaries = adapter.entity_summaries(agent_ids=["agent-a"])
+        assert summaries[0]["entry_count"] == 1
+        assert summaries[0]["agents"] == ["agent-a"]
+
+    def test_stats_extended_matches_helper(self) -> None:
+        entries = [_entry("repo/a", "k1", recall_count=3)]
+        adapter = _fake_adapter(entries, [])
+        assert adapter.stats_extended() == extended_stats_from_entries(entries)
+
+    def test_share_stats_delegates(self) -> None:
+        traces = [_trace("reader-a", ["writer-b"])]
+        adapter = _fake_adapter([], traces)
+        assert adapter.share_stats()["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# HTTP handlers
+# ---------------------------------------------------------------------------
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+from fastapi.testclient import TestClient  # noqa: E402
+
+import amfs_http.server as server  # noqa: E402
+
+
+@pytest.fixture()
+def entries() -> list[MemoryEntry]:
+    return [
+        _entry("repo/a", "k1", "agent-a", 0.9, NOW, recall_count=4),
+        _entry("repo/a", "k2", "agent-b", 0.7, NOW - timedelta(days=1), recall_count=9),
+        _entry("repo/b", "k1", "agent-a", 0.5, NOW - timedelta(days=2), recall_count=1),
+    ]
+
+
+@pytest.fixture()
+def client(
+    monkeypatch: pytest.MonkeyPatch, entries: list[MemoryEntry]
+) -> TestClient:
+    traces = [_trace("reader-a", ["writer-b", "writer-b"])]
+    adapter = _fake_adapter(entries, traces)
+
+    mem = MagicMock()
+    mem.namespace = "test-ns"
+    mem._adapter = adapter
+    mem.list.side_effect = lambda *a, **kw: adapter.list()
+
+    monkeypatch.setattr(server, "_memory", mem)
+    monkeypatch.setattr(server, "_get_memory", lambda: mem)
+    monkeypatch.setattr(server, "_async_adapter", None)
+    monkeypatch.setattr(server, "_get_visibility_filter", lambda request: None)
+    return TestClient(server.app)
+
+
+class TestEntriesPagination:
+    def test_default_returns_all_with_total(self, client: TestClient) -> None:
+        res = client.get("/api/v1/entries")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["total"] == 3
+        assert len(body["entries"]) == 3
+        assert "value" in body["entries"][0]
+
+    def test_sort_limit_offset(self, client: TestClient) -> None:
+        res = client.get(
+            "/api/v1/entries", params={"sort": "recall_count", "limit": 1, "offset": 1}
+        )
+        body = res.json()
+        assert body["total"] == 3
+        assert len(body["entries"]) == 1
+        assert body["entries"][0]["recall_count"] == 4
+
+    def test_fields_meta_strips_values(self, client: TestClient) -> None:
+        res = client.get("/api/v1/entries", params={"fields": "meta"})
+        body = res.json()
+        assert all("value" not in e for e in body["entries"])
+        assert all("recall_count" in e for e in body["entries"])
+
+    def test_invalid_sort_rejected(self, client: TestClient) -> None:
+        res = client.get("/api/v1/entries", params={"sort": "nope"})
+        assert res.status_code == 422
+
+
+class TestEntitiesEndpoint:
+    def test_returns_summaries_without_values(self, client: TestClient) -> None:
+        res = client.get("/api/v1/entities")
+        assert res.status_code == 200
+        body = res.json()
+        assert len(body["entities"]) == 2
+        first = body["entities"][0]
+        assert first["entity_path"] == "repo/a"
+        assert first["entry_count"] == 2
+        assert "value" not in first
+        assert "entries" not in first
+
+    def test_visibility_filter_applied(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        vis = MagicMock()
+        vis.should_filter.return_value = True
+        vis.filter_entries.side_effect = lambda entries: [
+            e for e in entries if e.provenance.agent_id == "agent-b"
+        ]
+        monkeypatch.setattr(server, "_get_visibility_filter", lambda request: vis)
+
+        res = client.get("/api/v1/entities")
+        body = res.json()
+        assert len(body["entities"]) == 1
+        assert body["entities"][0]["entry_count"] == 1
+
+
+class TestStatsExtended:
+    def test_includes_extended_fields(self, client: TestClient) -> None:
+        res = client.get("/api/v1/stats")
+        assert res.status_code == 200
+        body = res.json()
+        # Backward-compatible MemoryStats fields
+        assert body["total_entries"] == 3
+        assert body["total_entities"] == 2
+        assert body["confidence_avg"] == pytest.approx(0.7)
+        # New extended fields
+        assert body["total_recalls"] == 14
+        assert "entries_this_week" in body
+        assert body["memory_type_counts"] == {"fact": 3}
+
+    def test_visibility_branch_has_same_shape(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        vis = MagicMock()
+        vis.should_filter.return_value = True
+        vis.filter_entries.side_effect = lambda entries: entries[:1]
+        monkeypatch.setattr(server, "_get_visibility_filter", lambda request: vis)
+
+        res = client.get("/api/v1/stats")
+        body = res.json()
+        assert body["total_entries"] == 1
+        assert body["total_recalls"] == 4
+        assert "confidence_avg" in body
+        assert "oldest_entry_at" in body
+
+
+class TestShareStatsEndpoint:
+    def test_share_stats_route_wins_over_trace_id(self, client: TestClient) -> None:
+        res = client.get("/api/v1/traces/share-stats")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["total"] == 2
+        assert body["pairs"] == [
+            {"reader": "reader-a", "author": "writer-b", "count": 2}
+        ]
+
+    def test_visibility_restricts_agents(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        vis = MagicMock()
+        vis.should_filter.return_value = True
+        vis.get_visible_agent_ids.return_value = {"someone-else"}
+        monkeypatch.setattr(server, "_get_visibility_filter", lambda request: vis)
+
+        res = client.get("/api/v1/traces/share-stats")
+        assert res.json()["total"] == 0


### PR DESCRIPTION
## Summary
Promotion of raia-live/amfs#248 (merged to dev, validated on the dev environment) to main:

- New `GET /api/v1/entities`: per-entity aggregates (count, avg confidence, last write, agents, hashed count) — a few KB instead of the multi-MB full entries payload
- `GET /api/v1/stats` extended with `total_recalls`, `entries_this_week`, `entries_last_week`, `memory_type_counts` (backward-compatible superset; visibility-scoped branch returns the same shape)
- New `GET /api/v1/traces/share-stats`: cross-agent knowledge-share totals + top reader/author pairs, aggregated via JSONB in SQL
- `GET /api/v1/entries` gains optional `limit`/`offset`/`sort`/`fields=meta`, applied after the visibility filter; defaults preserve existing behavior
- Shared helpers in `amfs_core.aggregates` keep AdapterABC defaults, Postgres SQL overrides, and visibility-filtered handler paths in agreement; `HttpAdapter` proxies the new endpoints with 404 fallbacks for older servers

## Test plan
- [x] 21 unit tests in `tests/unit/test_aggregate_endpoints.py`
- [x] Full unit suite passes (pre-existing failures on main unrelated)
- [x] Validated on the dev environment (amfs-api-dev serves the new routes; dashboard-dev consumes them)