### PR TITLE
feat(aggregates): expose total_recalls per topic

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -1726,7 +1726,8 @@ class PostgresAdapter(AdapterABC):
                    MAX(written_at) AS last_updated,
                    (ARRAY_AGG(agent_id ORDER BY written_at DESC))[1] AS last_agent,
                    ARRAY_AGG(DISTINCT agent_id) AS agents,
-                   COUNT(*) FILTER (WHERE content_hash IS NOT NULL) AS hashed_count
+                   COUNT(*) FILTER (WHERE content_hash IS NOT NULL) AS hashed_count,
+                   COALESCE(SUM(recall_count), 0) AS total_recalls
             FROM amfs_memory_entries
             WHERE {where}
             GROUP BY entity_path
@@ -1746,6 +1747,7 @@ class PostgresAdapter(AdapterABC):
                 "last_agent": r["last_agent"],
                 "agents": sorted(r["agents"] or []),
                 "hashed_count": r["hashed_count"],
+                "total_recalls": int(r["total_recalls"] or 0),
             }
             for r in rows
         ]

--- a/packages/core/src/amfs_core/abc.py
+++ b/packages/core/src/amfs_core/abc.py
@@ -274,7 +274,7 @@ class AdapterABC(ABC):
 
         Returns a list of dicts sorted by most recently updated:
         ``{entity_path, entry_count, avg_confidence, last_updated,
-        last_agent, agents, hashed_count}``.
+        last_agent, agents, hashed_count, total_recalls}``.
 
         *agent_ids*, when given, restricts aggregation to entries written by
         those agents (used by per-user visibility layers).

--- a/packages/core/src/amfs_core/aggregates.py
+++ b/packages/core/src/amfs_core/aggregates.py
@@ -35,6 +35,7 @@ def entity_summaries_from_entries(entries: "list[MemoryEntry]") -> list[dict]:
                 "last_agent": group_sorted[0].provenance.agent_id,
                 "agents": sorted({e.provenance.agent_id for e in group}),
                 "hashed_count": sum(1 for e in group if e.content_hash),
+                "total_recalls": sum(e.recall_count for e in group),
             }
         )
     summaries.sort(key=lambda s: s["last_updated"], reverse=True)

--- a/tests/unit/test_aggregate_endpoints.py
+++ b/tests/unit/test_aggregate_endpoints.py
@@ -109,6 +109,16 @@ class TestEntitySummaries:
     def test_empty(self) -> None:
         assert entity_summaries_from_entries([]) == []
 
+    def test_sums_recall_counts_per_entity(self) -> None:
+        entries = [
+            _entry("repo/a", "k1", "agent-a", recall_count=5, written_at=NOW),
+            _entry("repo/a", "k2", "agent-b", recall_count=2, written_at=NOW),
+            _entry("repo/b", "k1", "agent-a", recall_count=9, written_at=NOW),
+        ]
+        by_path = {s["entity_path"]: s for s in entity_summaries_from_entries(entries)}
+        assert by_path["repo/a"]["total_recalls"] == 7
+        assert by_path["repo/b"]["total_recalls"] == 9
+
 
 class TestExtendedStats:
     def test_counts_recalls_and_weekly_delta(self) -> None:


### PR DESCRIPTION
## Summary
- Adds `total_recalls` (SUM of `recall_count`) to `entity_summaries()` in the Postgres GROUP BY query and the in-memory `entity_summaries_from_entries()` fallback, plus the `AdapterABC` docstring.
- Lets the dashboard show reuse -> tokens-saved per topic without downloading entry values.