### PR TITLE
feat(stats): weekly recall deltas from the event log

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -1677,7 +1677,48 @@ class PostgresAdapter(AdapterABC):
                 )
                 type_rows = cur.fetchall()
 
+                # Weekly reuse deltas from the timestamped event log (READ /
+                # CROSS_AGENT_READ events). recall_count on entries is a bare
+                # counter, so this is the only source of *when* reuse happened.
+                event_conditions = [
+                    "namespace = %s",
+                    "event_type IN ('read', 'cross_agent_read')",
+                ]
+                event_params: list[Any] = [self._namespace]
+                if agent_ids is not None:
+                    event_conditions.append("agent_id = ANY(%s)")
+                    event_params.append(list(agent_ids))
+                event_where = " AND ".join(event_conditions)
+                recalls_this_week = 0
+                recalls_last_week = 0
+                try:
+                    cur.execute(
+                        f"""
+                        SELECT
+                            COUNT(*) FILTER (
+                                WHERE created_at >= NOW() - INTERVAL '7 days'
+                            ) AS recalls_this_week,
+                            COUNT(*) FILTER (
+                                WHERE created_at >= NOW() - INTERVAL '14 days'
+                                  AND created_at < NOW() - INTERVAL '7 days'
+                            ) AS recalls_last_week
+                        FROM amfs_events
+                        WHERE {event_where}
+                        """,
+                        event_params,
+                    )
+                    event_row = cur.fetchone()
+                    if event_row:
+                        recalls_this_week = int(event_row["recalls_this_week"] or 0)
+                        recalls_last_week = int(event_row["recalls_last_week"] or 0)
+                except Exception:
+                    # Older deployments without the events table: deltas stay 0
+                    # and the dashboard hides the trend line.
+                    pass
+
         return {
+            "recalls_this_week": recalls_this_week,
+            "recalls_last_week": recalls_last_week,
             "total_entries": row["total_entries"] if row else 0,
             "total_entities": row["total_entities"] if row else 0,
             "total_agents": row["total_agents"] if row else 0,

--- a/packages/core/src/amfs_core/aggregates.py
+++ b/packages/core/src/amfs_core/aggregates.py
@@ -93,6 +93,11 @@ def extended_stats_from_entries(entries: "list[MemoryEntry]") -> dict:
         "total_recalls": total_recalls,
         "entries_this_week": this_week,
         "entries_last_week": last_week,
+        # Entries carry only a recall counter, not recall timestamps, so the
+        # pure-Python path can't compute weekly reuse deltas. None (vs 0) lets
+        # clients distinguish "unknown" from "no reuse" and hide the trend.
+        "recalls_this_week": None,
+        "recalls_last_week": None,
         "memory_type_counts": memory_type_counts,
     }
 

--- a/tests/unit/test_aggregate_endpoints.py
+++ b/tests/unit/test_aggregate_endpoints.py
@@ -143,6 +143,13 @@ class TestExtendedStats:
         assert stats["oldest_entry_at"] == NOW - timedelta(days=30)
         assert stats["newest_entry_at"] == NOW
 
+    def test_recall_deltas_unknown_from_entries(self) -> None:
+        # Entries carry only a recall counter (no timestamps), so the pure
+        # path reports None — clients hide the trend instead of showing 0.
+        stats = extended_stats_from_entries([_entry("repo/a", "k", "agent-a")])
+        assert stats["recalls_this_week"] is None
+        assert stats["recalls_last_week"] is None
+
     def test_empty(self) -> None:
         stats = extended_stats_from_entries([])
         assert stats["total_entries"] == 0


### PR DESCRIPTION
## Summary
- `stats_extended` (Postgres adapter) now computes `recalls_this_week` / `recalls_last_week` from timestamped READ / CROSS_AGENT_READ events in `amfs_events`, enabling dashboards to show memory reuse trending week over week (compounding ROI).
- Pure-Python aggregate path returns `None` for both fields — entries only carry a recall counter, not timestamps — so clients can distinguish "unknown" from "no reuse" and hide the trend line.
- Fails open on deployments without the events table (deltas report 0).

## Test plan
- [x] 22 unit tests pass (`tests/unit/test_aggregate_endpoints.py`), including a new test for the None semantics
- [ ] Verify dev API deploy returns the new fields on `/api/v1/stats`