### PR TITLE
feat(retrieval): artifact-aware ranking — classify, demote, and re-embed stored code

### DIFF
--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -198,13 +198,15 @@ class HttpAdapter(AdapterABC):
         recency_weight: float = 0.3,
         confidence_weight: float = 0.2,
         branch: str = "main",
+        include_artifacts: bool = True,
     ) -> list[tuple[MemoryEntry, float, dict[str, float]]]:
         """Server-side semantic retrieval via POST /api/v1/retrieve.
 
         The server does the embedding + pgvector similarity + blend, so this
         works even when the client has no embedder. Returns
         (entry, score, breakdown) tuples; breakdown is empty on the server's
-        lexical fallback.
+        lexical fallback. Artifacts (stored source files) are demoted by the
+        server; pass ``include_artifacts=False`` to exclude them entirely.
         """
         body: dict[str, Any] = {
             "query": query,
@@ -214,6 +216,7 @@ class HttpAdapter(AdapterABC):
             "recency_weight": recency_weight,
             "confidence_weight": confidence_weight,
             "branch": branch,
+            "include_artifacts": include_artifacts,
         }
         if entity_path:
             body["entity_path"] = entity_path

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -15,6 +15,7 @@ import psycopg
 from psycopg.rows import dict_row
 
 from amfs_core.abc import AdapterABC, WatchHandle
+from amfs_core.content import ARTIFACT_PENALTY, classify_artifact, embedding_input
 from amfs_core.embedder import EmbedderABC
 from amfs_core.exceptions import AdapterError, VersionConflictError
 from amfs_core.models import (
@@ -179,6 +180,7 @@ class PostgresAdapter(AdapterABC):
         self._namespace = namespace
         self._has_embedding_col = False
         self._has_search_tsv = False
+        self._has_is_artifact_col = False
         # When an embedder is provided, embeddings are computed at write time and
         # persisted, so ANN retrieval (semantic_search / pgvector HNSW) works
         # without a separate backfill pass. embedding_dim must match the column
@@ -240,6 +242,17 @@ class PostgresAdapter(AdapterABC):
         cur.execute("""
             ALTER TABLE amfs_memory_entries
             ADD COLUMN IF NOT EXISTS branch TEXT NOT NULL DEFAULT 'main'
+        """)
+        # Artifact flag: distinguishes stored working files (source code, markup,
+        # config) from knowledge facts so retrieval can demote them. Partial index
+        # stays tiny because only the artifact rows are indexed.
+        cur.execute("""
+            ALTER TABLE amfs_memory_entries
+            ADD COLUMN IF NOT EXISTS is_artifact BOOLEAN NOT NULL DEFAULT FALSE
+        """)
+        cur.execute("""
+            CREATE INDEX IF NOT EXISTS idx_entries_is_artifact
+            ON amfs_memory_entries (is_artifact) WHERE is_artifact
         """)
         cur.execute("""
             ALTER TABLE amfs_outcomes
@@ -400,14 +413,16 @@ class PostgresAdapter(AdapterABC):
                             namespace, entity_path, key, version, value,
                             agent_id, session_id, written_at, pattern_refs,
                             confidence, outcome_count, recall_count,
-                            ttl_at, memory_type, shared, artifact_refs
+                            ttl_at, memory_type, shared, artifact_refs,
+                            is_artifact
                         ) VALUES (
                             cur.namespace, cur.entity_path, cur.key, cur.version + 1, cur.value,
                             cur.agent_id, cur.session_id, cur.written_at, cur.pattern_refs,
                             LEAST(1.0, GREATEST(0.0, cur.confidence * multiplier * NEW.causal_confidence)),
                             cur.outcome_count + 1, cur.recall_count,
                             cur.ttl_at, cur.memory_type,
-                            cur.shared, cur.artifact_refs
+                            cur.shared, cur.artifact_refs,
+                            cur.is_artifact
                         );
                     END IF;
                 END LOOP;
@@ -719,12 +734,13 @@ class PostgresAdapter(AdapterABC):
                     """
                     SELECT column_name FROM information_schema.columns
                     WHERE table_name = 'amfs_memory_entries'
-                      AND column_name IN ('embedding', 'search_tsv')
+                      AND column_name IN ('embedding', 'search_tsv', 'is_artifact')
                     """,
                 )
                 found = {row["column_name"] for row in cur.fetchall()}
                 self._has_embedding_col = "embedding" in found
                 self._has_search_tsv = "search_tsv" in found
+                self._has_is_artifact_col = "is_artifact" in found
 
     # ------------------------------------------------------------------
     # read
@@ -852,6 +868,14 @@ class PostgresAdapter(AdapterABC):
 
                     entry_id = uuid.uuid4()
 
+                    # Classify at the persistence chokepoint so every write path
+                    # (HTTP async hot path, TransactionBuffer, Cortex, lifecycle,
+                    # snapshot — all of which bypass CoWEngine) gets a consistent
+                    # flag, and so a new version after a redact/revert re-classifies.
+                    is_artifact = bool(entry.is_artifact) or classify_artifact(
+                        entry.key, entry.value
+                    )
+
                     columns = [
                         "id", "namespace", "entity_path", "key", "version",
                         "value", "agent_id", "session_id", "written_at",
@@ -882,14 +906,21 @@ class PostgresAdapter(AdapterABC):
                         branch,
                     ]
 
+                    if self._has_is_artifact_col:
+                        columns.append("is_artifact")
+                        params.append(is_artifact)
+
                     # Write-time embedding: compute and persist an embedding when
                     # the caller did not supply one and an embedder is configured.
-                    # Guarded so an embedder failure never blocks a write.
+                    # Artifacts embed a clean descriptor (filename + symbols), not
+                    # the noisy, 512-token-truncated raw blob. Guarded so an
+                    # embedder failure never blocks a write.
                     embedding = entry.embedding
                     if (embedding is None and self._embedder is not None
                             and self._has_embedding_col):
                         try:
-                            embedding = self._embedder.embed_value(entry.value)
+                            _, embed_text = embedding_input(entry.key, entry.value)
+                            embedding = self._embedder.embed(embed_text)
                         except Exception:  # noqa: BLE001
                             logger.warning(
                                 "write-time embedding failed for %s/%s; storing without vector",
@@ -913,7 +944,11 @@ class PostgresAdapter(AdapterABC):
                         params,
                     )
 
-        return entry.model_copy(update={"version": new_version, "embedding": embedding})
+        return entry.model_copy(update={
+            "version": new_version,
+            "embedding": embedding,
+            "is_artifact": is_artifact,
+        })
 
     def ensure_embedding_column(self, dim: int | None = None) -> None:
         """Create the pgvector embedding column + HNSW index at a given dimension.
@@ -981,6 +1016,80 @@ class PostgresAdapter(AdapterABC):
                     updated += 1
         return updated
 
+    def backfill_is_artifact(self, *, batch_size: int = 200, reembed: bool = True) -> int:
+        """Classify existing rows and set ``is_artifact``; re-embed newly-flagged
+        artifacts from a clean descriptor.
+
+        This fixes two things on historical data: rows written before the flag
+        existed are classified, and code blobs whose vectors were the noisy,
+        512-token-truncated raw content are re-embedded from a filename+symbols
+        descriptor so they stop spuriously matching generic prose queries.
+
+        Idempotent and resumable: only rows whose flag actually flips are
+        touched (and only those are re-embedded), so re-running is cheap.
+        Returns the number of rows updated.
+
+        TODO(integration-test): exercised against a real DB in
+        tests/integration/test_postgres_embeddings.py (needs AMFS_TEST_PG_DSN).
+        """
+        if not self._has_is_artifact_col:
+            return 0
+        can_embed = reembed and self._embedder is not None and self._has_embedding_col
+        updated = 0
+        last_id = "00000000-0000-0000-0000-000000000000"
+        while True:
+            with self._pool.connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT id, key, value, is_artifact FROM amfs_memory_entries "
+                        "WHERE namespace = %s AND id > %s "
+                        "ORDER BY id LIMIT %s",
+                        (self._namespace, last_id, batch_size),
+                    )
+                    rows = cur.fetchall()
+                    if not rows:
+                        break
+                    for r in rows:
+                        last_id = r["id"]
+                        stored = bool(r["is_artifact"])
+                        try:
+                            value = (
+                                json.loads(r["value"])
+                                if isinstance(r["value"], str)
+                                else r["value"]
+                            )
+                        except (json.JSONDecodeError, ValueError):
+                            value = r["value"]
+                        is_art = classify_artifact(r["key"], value)
+                        if is_art == stored:
+                            continue
+                        if is_art and can_embed:
+                            try:
+                                _, text = embedding_input(r["key"], value)
+                                vec = self._embedder.embed(text)
+                                cur.execute(
+                                    "UPDATE amfs_memory_entries "
+                                    "SET is_artifact = %s, embedding = %s WHERE id = %s",
+                                    (is_art, f"[{','.join(str(v) for v in vec)}]", r["id"]),
+                                )
+                            except Exception:  # noqa: BLE001
+                                logger.warning(
+                                    "backfill re-embed failed for row %s", r["id"],
+                                    exc_info=True,
+                                )
+                                cur.execute(
+                                    "UPDATE amfs_memory_entries "
+                                    "SET is_artifact = %s WHERE id = %s",
+                                    (is_art, r["id"]),
+                                )
+                        else:
+                            cur.execute(
+                                "UPDATE amfs_memory_entries SET is_artifact = %s WHERE id = %s",
+                                (is_art, r["id"]),
+                            )
+                        updated += 1
+        return updated
+
     # ------------------------------------------------------------------
     # list
     # ------------------------------------------------------------------
@@ -1026,6 +1135,7 @@ class PostgresAdapter(AdapterABC):
         (``"recency"``, ``"version"``) are respected as-is.
         """
         use_fts = bool(query.query and getattr(self, "_has_search_tsv", False))
+        col_ready = getattr(self, "_has_is_artifact_col", False)
 
         conditions = ["namespace = %s", "branch = %s", "superseded_at IS NULL"]
         params: list[Any] = [self._namespace, branch]
@@ -1033,6 +1143,10 @@ class PostgresAdapter(AdapterABC):
         if query.depth < 3:
             conditions.append("tier <= %s")
             params.append(query.depth)
+
+        # Exclude artifacts entirely at the SQL layer when the column is ready.
+        if col_ready and not query.include_artifacts:
+            conditions.append("is_artifact IS NOT TRUE")
 
         if query.entity_path is not None:
             conditions.append("entity_path = %s")
@@ -1081,6 +1195,14 @@ class PostgresAdapter(AdapterABC):
             order = order_map.get(query.sort_by, "confidence DESC")
             fetch_limit = query.limit
 
+        # Demote artifacts beneath equally-ranked facts. With the column ready we
+        # do it in SQL (leading sort key); otherwise we over-fetch and demote in
+        # Python below so the pre-backfill window still behaves.
+        if col_ready and not use_priority_sort:
+            order = f"is_artifact ASC, {order}"
+        elif not col_ready:
+            fetch_limit = min(max(fetch_limit, query.limit * 3), 1000)
+
         where = " AND ".join(conditions)
         sql = f"""
             SELECT * FROM amfs_memory_entries
@@ -1097,11 +1219,28 @@ class PostgresAdapter(AdapterABC):
 
         entries = [self._row_to_entry(r) for r in rows]
 
+        def _art(e: MemoryEntry) -> bool:
+            return bool(e.is_artifact) if col_ready else classify_artifact(e.key, e.value)
+
+        # Read-time fallback (column not yet backfilled): exclude or stable-demote
+        # artifacts in Python. Stable so non-artifact ordering is preserved.
+        if not col_ready:
+            if not query.include_artifacts:
+                entries = [e for e in entries if not _art(e)]
+            elif not use_priority_sort:
+                entries.sort(key=_art)
+
         if use_priority_sort:
             from amfs_core.tiering import PriorityScorer
             scorer = PriorityScorer()
             scores = scorer.score_batch(entries)
-            entries.sort(key=lambda e: scores.get(e.entry_key, 0.0), reverse=True)
+            entries.sort(
+                key=lambda e: scores.get(e.entry_key, 0.0)
+                * (ARTIFACT_PENALTY if _art(e) else 1.0),
+                reverse=True,
+            )
+            entries = entries[: query.limit]
+        elif not col_ready:
             entries = entries[: query.limit]
 
         return entries
@@ -2124,6 +2263,7 @@ class PostgresAdapter(AdapterABC):
             memory_type=memory_type,
             shared=row.get("shared", True),
             branch=row.get("branch", "main"),
+            is_artifact=bool(row.get("is_artifact", False)),
         )
 
     # ── Digest storage (Memory Cortex) ──────────────────────────────
@@ -3349,6 +3489,9 @@ class PostgresAdapter(AdapterABC):
                             be.get("shared", True), json.dumps(be.get("artifact_refs") or [], default=str),
                             parent,
                         ]
+                        if self._has_is_artifact_col:
+                            columns.append("is_artifact")
+                            params_list.append(be.get("is_artifact", False))
                         cols_sql = ", ".join(columns)
                         placeholders = ", ".join(["%s"] * len(params_list))
                         cur.execute(
@@ -3887,13 +4030,13 @@ class PostgresAdapter(AdapterABC):
                              agent_id, session_id, tool_context, pattern_refs,
                              written_at, confidence, outcome_count,
                              ttl_at, artifact_refs, memory_type, shared,
-                             branch, embedding)
+                             branch, embedding, is_artifact)
                             VALUES
                             (%s, %s, %s, 1, %s,
                              %s, %s, %s, %s,
                              NOW(), %s, 0,
                              %s, %s, %s, %s,
-                             'main', %s)
+                             'main', %s, %s)
                             ON CONFLICT ON CONSTRAINT uq_entry_version DO NOTHING
                             """,
                             (
@@ -3911,6 +4054,7 @@ class PostgresAdapter(AdapterABC):
                                 row.get("memory_type", "fact"),
                                 row.get("shared", False),
                                 row.get("embedding"),
+                                row.get("is_artifact", False),
                             ),
                         )
                         copied += cur.rowcount

--- a/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
@@ -18,6 +18,7 @@ from typing import Any
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool
 
+from amfs_core.content import classify_artifact
 from amfs_core.exceptions import VersionConflictError
 from amfs_core.models import (
     Agent,
@@ -134,6 +135,7 @@ class AsyncPostgresAdapter:
         self._namespace = namespace
         self._has_embedding_col = False
         self._has_search_tsv = False
+        self._has_is_artifact_col = False
         self._pool = _AsyncTenantRLSPoolWrapper(
             AsyncConnectionPool(
                 dsn,
@@ -162,13 +164,14 @@ class AsyncPostgresAdapter:
                     """
                     SELECT column_name FROM information_schema.columns
                     WHERE table_name = 'amfs_memory_entries'
-                      AND column_name IN ('embedding', 'search_tsv')
+                      AND column_name IN ('embedding', 'search_tsv', 'is_artifact')
                     """,
                 )
                 rows = await cur.fetchall()
                 found = {row["column_name"] for row in rows}
                 self._has_embedding_col = "embedding" in found
                 self._has_search_tsv = "search_tsv" in found
+                self._has_is_artifact_col = "is_artifact" in found
 
     # ── helpers (delegated to sync adapter statics) ─────────────────
 
@@ -293,6 +296,14 @@ class AsyncPostgresAdapter:
 
                     entry_id = uuid.uuid4()
 
+                    # Classify at the persistence chokepoint (the HTTP hot path
+                    # builds entries inline and bypasses CoWEngine). The HTTP
+                    # handler already embeds a descriptor for artifacts before
+                    # calling write; this just guarantees the flag is set.
+                    is_artifact = bool(entry.is_artifact) or classify_artifact(
+                        entry.key, entry.value
+                    )
+
                     columns = [
                         "id", "namespace", "entity_path", "key", "version",
                         "value", "agent_id", "session_id", "written_at",
@@ -322,6 +333,10 @@ class AsyncPostgresAdapter:
                         ),
                         branch,
                     ]
+
+                    if self._has_is_artifact_col:
+                        columns.append("is_artifact")
+                        params.append(is_artifact)
 
                     if self._has_embedding_col and entry.embedding:
                         columns.append("embedding")
@@ -360,7 +375,7 @@ class AsyncPostgresAdapter:
                 entry.entity_path, entry.key, inserted_row["id"],
             )
 
-        return entry.model_copy(update={"version": new_version})
+        return entry.model_copy(update={"version": new_version, "is_artifact": is_artifact})
 
     # ──────────────────────────────────────────────────────────────
     # 3. list
@@ -399,6 +414,7 @@ class AsyncPostgresAdapter:
 
     async def search(self, query: SearchQuery, *, branch: str = "main") -> list[MemoryEntry]:
         use_fts = bool(query.query and self._has_search_tsv)
+        col_ready = self._has_is_artifact_col
 
         conditions = ["namespace = %s", "branch = %s", "superseded_at IS NULL"]
         params: list[Any] = [self._namespace, branch]
@@ -406,6 +422,9 @@ class AsyncPostgresAdapter:
         if query.depth < 3:
             conditions.append("tier <= %s")
             params.append(query.depth)
+
+        if col_ready and not query.include_artifacts:
+            conditions.append("is_artifact IS NOT TRUE")
 
         if query.entity_path is not None:
             conditions.append("entity_path = %s")
@@ -448,6 +467,14 @@ class AsyncPostgresAdapter:
         else:
             order = order_map.get(query.sort_by, "confidence DESC")
 
+        # Demote artifacts beneath equally-ranked facts (leading sort key when
+        # the column is ready; Python fallback below otherwise).
+        fetch_limit = query.limit
+        if col_ready and query.sort_by != "priority":
+            order = f"is_artifact ASC, {order}"
+        elif not col_ready:
+            fetch_limit = min(query.limit * 3, 1000)
+
         where = " AND ".join(conditions)
         sql = f"""
             SELECT * FROM amfs_memory_entries
@@ -455,14 +482,21 @@ class AsyncPostgresAdapter:
             ORDER BY {order}
             LIMIT %s
         """
-        params.append(query.limit)
+        params.append(fetch_limit)
 
         async with self._pool.connection() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(sql, params)
                 rows = await cur.fetchall()
 
-        return [self._row_to_entry(r) for r in rows]
+        entries = [self._row_to_entry(r) for r in rows]
+        if not col_ready:
+            if not query.include_artifacts:
+                entries = [e for e in entries if not classify_artifact(e.key, e.value)]
+            else:
+                entries.sort(key=lambda e: classify_artifact(e.key, e.value))
+            entries = entries[: query.limit]
+        return entries
 
     # ──────────────────────────────────────────────────────────────
     # 4b. semantic_search (pgvector cosine, account-scoped via RLS pool)

--- a/packages/adapters/postgres/src/amfs_postgres/migrations/006_is_artifact.sql
+++ b/packages/adapters/postgres/src/amfs_postgres/migrations/006_is_artifact.sql
@@ -1,0 +1,20 @@
+-- Migration 006: artifact classification flag on memory entries.
+--
+-- Distinguishes stored working files (source code, markup, config) from
+-- knowledge facts so retrieval can demote them. Applied automatically by
+-- PostgresAdapter._apply_migrations() on adapter init; this file is the manual
+-- reference for operators applying schema by hand.
+--
+--     psql "$AMFS_POSTGRES_DSN" -f 006_is_artifact.sql
+--
+-- After applying, populate historical rows (classify + re-embed artifacts):
+--     AMFS_POSTGRES_DSN=... python -c "from amfs_postgres import PostgresAdapter; \
+--         print(PostgresAdapter('$AMFS_POSTGRES_DSN', embedder=<embedder>).backfill_is_artifact())"
+
+ALTER TABLE amfs_memory_entries
+    ADD COLUMN IF NOT EXISTS is_artifact BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Partial index: only artifact rows are indexed, so it stays small while still
+-- supporting fast "exclude/demote artifacts" filters.
+CREATE INDEX IF NOT EXISTS idx_entries_is_artifact
+    ON amfs_memory_entries (is_artifact) WHERE is_artifact;

--- a/packages/core/src/amfs_core/__init__.py
+++ b/packages/core/src/amfs_core/__init__.py
@@ -1,6 +1,14 @@
 """AMFS Core — models, engine, and adapter ABC."""
 
 from amfs_core.abc import AdapterABC, WatchHandle
+from amfs_core.content import (
+    ARTIFACT_PENALTY,
+    artifact_descriptor,
+    classify_artifact,
+    embedding_input,
+    is_artifact_key,
+    is_code_like,
+)
 from amfs_core.embedder import EmbedderABC, cosine_similarity
 from amfs_core.engine import CausalTagger, CoWEngine, ReadTracker
 from amfs_core.exceptions import (
@@ -63,11 +71,17 @@ from amfs_core.quality import (
 )
 
 __all__ = [
+    "ARTIFACT_PENALTY",
     "AMFSConfig",
     "AMFSError",
     "AdapterABC",
     "AdapterError",
     "Agent",
+    "artifact_descriptor",
+    "classify_artifact",
+    "embedding_input",
+    "is_artifact_key",
+    "is_code_like",
     "Branch",
     "BranchAccess",
     "BranchAccessPermission",

--- a/packages/core/src/amfs_core/content.py
+++ b/packages/core/src/amfs_core/content.py
@@ -1,0 +1,162 @@
+"""Content classification for memory entries.
+
+Distinguishes *knowledge* (durable facts, beliefs, experiences written in prose)
+from *artifacts* (stored source code, markup, config, and other working files).
+The two need different treatment in retrieval: an agent that dumps a 10 KB React
+component into memory as a ``fact`` should not have that file outrank a genuine
+preference on a query like "what do I prefer".
+
+This module is the single source of truth for that distinction. It is used to:
+
+* set ``MemoryEntry.is_artifact`` at persistence time (adapter write chokepoint),
+* choose what text to embed (a clean descriptor for artifacts, so the vector
+  represents *what the file is* rather than its noisy, truncated body), and
+* demote artifacts in the retrieve/search/briefing read paths.
+
+The heuristics are intentionally narrow (precision over recall): a genuine
+natural-language fact that happens to contain a word like ``return`` must not be
+misread as code.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+# Ranking prior applied to artifacts in the read paths. A demoted artifact is
+# still returned (multiplicative, not a hard filter), so a genuinely
+# code-relevant query can still surface it via high similarity. Shared by the
+# OSS blend and mirrored by the Pro MultiStrategyRetriever.
+ARTIFACT_PENALTY = 0.5
+
+# Only scan the head of a value: enough to detect code markers cheaply and to
+# build a descriptor, without paying to regex a multi-megabyte blob on every
+# write or every candidate in a read-time fallback.
+_SCAN_LIMIT = 4096
+
+# File extensions that mark an entry key as a stored *artifact* (source code,
+# markup, config, docs) rather than a knowledge-fact identifier. Kept in sync
+# with amfs_security's poisoning detector (which now imports from here).
+_ARTIFACT_EXTENSIONS = {
+    "tsx", "ts", "js", "jsx", "mjs", "cjs", "py", "go", "rs", "java", "rb", "php",
+    "c", "cc", "cpp", "h", "hpp", "cs", "css", "scss", "less", "html", "htm",
+    "vue", "svelte", "json", "yaml", "yml", "toml", "ini", "xml", "md", "mdx",
+    "rst", "sql", "sh", "bash", "zsh", "swift", "kt", "kts", "scala", "dart",
+    "lua", "r", "pl", "proto", "gradle",
+}
+
+# Human-readable language labels for the most common source extensions, used to
+# build the embedding descriptor.
+_LANGUAGE_BY_EXT = {
+    "tsx": "TypeScript React", "ts": "TypeScript", "js": "JavaScript",
+    "jsx": "JavaScript React", "mjs": "JavaScript", "cjs": "JavaScript",
+    "py": "Python", "go": "Go", "rs": "Rust", "java": "Java", "rb": "Ruby",
+    "php": "PHP", "c": "C", "cc": "C++", "cpp": "C++", "h": "C header",
+    "hpp": "C++ header", "cs": "C#", "css": "CSS", "scss": "SCSS",
+    "less": "LESS", "html": "HTML", "htm": "HTML", "vue": "Vue", "svelte": "Svelte",
+    "json": "JSON", "yaml": "YAML", "yml": "YAML", "toml": "TOML", "ini": "INI",
+    "xml": "XML", "md": "Markdown", "mdx": "MDX", "rst": "reStructuredText",
+    "sql": "SQL", "sh": "shell", "bash": "shell", "zsh": "shell", "swift": "Swift",
+    "kt": "Kotlin", "kts": "Kotlin", "scala": "Scala", "dart": "Dart", "lua": "Lua",
+    "r": "R", "pl": "Perl", "proto": "Protobuf", "gradle": "Gradle",
+}
+
+# Strong, code-specific markers. Deliberately narrow so prose is not misread as
+# code. Mirrors amfs_security.detectors.poisoning._CODE_MARKERS.
+_CODE_MARKERS = re.compile(
+    r"(?m)^\s*(?:import\s|from\s+\S+\s+import\b|export\s+(?:default\s+|const\s+|function\b)|"
+    r"def\s+\w+\s*\(|class\s+\w+|function\s+\w*\s*\(|#include\b|package\s+\w|@\w+\s*$)"
+    r"|=>|</[A-Za-z]|/\*|\bconsole\.\w|\brequire\("
+)
+
+# Top-level symbol declarations, used to summarise an artifact in its descriptor.
+_SYMBOL_RE = re.compile(
+    r"(?m)^\s*(?:export\s+)?(?:default\s+)?"
+    r"(?:async\s+)?(?:def|class|function|const|let|var|interface|type|struct|enum|func)\s+"
+    r"([A-Za-z_][A-Za-z0-9_]*)"
+)
+
+
+def _stringify(value: Any) -> str:
+    """Best-effort string form of an arbitrary memory value."""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, default=str)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _basename(key: str) -> str:
+    return key.strip().rsplit("/", 1)[-1]
+
+
+def _extension(key: str) -> str | None:
+    base = _basename(key).lower()
+    if "." not in base:
+        return None
+    return base.rsplit(".", 1)[-1]
+
+
+def is_artifact_key(key: str) -> bool:
+    """True when the entry key looks like a stored file path (e.g.
+    ``src/pages/InsightsPage.tsx``) rather than a knowledge-fact identifier."""
+    ext = _extension(key)
+    return ext is not None and ext in _ARTIFACT_EXTENSIONS
+
+
+def is_code_like(value: Any) -> bool:
+    """True when a value's text looks like source code/markup, not prose."""
+    text = _stringify(value).strip()
+    if len(text) < 24:
+        return False
+    return bool(_CODE_MARKERS.search(text[:_SCAN_LIMIT]))
+
+
+def classify_artifact(key: str, value: Any) -> bool:
+    """An entry is an artifact if its key is a file path or its content is code."""
+    return is_artifact_key(key) or is_code_like(value)
+
+
+def artifact_descriptor(key: str, value: Any) -> str:
+    """A clean, embeddable summary of *what an artifact is*.
+
+    bge-small caps at 512 tokens with no chunking, so embedding a large source
+    file captures only a noisy, prefix-biased slice of it. Instead we embed a
+    short descriptor built from the filename, detected language, and top-level
+    symbol names — signal that actually distinguishes one file from another and
+    keeps code blobs from spuriously matching generic prose queries.
+    """
+    base = _basename(key) or key.strip()
+    ext = _extension(key)
+    language = _LANGUAGE_BY_EXT.get(ext or "", "source")
+
+    text = _stringify(value)[:_SCAN_LIMIT]
+    symbols: list[str] = []
+    seen: set[str] = set()
+    for match in _SYMBOL_RE.finditer(text):
+        name = match.group(1)
+        if name not in seen:
+            seen.add(name)
+            symbols.append(name)
+        if len(symbols) >= 8:
+            break
+
+    parts = [f"{language} file {base}." if base else f"{language} file."]
+    if symbols:
+        parts.append(f"Defines: {', '.join(symbols)}.")
+    return " ".join(parts)
+
+
+def embedding_input(key: str, value: Any) -> tuple[bool, str]:
+    """Return ``(is_artifact, text_to_embed)`` for an entry's key/value.
+
+    Artifacts embed their descriptor; everything else embeds its value text.
+    Every embed site (SDK write, HTTP write handler, adapter fallback, backfill,
+    Pro retriever) routes through this so the classification and the embedded
+    text never diverge.
+    """
+    if classify_artifact(key, value):
+        return True, artifact_descriptor(key, value)
+    return False, _stringify(value)

--- a/packages/core/src/amfs_core/models.py
+++ b/packages/core/src/amfs_core/models.py
@@ -160,6 +160,10 @@ class MemoryEntry(BaseModel):
     embedding: list[float] | None = None
     artifact_refs: list[ArtifactRef] = Field(default_factory=list)
     memory_type: MemoryType = MemoryType.FACT
+    # True when the value is a stored working file (source code, markup, config)
+    # rather than a knowledge claim. Orthogonal to ``memory_type``; used to demote
+    # artifacts in retrieve/search/briefing so they don't crowd out real facts.
+    is_artifact: bool = False
     shared: bool = True
     branch: str = "main"
     content_hash: str | None = None
@@ -403,6 +407,9 @@ class SearchQuery(BaseModel):
     sort_by: str = "confidence"  # "confidence", "recency", "version", "priority"
     recall_config: RecallConfig | None = None
     depth: int = 3
+    # When True (default) artifacts (stored source files) are demoted to the
+    # bottom of results; when False they are excluded entirely.
+    include_artifacts: bool = True
 
 
 class TierConfig(BaseModel):

--- a/packages/cortex/src/amfs_cortex/briefing.py
+++ b/packages/cortex/src/amfs_cortex/briefing.py
@@ -85,6 +85,9 @@ class BriefingService:
                     entity_path=entity_path,
                     sort_by="priority",
                     limit=_HOT_CONTEXT_LIMIT,
+                    # Working files shouldn't dominate the "what you know" context
+                    # an agent reads at task start.
+                    include_artifacts=False,
                 ),
                 branch=branch,
             )
@@ -129,6 +132,9 @@ class BriefingService:
                     entity_path=entity_path,
                     sort_by="priority",
                     limit=_HOT_CONTEXT_LIMIT,
+                    # Working files shouldn't dominate the "what you know" context
+                    # an agent reads at task start.
+                    include_artifacts=False,
                 ),
                 branch=branch,
             )

--- a/packages/cortex/src/amfs_cortex/strategies.py
+++ b/packages/cortex/src/amfs_cortex/strategies.py
@@ -50,6 +50,8 @@ class RuleBasedStrategy:
             entity_path=entity_path,
             limit=1000,
             sort_by="confidence",
+            # Digest narrative/top_keys summarise knowledge, not stored code files.
+            include_artifacts=False,
         ), branch=branch)
         if not entries:
             return None

--- a/packages/http-server/src/amfs_http/models.py
+++ b/packages/http-server/src/amfs_http/models.py
@@ -39,6 +39,9 @@ class SearchRequest(BaseModel):
     sort_by: str = "confidence"
     branch: str = "main"
     depth: int = 3
+    # When True (default) artifacts are demoted to the bottom of results; when
+    # False they are excluded entirely.
+    include_artifacts: bool = True
 
 
 class RetrieveRequest(BaseModel):
@@ -57,6 +60,9 @@ class RetrieveRequest(BaseModel):
     recency_weight: float = 0.3
     confidence_weight: float = 0.2
     branch: str = "main"
+    # When True (default) artifacts (stored source files) are demoted but still
+    # returned; when False they are excluded entirely from results.
+    include_artifacts: bool = True
 
 
 class ContextRequest(BaseModel):

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -572,8 +572,12 @@ async def write_entry(
                         pass
                     _ensure_agent_owner(request, req.agent_id, _agent_ns)
 
+            from amfs_core.content import embedding_input
             from amfs_core.models import Provenance
             provenance = mem._tagger.tag(pattern_refs=req.pattern_refs or None)
+            # Classify here so the flag is set before the inline-built entry hits
+            # the async adapter, and embed a clean descriptor for artifacts.
+            _is_artifact, _embed_text = embedding_input(req.key, req.value)
             entry_obj = MemoryEntry(
                 entity_path=req.entity_path,
                 key=req.key,
@@ -584,6 +588,7 @@ async def write_entry(
                 memory_type=mt,
                 shared=req.shared,
                 branch=req.branch,
+                is_artifact=_is_artifact,
             )
             # Write-time embedding for semantic retrieval. The async adapter
             # persists entry.embedding when the pgvector column exists; without
@@ -593,7 +598,7 @@ async def write_entry(
             if _embedder is not None:
                 try:
                     entry_obj = entry_obj.model_copy(
-                        update={"embedding": _embedder.embed_value(req.value)}
+                        update={"embedding": _embedder.embed(_embed_text)}
                     )
                 except Exception:  # noqa: BLE001 - never fail a write on embedding
                     logger.warning(
@@ -885,6 +890,7 @@ async def search_entries(
         sort_by=req.sort_by,
         limit=req.limit,
         depth=req.depth,
+        include_artifacts=req.include_artifacts,
     )
     mem = _get_memory()
     if _async_adapter is not None:
@@ -961,6 +967,20 @@ async def retrieve_entries(
             allowed = {id(e) for e in vis.filter_entries([e for e, _ in pairs])}
             pairs = [(e, s) for e, s in pairs if id(e) in allowed]
 
+        # Artifact awareness. The is_artifact column is authoritative once
+        # backfilled; before that (older DB) classify on the fly over the small
+        # candidate pool so demotion works immediately.
+        from amfs_core.content import ARTIFACT_PENALTY, classify_artifact
+        col_ready = getattr(_async_adapter, "_has_is_artifact_col", False)
+
+        def _is_artifact(e: MemoryEntry) -> bool:
+            if col_ready:
+                return bool(e.is_artifact)
+            return classify_artifact(e.key, e.value)
+
+        if not req.include_artifacts:
+            pairs = [(e, s) for e, s in pairs if not _is_artifact(e)]
+
         now = _dt.now(_tz.utc)
         half_life = 30.0
         scored: list[tuple[MemoryEntry, float, dict[str, float]]] = []
@@ -979,10 +999,17 @@ async def retrieve_entries(
                 + req.recency_weight * recency
                 + req.confidence_weight * conf
             )
+            artifact = _is_artifact(entry)
+            if artifact:
+                # Multiplicative demotion: a code file no longer outranks a real
+                # fact on a generic query, but a genuinely code-relevant query
+                # (high sim) can still surface it.
+                score *= ARTIFACT_PENALTY
             scored.append((entry, score, {
                 "semantic": round(sim, 4),
                 "recency": round(recency, 4),
                 "confidence": round(conf, 4),
+                "is_artifact": artifact,
             }))
 
         scored.sort(key=lambda t: t[1], reverse=True)
@@ -1002,6 +1029,7 @@ async def retrieve_entries(
         limit=req.limit,
         sort_by="confidence",
         depth=3,
+        include_artifacts=req.include_artifacts,
     )
     mem = _get_memory()
     results: list[MemoryEntry] = []

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -757,6 +757,7 @@ def amfs_search(
     sort_by: str = "confidence",
     limit: int = 20,
     depth: int = 3,
+    include_artifacts: bool = True,
 ) -> str:
     """Search across all memory entries with structured filters or exact keywords.
 
@@ -782,6 +783,8 @@ def amfs_search(
         sort_by: Sort order — "confidence", "recency", "version", or "priority"
         limit: Maximum results to return
         depth: Tier depth (1=hot only, 2=hot+warm, 3=all tiers)
+        include_artifacts: When False, exclude stored source files from results
+            (they are demoted by default)
 
     Example: amfs_search(entity_path="checkout-service", min_confidence=0.5)
     """
@@ -804,6 +807,7 @@ def amfs_search(
         sort_by=sort_by,
         limit=limit,
         depth=depth,
+        include_artifacts=include_artifacts,
     )
 
     if not results:
@@ -834,6 +838,7 @@ def amfs_retrieve(
     recency_weight: float = 0.3,
     confidence_weight: float = 0.2,
     depth: int = 3,
+    include_artifacts: bool = True,
 ) -> str:
     """Find memories by meaning — the default tool for any recall/lookup.
 
@@ -857,6 +862,8 @@ def amfs_retrieve(
         recency_weight: Weight for recency (0.0-1.0)
         confidence_weight: Weight for confidence (0.0-1.0)
         depth: Tier depth (1=hot only, 2=hot+warm, 3=all tiers)
+        include_artifacts: When False, exclude stored source files from results
+            (they are demoted by default so genuine facts rank above code)
 
     Returns ranked results with score breakdowns showing how each
     signal contributed to the final ranking.
@@ -878,6 +885,7 @@ def amfs_retrieve(
         min_confidence=min_confidence,
         limit=limit,
         recall_config=recall_config,
+        include_artifacts=include_artifacts,
     )
 
     serialized = []

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from amfs_core.abc import AdapterABC, WatchHandle
+from amfs_core.content import embedding_input
 from amfs_core.embedder import EmbedderABC
 from amfs_core.engine import CausalTagger, CoWEngine, ReadTracker
 from amfs_core.exceptions import StaleWriteError
@@ -314,9 +315,13 @@ class AgentMemory:
                         current.provenance.agent_id,
                     )
 
+        # Artifacts embed a clean descriptor (filename + symbols) rather than the
+        # raw, 512-token-truncated blob, so code files stop matching generic queries.
+        # The adapter is the authoritative place the is_artifact flag is persisted.
+        _, embed_text = embedding_input(key, value)
         embedding = None
         if self._embedder is not None:
-            embedding = self._embedder.embed_value(value)
+            embedding = self._embedder.embed(embed_text)
 
         importance_score = None
         importance_dimensions = None
@@ -472,6 +477,7 @@ class AgentMemory:
         sort_by: str = "confidence",
         recall_config: RecallConfig | None = None,
         depth: int = 3,
+        include_artifacts: bool = True,
     ) -> list[MemoryEntry] | list[ScoredEntry]:
         """Search across all entities with rich filters.
 
@@ -508,6 +514,7 @@ class AgentMemory:
                 sort_by=sort_by,
                 recall_config=recall_config,
                 depth=depth,
+                include_artifacts=include_artifacts,
             )
             for entry in self._adapter.search(sq):
                 if entry.entry_key not in seen_keys:
@@ -607,6 +614,7 @@ class AgentMemory:
         min_confidence: float = 0.0,
         limit: int = 10,
         recall_config: RecallConfig | None = None,
+        include_artifacts: bool = True,
     ) -> list[ScoredEntry]:
         """Rank memories by meaning for a natural-language query.
 
@@ -614,6 +622,9 @@ class AgentMemory:
         HTTP adapter, where the server owns the embedder + pgvector index), so
         semantic recall works even when this client has no local embedder.
         Otherwise falls back to client-side composite scoring via ``search``.
+
+        Artifacts (stored source files) are demoted by default; pass
+        ``include_artifacts=False`` to exclude them entirely.
         """
         cfg = recall_config or RecallConfig()
 
@@ -628,6 +639,7 @@ class AgentMemory:
                     semantic_weight=cfg.semantic_weight,
                     recency_weight=cfg.recency_weight,
                     confidence_weight=cfg.confidence_weight,
+                    include_artifacts=include_artifacts,
                 )
                 return [
                     ScoredEntry(entry=entry, score=score, breakdown=breakdown or {})
@@ -642,6 +654,7 @@ class AgentMemory:
             min_confidence=min_confidence,
             limit=limit,
             recall_config=cfg,
+            include_artifacts=include_artifacts,
         )
         return result  # type: ignore[return-value]
 

--- a/tests/unit/test_content_classification.py
+++ b/tests/unit/test_content_classification.py
@@ -1,0 +1,115 @@
+"""Unit tests for amfs_core.content — artifact classification, descriptors, embedding routing."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from amfs_core.content import (
+    ARTIFACT_PENALTY,
+    artifact_descriptor,
+    classify_artifact,
+    embedding_input,
+    is_artifact_key,
+    is_code_like,
+)
+from amfs_core.models import MemoryEntry, Provenance, SearchQuery
+
+
+class TestIsArtifactKey:
+    def test_source_file_paths_are_artifacts(self):
+        assert is_artifact_key("src/pages/InsightsPage.tsx")
+        assert is_artifact_key("packages/core/engine.py")
+        assert is_artifact_key("styles/app.css")
+        assert is_artifact_key("config.yaml")
+
+    def test_knowledge_keys_are_not_artifacts(self):
+        assert not is_artifact_key("food-preference-pizza")
+        assert not is_artifact_key("user/preferences/favorite-color")
+        assert not is_artifact_key("decision-use-jwt")
+        # A dotted key that isn't a known code extension stays a fact.
+        assert not is_artifact_key("release-v1.2")
+
+    def test_extension_case_insensitive(self):
+        assert is_artifact_key("Component.TSX")
+
+
+class TestIsCodeLike:
+    def test_detects_code_content(self):
+        assert is_code_like("import React from 'react';\nexport const App = () => null;")
+        assert is_code_like("def compute(x):\n    return x * 2\n")
+        assert is_code_like("class FooBarBaz:\n    def __init__(self):\n        self.x = 1\n")
+
+    def test_prose_is_not_code(self):
+        assert not is_code_like("The user prefers pizza with extra cheese on Fridays.")
+        assert not is_code_like("We decided to use JWT because sessions did not scale.")
+
+    def test_short_strings_are_not_code(self):
+        # Below the min-length guard; avoids misreading a terse fact as code.
+        assert not is_code_like("return home")
+
+
+class TestClassifyArtifact:
+    def test_key_or_content_triggers(self):
+        # Key alone.
+        assert classify_artifact("a/b/x.py", "just some prose value here for length")
+        # Content alone (non-code key).
+        assert classify_artifact("notes", "export default function App() { return null }")
+        # Neither.
+        assert not classify_artifact("food-pref", "I like pizza and pasta on weekends.")
+
+    def test_non_string_values(self):
+        assert not classify_artifact("prefs", {"food": "pizza", "drink": "water"})
+
+
+class TestArtifactDescriptor:
+    def test_includes_language_filename_and_symbols(self):
+        code = (
+            "import React from 'react'\n"
+            "export const InsightsPage = () => <div/>\n"
+            "function helper() { return 1 }\n"
+        )
+        desc = artifact_descriptor("src/pages/InsightsPage.tsx", code)
+        assert "TypeScript React" in desc
+        assert "InsightsPage.tsx" in desc
+        assert "InsightsPage" in desc
+        # Descriptor is compact, not the whole blob.
+        assert len(desc) < len(code) + 200
+
+    def test_python_symbols(self):
+        code = "def alpha():\n    pass\n\nclass Beta:\n    pass\n"
+        desc = artifact_descriptor("mod/thing.py", code)
+        assert "Python" in desc
+        assert "alpha" in desc and "Beta" in desc
+
+
+class TestEmbeddingInput:
+    def test_artifact_returns_descriptor(self):
+        is_art, text = embedding_input("src/x.ts", "export const y = 1\n" * 5)
+        assert is_art is True
+        assert "TypeScript" in text
+        # Not the raw blob.
+        assert "export const y" not in text
+
+    def test_fact_returns_value_text(self):
+        is_art, text = embedding_input("food-pref", "I love pizza")
+        assert is_art is False
+        assert text == "I love pizza"
+
+    def test_penalty_in_range(self):
+        assert 0.0 < ARTIFACT_PENALTY < 1.0
+
+
+class TestModelField:
+    def test_memory_entry_defaults_not_artifact(self):
+        e = MemoryEntry(
+            entity_path="svc/a", key="k", value="v",
+            provenance=Provenance(
+                agent_id="a", session_id="s",
+                written_at=datetime.now(timezone.utc),
+            ),
+        )
+        assert e.is_artifact is False
+
+    def test_search_query_include_artifacts_default(self):
+        assert SearchQuery().include_artifacts is True
+        assert SearchQuery(include_artifacts=False).include_artifacts is False


### PR DESCRIPTION
## Summary

Stored source files (written as `memory_type: "fact"` at ~0.95 confidence) were competing with genuine knowledge on generic queries (e.g. "what do I prefer" surfacing React/CSS files right behind a real preference). Two root causes: the ranking blend had no notion of a *code artifact*, and large files were embedded from a noisy, 512-token-truncated prefix of the raw blob.

This makes retrieval artifact-aware end to end:

- **Classifier (single source of truth):** new `amfs_core.content` with `classify_artifact` / `artifact_descriptor` / `embedding_input` and `ARTIFACT_PENALTY`; adds `MemoryEntry.is_artifact`.
- **Write chokepoint:** classify + persist `is_artifact` in `PostgresAdapter.write` (sync) and `AsyncPostgresAdapter.write`, plus the SDK and HTTP write sites. Artifacts embed a clean `filename + language + symbols` descriptor instead of the raw blob.
- **Schema:** `is_artifact` column + partial index applied inline via `_apply_migrations()` (with a reference `006_is_artifact.sql`), row mapping, and INSERT plumbing for the outcome trigger, branch-merge, and copy-agent paths. `backfill_is_artifact()` classifies and re-embeds historical rows (idempotent, resumable).
- **Read paths:** `/api/v1/retrieve` demotes artifacts multiplicatively (still returned, so a genuinely code-relevant query can resurface them) with a read-time classify fallback for pre-backfill rows; `/api/v1/search` demotes (or excludes); the Cortex briefing excludes artifacts from hot context and digest compilation.
- **API surface:** `include_artifacts` (default `true` = demote; `false` = exclude) threaded through `SearchQuery`, `RetrieveRequest`, `HttpAdapter`, `AgentMemory`, and the `amfs_retrieve` / `amfs_search` MCP tools.
