### PR TITLE
feat(retrieve): hybrid semantic∪lexical recall + temporal + abstain + injectable rerank

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/_fts.py
+++ b/packages/adapters/postgres/src/amfs_postgres/_fts.py
@@ -1,0 +1,41 @@
+"""Full-text query helpers shared by the sync and async Postgres adapters."""
+from __future__ import annotations
+
+import re
+
+# Word tokens only: drop punctuation/underscores so each term is safe to feed
+# to plainto_tsquery individually.
+_WORD_RE = re.compile(r"[^\W_]+", re.UNICODE)
+
+# Bound the number of OR terms so a pathologically long query can't explode the
+# SQL / param list. 20 covers any realistic natural-language recall query.
+_MAX_TERMS = 20
+
+
+def or_tsquery(query: str) -> tuple[str, list[str]]:
+    """Build an OR-combined tsquery expression + its bound params.
+
+    ``plainto_tsquery`` and ``websearch_to_tsquery`` both combine adjacent
+    unquoted words with AND (``&``), so a noisy multi-term query such as
+    ``"browser plugin extension delivered yesterday"`` only matches documents
+    that contain *every* term — keyword recall silently collapses to zero when
+    any single term is absent (this is why ``amfs_search`` returned empty).
+
+    We instead OR each term's ``plainto_tsquery`` via the tsquery ``||``
+    operator so a document matching ANY term becomes a candidate. ``ts_rank``
+    evaluated over the same expression still ranks documents that match more
+    (and rarer) terms higher, so precision is preserved at the top of the list
+    while recall no longer depends on an exact full-term match.
+
+    Returns ``(sql_expr, params)`` where ``sql_expr`` contains ``%s``
+    placeholders and ``params`` are the per-term strings, in order. Single-term
+    or empty input falls back to a plain ``plainto_tsquery`` (identical to the
+    previous behaviour). The caller extends its param list with ``params`` once
+    per occurrence of ``sql_expr`` in the final statement (e.g. WHERE + ORDER).
+    """
+    # Preserve order, drop duplicates, cap length.
+    terms = list(dict.fromkeys(_WORD_RE.findall(query or "")))[:_MAX_TERMS]
+    if len(terms) <= 1:
+        return "plainto_tsquery('english', %s)", [query or ""]
+    expr = "(" + " || ".join(["plainto_tsquery('english', %s)"] * len(terms)) + ")"
+    return expr, terms

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -14,6 +14,7 @@ from typing import Any, Callable
 import psycopg
 from psycopg.rows import dict_row
 
+from amfs_postgres._fts import or_tsquery
 from amfs_core.abc import AdapterABC, WatchHandle
 from amfs_core.content import ARTIFACT_PENALTY, classify_artifact, embedding_input
 from amfs_core.embedder import EmbedderABC
@@ -1129,13 +1130,16 @@ class PostgresAdapter(AdapterABC):
         """Search using PostgreSQL full-text search when a text query is available.
 
         When ``SearchQuery.query`` is set and the ``search_tsv`` column exists
-        the adapter adds a ``search_tsv @@ plainto_tsquery(...)`` filter and,
-        when ``sort_by`` is the default ``"confidence"``, orders by ts_rank so
-        keyword relevance is factored in.  Explicit ``sort_by`` values
-        (``"recency"``, ``"version"``) are respected as-is.
+        the adapter adds an OR-combined tsquery filter (see ``_fts.or_tsquery``)
+        so multi-term queries recall documents matching ANY term instead of
+        requiring every term, and — when ``sort_by`` is the default
+        ``"confidence"`` — orders by ts_rank so keyword relevance is factored
+        in.  Explicit ``sort_by`` values (``"recency"``, ``"version"``) are
+        respected as-is.
         """
         use_fts = bool(query.query and getattr(self, "_has_search_tsv", False))
         col_ready = getattr(self, "_has_is_artifact_col", False)
+        tsq_sql, tsq_params = or_tsquery(query.query) if use_fts else ("", [])
 
         conditions = ["namespace = %s", "branch = %s", "superseded_at IS NULL"]
         params: list[Any] = [self._namespace, branch]
@@ -1168,8 +1172,8 @@ class PostgresAdapter(AdapterABC):
             params.append(query.pattern_ref)
 
         if use_fts:
-            conditions.append("search_tsv @@ plainto_tsquery('english', %s)")
-            params.append(query.query)
+            conditions.append(f"search_tsv @@ {tsq_sql}")
+            params.extend(tsq_params)
         elif query.query and query.recall_config is None:
             conditions.append(
                 "(key ILIKE %s OR entity_path ILIKE %s OR value::text ILIKE %s)"
@@ -1188,8 +1192,8 @@ class PostgresAdapter(AdapterABC):
             order = "confidence DESC"
             fetch_limit = min(query.limit * 3, 1000)
         elif use_fts and query.sort_by == "confidence":
-            order = "ts_rank(search_tsv, plainto_tsquery('english', %s)) DESC, confidence DESC"
-            params.append(query.query)
+            order = f"ts_rank(search_tsv, {tsq_sql}) DESC, confidence DESC"
+            params.extend(tsq_params)
             fetch_limit = query.limit
         else:
             order = order_map.get(query.sort_by, "confidence DESC")

--- a/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
@@ -18,6 +18,7 @@ from typing import Any
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool
 
+from amfs_postgres._fts import or_tsquery
 from amfs_core.content import classify_artifact
 from amfs_core.exceptions import VersionConflictError
 from amfs_core.models import (
@@ -415,6 +416,7 @@ class AsyncPostgresAdapter:
     async def search(self, query: SearchQuery, *, branch: str = "main") -> list[MemoryEntry]:
         use_fts = bool(query.query and self._has_search_tsv)
         col_ready = self._has_is_artifact_col
+        tsq_sql, tsq_params = or_tsquery(query.query) if use_fts else ("", [])
 
         conditions = ["namespace = %s", "branch = %s", "superseded_at IS NULL"]
         params: list[Any] = [self._namespace, branch]
@@ -446,8 +448,8 @@ class AsyncPostgresAdapter:
             params.append(query.pattern_ref)
 
         if use_fts:
-            conditions.append("search_tsv @@ plainto_tsquery('english', %s)")
-            params.append(query.query)
+            conditions.append(f"search_tsv @@ {tsq_sql}")
+            params.extend(tsq_params)
         elif query.query and query.recall_config is None:
             conditions.append(
                 "(key ILIKE %s OR entity_path ILIKE %s OR value::text ILIKE %s)"
@@ -462,8 +464,8 @@ class AsyncPostgresAdapter:
         }
 
         if use_fts and query.sort_by == "confidence":
-            order = "ts_rank(search_tsv, plainto_tsquery('english', %s)) DESC, confidence DESC"
-            params.append(query.query)
+            order = f"ts_rank(search_tsv, {tsq_sql}) DESC, confidence DESC"
+            params.extend(tsq_params)
         else:
             order = order_map.get(query.sort_by, "confidence DESC")
 

--- a/packages/core/src/amfs_core/query_norm.py
+++ b/packages/core/src/amfs_core/query_norm.py
@@ -1,0 +1,122 @@
+"""Temporal query normalization for retrieval.
+
+Natural-language recall queries frequently carry temporal intent ("what did we
+ship *yesterday*", "the plugin delivered *last week*"). Left in the query text,
+those words are embedded as topical noise — they drift the query vector away
+from the actual subject and never become the recency signal the user meant.
+
+``normalize_temporal`` splits that intent out: it returns the topical remainder
+(safe to embed / feed to full-text search) plus a recency signal the caller can
+turn into a stronger recency weight and/or a ``written_after`` lower bound.
+
+Pure/deterministic and dependency-free so it is trivially unit-testable and can
+be shared by the OSS ``/api/v1/retrieve`` path and the Pro retriever.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+
+@dataclass(frozen=True)
+class TemporalNorm:
+    """Result of stripping temporal intent from a query.
+
+    - ``topical``: query text with temporal phrases removed (falls back to the
+      original text when stripping would leave it empty, e.g. query was only
+      "yesterday").
+    - ``matched``: whether any temporal expression was found.
+    - ``written_after``: optional lower bound on ``written_at`` implied by the
+      phrase (timezone-aware UTC). Callers should treat this as a soft signal.
+    - ``recency_weight_boost``: multiplier the caller can apply to its recency
+      weight (1.0 = no change). Only > 1.0 when a temporal phrase matched.
+    """
+
+    topical: str
+    matched: bool
+    written_after: datetime | None
+    recency_weight_boost: float
+
+
+# Ordered longest/most-specific first so "last week" wins over "week", etc.
+# Each entry maps a regex to the number of days back the window should cover.
+_PHRASES: list[tuple[re.Pattern[str], float]] = [
+    (re.compile(r"\bjust now\b", re.I), 1),
+    (re.compile(r"\bearlier today\b", re.I), 1),
+    (re.compile(r"\bthis morning\b", re.I), 1),
+    (re.compile(r"\bthis afternoon\b", re.I), 1),
+    (re.compile(r"\btonight\b", re.I), 1),
+    (re.compile(r"\btoday\b", re.I), 1),
+    (re.compile(r"\byesterday\b", re.I), 2),
+    (re.compile(r"\bthe day before yesterday\b", re.I), 3),
+    (re.compile(r"\blast week\b", re.I), 14),
+    (re.compile(r"\bthis week\b", re.I), 7),
+    (re.compile(r"\bpast week\b", re.I), 7),
+    (re.compile(r"\blast month\b", re.I), 60),
+    (re.compile(r"\bthis month\b", re.I), 30),
+    (re.compile(r"\bpast month\b", re.I), 30),
+    (re.compile(r"\b(?:lately|recently|recent|latest|newest)\b", re.I), 7),
+]
+
+# Numeric phrases: "3 days ago", "past 2 weeks", "last 5 months".
+_NUMERIC = re.compile(
+    r"\b(?:in the )?(?:past|last)?\s*(\d{1,3})\s*(day|days|week|weeks|month|months)\s*(?:ago)?\b",
+    re.I,
+)
+_UNIT_DAYS = {"day": 1, "days": 1, "week": 7, "weeks": 7, "month": 30, "months": 30}
+
+
+def normalize_temporal(query: str, *, now: datetime | None = None) -> TemporalNorm:
+    """Extract temporal intent from ``query``.
+
+    ``now`` is injectable for deterministic tests; defaults to current UTC.
+    """
+    if not query or not query.strip():
+        return TemporalNorm(topical=query or "", matched=False, written_after=None, recency_weight_boost=1.0)
+
+    now = now or datetime.now(timezone.utc)
+    remaining = query
+    max_days: float | None = None
+
+    # Numeric phrases first (most specific), then keyword phrases.
+    def _consume_numeric(m: re.Match[str]) -> str:
+        nonlocal max_days
+        n = int(m.group(1))
+        days = n * _UNIT_DAYS[m.group(2).lower()]
+        # +1 day buffer so an entry written "3 days ago" isn't excluded by a
+        # sub-day boundary difference.
+        days += 1
+        max_days = days if max_days is None else max(max_days, days)
+        return " "
+
+    remaining = _NUMERIC.sub(_consume_numeric, remaining)
+
+    for pattern, days in _PHRASES:
+        if pattern.search(remaining):
+            max_days = float(days) if max_days is None else max(max_days, float(days))
+            remaining = pattern.sub(" ", remaining)
+
+    matched = max_days is not None
+
+    # Clean up leftover connective words / whitespace left by stripping.
+    topical = re.sub(r"\s+", " ", remaining).strip()
+    topical = re.sub(r"^(?:the|from|in|on|since|of|for|about)\s+", "", topical, flags=re.I).strip()
+    topical = re.sub(r"\s+(?:the|from|in|on|since|of|for|about)$", "", topical, flags=re.I).strip()
+    if not topical:
+        # Query was purely temporal — keep original so we never embed "".
+        topical = query.strip()
+
+    if not matched:
+        return TemporalNorm(topical=topical, matched=False, written_after=None, recency_weight_boost=1.0)
+
+    written_after = now - timedelta(days=float(max_days))
+    # Tighter windows (more explicit recency intent) get a bigger recency boost,
+    # capped so recency never fully dominates semantic relevance.
+    boost = 2.0 if max_days <= 14 else 1.5
+    return TemporalNorm(
+        topical=topical,
+        matched=True,
+        written_after=written_after,
+        recency_weight_boost=boost,
+    )

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -19,6 +19,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import secrets
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
@@ -189,6 +190,67 @@ def _get_server_embedder():
             logger.info("AMFS_ENABLE_EMBEDDINGS is off — semantic retrieval disabled")
     return _server_embedder
 
+
+# ── Injectable retrieval enhancers (Pro layer) ─────────────────────────
+# The Pro layer registers a cross-encoder reranker and/or an LLM query
+# rewriter into the SINGLE /api/v1/retrieve path (see set_retrieval_enhancers,
+# called from mount_pro_api). Keeping ranking here — rather than in a separate
+# Pro endpoint — means account (RLS) + per-user/room (UserVisibilityFilter)
+# isolation is enforced in exactly one place and can never drift. Both are
+# no-ops when unset, so a pure-OSS deployment is unchanged.
+_retrieval_reranker: Any = None
+_retrieval_query_rewriter: Any = None
+
+
+def set_retrieval_enhancers(reranker: Any = None, query_rewriter: Any = None) -> None:
+    """Register optional retrieval enhancers used by /api/v1/retrieve.
+
+    - ``reranker``: object with ``available: bool`` and
+      ``rerank(query, docs) -> list[float]`` (e.g. amfs_retrieval.CrossEncoderReranker).
+    - ``query_rewriter``: object with ``expand(query) -> list[str]``
+      (e.g. amfs_retrieval.LLMQueryRewriter). Should return ``[query]`` when
+      disabled.
+    """
+    global _retrieval_reranker, _retrieval_query_rewriter
+    if reranker is not None:
+        _retrieval_reranker = reranker
+    if query_rewriter is not None:
+        _retrieval_query_rewriter = query_rewriter
+
+
+# Benchmark/system scratch namespaces must never outrank a user's real memory
+# in recall (the incident that motivated this had bench rows crowding out real
+# task summaries). Matched against the leading segment of entity_path.
+_EXCLUDED_ENTITY_RE = re.compile(r"^(?:_system(?:/|$)|_?bench[-/])", re.I)
+
+
+def _is_excluded_entity(entity_path: str) -> bool:
+    return bool(entity_path) and bool(_EXCLUDED_ENTITY_RE.match(entity_path))
+
+
+def _retrieve_min_semantic() -> float:
+    """Abstain floor: results whose semantic similarity is below this AND that
+    have no keyword match are trimmed as clearly-irrelevant tail (the top
+    result is always kept). Env-tunable; conservative default."""
+    try:
+        return float(os.environ.get("AMFS_RETRIEVE_MIN_SEMANTIC", "0.15"))
+    except ValueError:
+        return 0.15
+
+
+def _doc_text_for_rerank(entry: MemoryEntry) -> str:
+    """Compact document text for the cross-encoder: key + stringified value,
+    bounded so a huge value can't blow up the reranker input."""
+    val = entry.value
+    if not isinstance(val, str):
+        try:
+            val = json.dumps(val, default=str)
+        except Exception:  # noqa: BLE001
+            val = str(val)
+    text = f"{entry.key}: {val}"
+    return text[:2000]
+
+
 _immutable_trace_store = None
 try:
     from amfs_traces.api import mount_pro_routes
@@ -286,6 +348,33 @@ try:
     logger.info("Pro API endpoints mounted (intelligence, extraction)")
 except ImportError:
     pass
+
+# Optional retrieval enhancers (proprietary amfs_retrieval, same optional-import
+# pattern as the pro blocks above). When the package is present — as in the
+# hosted amfs-pro image that serves /api/v1/retrieve — inject a cross-encoder
+# reranker + query rewriter into the SINGLE retrieve path so ranking improves
+# without a second endpoint (isolation stays enforced in one place). Absent in
+# pure-OSS installs, where retrieve stays hybrid-but-unreranked.
+try:
+    from amfs_retrieval import CrossEncoderReranker, LLMQueryRewriter
+
+    _rerank_on = os.environ.get("AMFS_RERANK", "true").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+    # ms-marco-MiniLM-L-6-v2: 0.08GB, apache-2.0 (commercial-safe). The
+    # fastembed default (jina v2) is cc-by-nc-4.0 and 1.1GB — unsuitable for a
+    # commercial SaaS image. Overridable via AMFS_RERANK_MODEL.
+    _rerank_model = os.environ.get("AMFS_RERANK_MODEL", "Xenova/ms-marco-MiniLM-L-6-v2")
+    _reranker = CrossEncoderReranker(model_name=_rerank_model) if _rerank_on else None
+    set_retrieval_enhancers(reranker=_reranker, query_rewriter=LLMQueryRewriter())
+    logger.info(
+        "Retrieval enhancers registered (rerank=%s model=%s, query_rewrite=%s)",
+        _rerank_on, _rerank_model, os.environ.get("AMFS_QUERY_REWRITE", "false"),
+    )
+except ImportError:
+    logger.debug("amfs_retrieval not installed — /retrieve stays hybrid without rerank")
+except Exception:  # noqa: BLE001 - never block startup on enhancers
+    logger.warning("Retrieval enhancer registration failed", exc_info=True)
 
 try:
     from amfs_rooms import mount_rooms
@@ -939,118 +1028,210 @@ async def retrieve_entries(
     Account isolation comes from the RLS-scoped async adapter; user/room
     visibility is then enforced by UserVisibilityFilter (same as /search).
 
-    Degrades gracefully to lexical search when the embedder or pgvector column
-    is unavailable, so this endpoint never returns worse than /search.
+    Hybrid by construction: candidates are the UNION of pgvector semantic
+    neighbours and OR-tsquery lexical matches (not a zero-hit-only fallback),
+    so a paraphrase match and an exact-term match both surface. Temporal intent
+    ("yesterday", "last week") is parsed out of the query into a recency signal
+    instead of polluting the embedded text. Account isolation (RLS) + per-user/
+    room visibility (UserVisibilityFilter) are applied ONCE over the merged set.
+    A Pro-injected cross-encoder reranker and query rewriter refine the top
+    candidates when present. Degrades gracefully to lexical-only when the
+    embedder or pgvector column is unavailable.
     """
     from datetime import datetime as _dt, timezone as _tz
+
+    from amfs_core.content import ARTIFACT_PENALTY, classify_artifact
+    from amfs_core.query_norm import normalize_temporal
 
     branch = req.branch or "main"
     vis = _get_visibility_filter(request)
     embedder = _get_server_embedder()
 
-    pairs: list[tuple[MemoryEntry, float]] = []
-    if embedder is not None and _async_adapter is not None:
-        # Over-fetch a candidate pool so the recency/confidence blend has
-        # headroom beyond pure similarity, then trim to `limit` after scoring.
-        pool = max(req.limit * 5, 50)
-        sq = SemanticQuery(
-            text=req.query,
-            entity_path=req.entity_path,
-            min_confidence=req.min_confidence,
-            limit=pool,
-        )
+    # 1. Split temporal intent out of the query so it becomes a recency signal
+    #    rather than embedded/lexical noise.
+    tnorm = normalize_temporal(req.query)
+    topical = tnorm.topical
+    recency_weight = req.recency_weight * tnorm.recency_weight_boost
+
+    # 2. Query variants: the Pro-injected rewriter adds paraphrases/HyDE; in OSS
+    #    this is just the topical query.
+    queries: list[str] = [topical]
+    rewriter = _retrieval_query_rewriter
+    if rewriter is not None:
         try:
-            pairs = await _async_adapter.semantic_search(sq, embedder, branch=branch)
-        except Exception:
-            logger.warning("semantic_search failed — falling back to lexical", exc_info=True)
-            pairs = []
+            for q in rewriter.expand(topical):
+                if q and q not in queries:
+                    queries.append(q)
+        except Exception:  # noqa: BLE001 - rewrite is best-effort
+            logger.debug("query rewrite failed", exc_info=True)
 
-    if pairs:
-        if vis is not None and vis.should_filter():
-            allowed = {id(e) for e in vis.filter_entries([e for e, _ in pairs])}
-            pairs = [(e, s) for e, s in pairs if id(e) in allowed]
+    # Over-fetch a wide candidate pool so the blend + visibility filtering have
+    # headroom before trimming to `limit`.
+    pool = max(req.limit * 10, 150)
 
-        # Artifact awareness. The is_artifact column is authoritative once
-        # backfilled; before that (older DB) classify on the fly over the small
-        # candidate pool so demotion works immediately.
-        from amfs_core.content import ARTIFACT_PENALTY, classify_artifact
-        col_ready = getattr(_async_adapter, "_has_is_artifact_col", False)
+    # entry_key -> {"entry", "sim", "keyword"}
+    candidates: dict[str, dict[str, Any]] = {}
 
-        def _is_artifact(e: MemoryEntry) -> bool:
-            if col_ready:
-                return bool(e.is_artifact)
-            return classify_artifact(e.key, e.value)
-
-        if not req.include_artifacts:
-            pairs = [(e, s) for e, s in pairs if not _is_artifact(e)]
-
-        now = _dt.now(_tz.utc)
-        half_life = 30.0
-        scored: list[tuple[MemoryEntry, float, dict[str, float]]] = []
-        for entry, sim in pairs:
-            written = getattr(entry.provenance, "written_at", None)
-            if written is not None:
-                if written.tzinfo is None:
-                    written = written.replace(tzinfo=_tz.utc)
-                age_days = max(0.0, (now - written).total_seconds() / 86400.0)
-                recency = 0.5 ** (age_days / half_life)
-            else:
-                recency = 0.0
-            conf = float(entry.confidence)
-            score = (
-                req.semantic_weight * sim
-                + req.recency_weight * recency
-                + req.confidence_weight * conf
+    # 3a. Semantic channel (per query variant), keep best similarity per entry.
+    if embedder is not None and _async_adapter is not None:
+        for qtext in queries:
+            sq = SemanticQuery(
+                text=qtext,
+                entity_path=req.entity_path,
+                min_confidence=req.min_confidence,
+                limit=pool,
             )
-            artifact = _is_artifact(entry)
-            if artifact:
-                # Multiplicative demotion: a code file no longer outranks a real
-                # fact on a generic query, but a genuinely code-relevant query
-                # (high sim) can still surface it.
-                score *= ARTIFACT_PENALTY
-            scored.append((entry, score, {
-                "semantic": round(sim, 4),
-                "recency": round(recency, 4),
-                "confidence": round(conf, 4),
-                "is_artifact": artifact,
-            }))
+            try:
+                pairs = await _async_adapter.semantic_search(sq, embedder, branch=branch)
+            except Exception:
+                logger.warning("semantic_search failed — continuing with lexical", exc_info=True)
+                pairs = []
+            for entry, sim in pairs:
+                slot = candidates.get(entry.entry_key)
+                if slot is None:
+                    candidates[entry.entry_key] = {"entry": entry, "sim": sim, "keyword": 0.0}
+                elif sim > slot["sim"]:
+                    slot["sim"] = sim
 
-        scored.sort(key=lambda t: t[1], reverse=True)
-        out: list[dict[str, Any]] = []
-        for entry, score, breakdown in scored[: req.limit]:
-            data = _entry_to_response(entry)
-            data["_score"] = round(score, 4)
-            data["_breakdown"] = breakdown
-            out.append(data)
-        return out
-
-    # ── Lexical fallback (embedder/pgvector unavailable, or no vector hits) ──
+    # 3b. Lexical channel (first-class, always run — OR-tsquery recall).
     sq_lex = SearchQuery(
-        query=req.query,
+        query=topical,
         entity_path=req.entity_path,
         min_confidence=req.min_confidence,
-        limit=req.limit,
+        limit=pool,
         sort_by="confidence",
         depth=3,
         include_artifacts=req.include_artifacts,
     )
-    mem = _get_memory()
-    results: list[MemoryEntry] = []
+    lex_entries: list[MemoryEntry] = []
     if _async_adapter is not None:
         try:
-            results = await _async_adapter.search(sq_lex, branch=branch)
+            lex_entries = await _async_adapter.search(sq_lex, branch=branch)
         except Exception:
-            results = []
-    if not results:
+            logger.debug("async lexical search failed", exc_info=True)
+            lex_entries = []
+    for entry in lex_entries:
+        slot = candidates.get(entry.entry_key)
+        if slot is None:
+            candidates[entry.entry_key] = {"entry": entry, "sim": 0.0, "keyword": 1.0}
+        else:
+            slot["keyword"] = 1.0
+
+    # 3c. Sync fallback only if nothing came back from the async paths (e.g.
+    #     non-postgres deployment or embedder+async both unavailable).
+    if not candidates:
+        mem = _get_memory()
         try:
             results = mem._adapter.search(sq_lex, branch=branch)
         except TypeError:
             results = mem._adapter.search(sq_lex)
         except Exception:
             results = []
+        for entry in results:
+            candidates.setdefault(
+                entry.entry_key, {"entry": entry, "sim": 0.0, "keyword": 1.0}
+            )
+
+    # 4. Drop benchmark/system scratch namespaces from user recall.
+    candidates = {
+        k: v
+        for k, v in candidates.items()
+        if not _is_excluded_entity(getattr(v["entry"], "entity_path", ""))
+    }
+
+    # 5. Visibility (account RLS already scoped the fetch; this adds per-user +
+    #    room scoping) applied ONCE over the full merged set so lexical-only
+    #    hits are filtered exactly like semantic ones — no leak path.
     if vis is not None and vis.should_filter():
-        results = vis.filter_entries(results)
-    return [_entry_to_response(e) for e in results]
+        allowed = {e.entry_key for e in vis.filter_entries([v["entry"] for v in candidates.values()])}
+        candidates = {k: v for k, v in candidates.items() if k in allowed}
+
+    # 6. Artifact awareness (column authoritative once backfilled; classify on
+    #    the fly otherwise so demotion works immediately).
+    col_ready = getattr(_async_adapter, "_has_is_artifact_col", False)
+
+    def _is_artifact(e: MemoryEntry) -> bool:
+        if col_ready:
+            return bool(e.is_artifact)
+        return classify_artifact(e.key, e.value)
+
+    if not req.include_artifacts:
+        candidates = {k: v for k, v in candidates.items() if not _is_artifact(v["entry"])}
+
+    # 7. Blend semantic + recency + confidence + keyword.
+    now = _dt.now(_tz.utc)
+    half_life = 30.0
+    keyword_weight = 0.15
+    scored: list[tuple[MemoryEntry, float, dict[str, Any]]] = []
+    for slot in candidates.values():
+        entry = slot["entry"]
+        sim = float(slot["sim"])
+        keyword = float(slot["keyword"])
+        written = getattr(entry.provenance, "written_at", None)
+        if written is not None:
+            if written.tzinfo is None:
+                written = written.replace(tzinfo=_tz.utc)
+            age_days = max(0.0, (now - written).total_seconds() / 86400.0)
+            recency = 0.5 ** (age_days / half_life)
+        else:
+            recency = 0.0
+        conf = float(entry.confidence)
+        score = (
+            req.semantic_weight * sim
+            + recency_weight * recency
+            + req.confidence_weight * conf
+            + keyword_weight * keyword
+        )
+        artifact = _is_artifact(entry)
+        if artifact:
+            score *= ARTIFACT_PENALTY
+        scored.append((entry, score, {
+            "semantic": round(sim, 4),
+            "recency": round(recency, 4),
+            "confidence": round(conf, 4),
+            "keyword": round(keyword, 4),
+            "is_artifact": artifact,
+        }))
+
+    scored.sort(key=lambda t: t[1], reverse=True)
+
+    # 8. Cross-encoder rerank (Pro-injected) over the top-N, then reorder them
+    #    ahead of the untouched tail.
+    reranker = _retrieval_reranker
+    rerank_top_n = 30
+    if reranker is not None and getattr(reranker, "available", False) and scored:
+        head = scored[:rerank_top_n]
+        try:
+            rr_scores = reranker.rerank(topical, [_doc_text_for_rerank(e) for e, _, _ in head])
+        except Exception:  # noqa: BLE001 - rerank is best-effort
+            logger.debug("rerank failed", exc_info=True)
+            rr_scores = None
+        if rr_scores and len(rr_scores) == len(head):
+            reranked = [
+                (entry, float(rs), {**bd, "rerank": round(float(rs), 4)})
+                for (entry, _, bd), rs in zip(head, rr_scores)
+            ]
+            reranked.sort(key=lambda t: t[1], reverse=True)
+            scored = reranked + scored[rerank_top_n:]
+
+    # 9. Abstain floor: trim clearly-irrelevant tail (low semantic AND no
+    #    keyword match), but never drop the single best result.
+    floor = _retrieve_min_semantic()
+    if floor > 0 and len(scored) > 1:
+        kept = [scored[0]]
+        for entry, score, bd in scored[1:]:
+            if bd.get("semantic", 0.0) < floor and not bd.get("keyword"):
+                continue
+            kept.append((entry, score, bd))
+        scored = kept
+
+    out: list[dict[str, Any]] = []
+    for entry, score, breakdown in scored[: req.limit]:
+        data = _entry_to_response(entry)
+        data["_score"] = round(score, 4)
+        data["_breakdown"] = breakdown
+        out.append(data)
+    return out
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/unit/test_hybrid_retrieve.py
+++ b/tests/unit/test_hybrid_retrieve.py
@@ -1,0 +1,257 @@
+"""Tier 1 hybrid retrieval tests.
+
+Covers the pieces that make /api/v1/retrieve robust to vaguely/temporally-worded
+queries without a live Postgres:
+  - or_tsquery: multi-term queries OR their terms (recall) instead of ANDing.
+  - normalize_temporal: temporal intent -> recency signal, not embedded noise.
+  - retrieve_entries: semantic UNION lexical candidate generation, visibility
+    applied over the merged set, Pro-injected rerank, and the abstain floor.
+
+The retrieve_entries tests drive the real endpoint coroutine against a fake
+async adapter + fake embedder by monkeypatching the module globals, so they
+exercise the exact serving-path logic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+from datetime import datetime, timedelta, timezone
+
+import amfs_http.server as server
+import pytest
+from amfs_core.models import MemoryEntry, Provenance
+from amfs_core.query_norm import normalize_temporal
+from amfs_http.models import RetrieveRequest
+from amfs_postgres._fts import or_tsquery
+
+# ──────────────────────────────────────────────────────────────────────
+# or_tsquery
+# ──────────────────────────────────────────────────────────────────────
+
+class TestOrTsquery:
+    def test_single_term_uses_plainto(self):
+        sql, params = or_tsquery("browser")
+        assert sql == "plainto_tsquery('english', %s)"
+        assert params == ["browser"]
+
+    def test_multi_term_ors_each_term(self):
+        sql, params = or_tsquery("browser plugin extension")
+        # One plainto per term, OR-combined with ||.
+        assert sql.count("plainto_tsquery('english', %s)") == 3
+        assert " || " in sql
+        assert params == ["browser", "plugin", "extension"]
+
+    def test_dedupes_and_drops_punctuation(self):
+        sql, params = or_tsquery("browser, browser plugin!")
+        assert params == ["browser", "plugin"]
+        assert sql.count("%s") == 2
+
+    def test_empty_query_is_safe(self):
+        sql, params = or_tsquery("")
+        assert "plainto_tsquery" in sql
+        assert params == [""]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# normalize_temporal
+# ──────────────────────────────────────────────────────────────────────
+
+class TestNormalizeTemporal:
+    def test_strips_yesterday_and_sets_window(self):
+        now = datetime(2026, 7, 23, 12, 0, tzinfo=timezone.utc)
+        r = normalize_temporal("browser plugin delivered yesterday", now=now)
+        assert r.matched is True
+        assert "yesterday" not in r.topical.lower()
+        assert "browser plugin delivered" in r.topical
+        assert r.written_after == now - timedelta(days=2)
+        assert r.recency_weight_boost > 1.0
+
+    def test_last_week(self):
+        now = datetime(2026, 7, 23, tzinfo=timezone.utc)
+        r = normalize_temporal("what did we ship last week", now=now)
+        assert r.matched
+        assert r.written_after == now - timedelta(days=14)
+
+    def test_numeric_phrase(self):
+        now = datetime(2026, 7, 23, tzinfo=timezone.utc)
+        r = normalize_temporal("bug fixed 3 days ago", now=now)
+        assert r.matched
+        # 3 days + 1 day buffer
+        assert r.written_after == now - timedelta(days=4)
+
+    def test_no_temporal_is_noop(self):
+        r = normalize_temporal("stripe checkout integration")
+        assert r.matched is False
+        assert r.recency_weight_boost == 1.0
+        assert r.written_after is None
+        assert r.topical == "stripe checkout integration"
+
+    def test_only_temporal_keeps_original(self):
+        r = normalize_temporal("yesterday")
+        assert r.topical  # never empty
+        assert r.matched
+
+
+# ──────────────────────────────────────────────────────────────────────
+# retrieve_entries hybrid serving path
+# ──────────────────────────────────────────────────────────────────────
+
+def _entry(entity_path: str, key: str, value: str, *, confidence: float = 0.9,
+           days_old: float = 1.0) -> MemoryEntry:
+    written = datetime.now(timezone.utc) - timedelta(days=days_old)
+    return MemoryEntry(
+        entity_path=entity_path,
+        key=key,
+        value=value,
+        confidence=confidence,
+        provenance=Provenance(agent_id="a", session_id="s", written_at=written),
+    )
+
+
+class _FakeAdapter:
+    """Deterministic stand-in: returns preset semantic + lexical hits so the
+    union/dedup/visibility logic can be asserted without a database."""
+
+    _has_is_artifact_col = True
+
+    def __init__(self, semantic_hits=None, lexical_hits=None):
+        self._semantic = semantic_hits or []
+        self._lexical = lexical_hits or []
+
+    async def semantic_search(self, query, embedder, *, branch="main"):
+        return list(self._semantic)
+
+    async def search(self, query, *, branch="main"):
+        return list(self._lexical)
+
+
+class _Vis:
+    def __init__(self, allowed_keys):
+        self._allowed = set(allowed_keys)
+
+    def should_filter(self):
+        return True
+
+    def filter_entries(self, entries):
+        return [e for e in entries if e.entry_key in self._allowed]
+
+
+def _request(vis=None):
+    state = types.SimpleNamespace(visibility_filter=vis)
+    return types.SimpleNamespace(state=state)
+
+
+def _run(request, req):
+    return asyncio.run(server.retrieve_entries(request, req, _auth=None))
+
+
+@pytest.fixture(autouse=True)
+def _reset_server_globals(monkeypatch):
+    monkeypatch.setattr(server, "_retrieval_reranker", None, raising=False)
+    monkeypatch.setattr(server, "_retrieval_query_rewriter", None, raising=False)
+    monkeypatch.setattr(server, "_get_server_embedder", lambda: object())
+    # Default floor for determinism unless a test overrides.
+    monkeypatch.setenv("AMFS_RETRIEVE_MIN_SEMANTIC", "0.15")
+    yield
+
+
+class TestHybridUnion:
+    def test_lexical_only_hit_surfaces(self, monkeypatch):
+        """A relevant entry the vector neighbours miss must still surface via
+        the lexical channel (the browser-extension incident)."""
+        target = _entry("amfs/browser-extension", "task-summary",
+                        "SenseLab web clipper browser extension connect flow")
+        noise = _entry("app/ui", "index.css", "body { margin: 0 }", confidence=0.95)
+        fake = _FakeAdapter(semantic_hits=[(noise, 0.22)], lexical_hits=[target])
+        monkeypatch.setattr(server, "_async_adapter", fake)
+
+        req = RetrieveRequest(query="browser plugin extension delivered yesterday", limit=10)
+        out = _run(_request(), req)
+        keys = [d["entity_path"] + "/" + d["key"] for d in out]
+        assert "amfs/browser-extension/task-summary" in keys
+        # keyword-matched, recent target should outrank the weak-sim css noise
+        assert keys[0] == "amfs/browser-extension/task-summary"
+
+    def test_visibility_applied_to_merged_set(self, monkeypatch):
+        """A foreign entry that only matched lexically must be filtered — the
+        union must not create a visibility bypass."""
+        mine = _entry("amfs/browser-extension", "task-summary", "browser extension clipper")
+        foreign = _entry("other/secret", "leak", "browser extension private note")
+        fake = _FakeAdapter(semantic_hits=[], lexical_hits=[mine, foreign])
+        monkeypatch.setattr(server, "_async_adapter", fake)
+
+        vis = _Vis(allowed_keys={mine.entry_key})
+        out = _run(_request(vis=vis), RetrieveRequest(query="browser extension", limit=10))
+        keys = {d["entity_path"] + "/" + d["key"] for d in out}
+        assert mine.entry_key in keys
+        assert foreign.entry_key not in keys
+
+    def test_excluded_namespaces_dropped(self, monkeypatch):
+        real = _entry("amfs/browser-extension", "task-summary", "browser extension clipper")
+        bench = _entry("bench-run-1/obs", "row", "browser extension benchmark row")
+        system = _entry("_system/telemetry", "row", "browser extension system row")
+        fake = _FakeAdapter(semantic_hits=[], lexical_hits=[real, bench, system])
+        monkeypatch.setattr(server, "_async_adapter", fake)
+
+        out = _run(_request(), RetrieveRequest(query="browser extension", limit=10))
+        keys = {d["entity_path"] + "/" + d["key"] for d in out}
+        assert real.entry_key in keys
+        assert bench.entry_key not in keys
+        assert system.entry_key not in keys
+
+    def test_injected_reranker_reorders(self, monkeypatch):
+        low = _entry("amfs/browser-extension", "target", "browser extension clipper")
+        high = _entry("app/ui", "other", "browser extension unrelated", confidence=0.99)
+        # Blend would favour `high` (higher confidence); reranker rescues target.
+        fake = _FakeAdapter(semantic_hits=[(low, 0.4), (high, 0.4)], lexical_hits=[])
+        monkeypatch.setattr(server, "_async_adapter", fake)
+
+        class _RR:
+            available = True
+
+            def rerank(self, query, docs):
+                # Score the target doc highest.
+                return [0.99 if "clipper" in d else 0.01 for d in docs]
+
+        monkeypatch.setattr(server, "_retrieval_reranker", _RR())
+        out = _run(_request(), RetrieveRequest(query="browser extension", limit=10))
+        assert out[0]["entity_path"] + "/" + out[0]["key"] == low.entry_key
+        assert "rerank" in out[0]["_breakdown"]
+
+    def test_query_rewriter_expands(self, monkeypatch):
+        calls = {}
+
+        class _RW:
+            def expand(self, q):
+                calls["q"] = q
+                return [q, "add-on plugin"]
+
+        recorded = []
+
+        class _CapturingAdapter(_FakeAdapter):
+            async def semantic_search(self, query, embedder, *, branch="main"):
+                recorded.append(query.text)
+                return []
+
+        fake = _CapturingAdapter(semantic_hits=[], lexical_hits=[
+            _entry("amfs/browser-extension", "t", "browser extension")
+        ])
+        monkeypatch.setattr(server, "_async_adapter", fake)
+        monkeypatch.setattr(server, "_retrieval_query_rewriter", _RW())
+        _run(_request(), RetrieveRequest(query="browser extension", limit=10))
+        # Both the original topical query and the rewriter paraphrase were searched.
+        assert "add-on plugin" in recorded
+
+    def test_abstain_trims_low_sim_no_keyword_tail(self, monkeypatch):
+        target = _entry("amfs/browser-extension", "task-summary", "browser extension clipper")
+        junk = _entry("app/ui", "index.css", "body{}", confidence=0.95)
+        # target: keyword hit (survives). junk: semantic 0.05 (< floor) + no keyword -> trimmed.
+        fake = _FakeAdapter(semantic_hits=[(junk, 0.05)], lexical_hits=[target])
+        monkeypatch.setattr(server, "_async_adapter", fake)
+        monkeypatch.setenv("AMFS_RETRIEVE_MIN_SEMANTIC", "0.15")
+
+        out = _run(_request(), RetrieveRequest(query="browser extension", limit=10))
+        keys = {d["entity_path"] + "/" + d["key"] for d in out}
+        assert target.entry_key in keys
+        assert junk.entry_key not in keys


### PR DESCRIPTION
## Summary

Fixes the class of failure where a vaguely/temporally-worded query (e.g. `browser plugin extension delivered yesterday`) silently misses relevant, recent memories. Makes the single OSS serving path (`/api/v1/retrieve`) genuinely hybrid and adds an injection point for Pro-tier reranking so account/user isolation stays enforced in exactly one place.

- **Hybrid candidate union**: `retrieve_entries` now unions pgvector semantic neighbours (per query variant) with OR-tsquery lexical matches, instead of treating lexical as a zero-hit-only fallback. Adds a keyword signal to the blend.
- **OR-tsquery** (`_fts.or_tsquery`, both sync + async adapters): `plainto_tsquery`/`websearch_to_tsquery` AND every term, so any missing term collapsed keyword recall to zero. We OR each term's `plainto_tsquery` via the tsquery `||` operator; `ts_rank` over the same expression still ranks docs matching more terms higher.
- **Temporal normalization** (`amfs_core.query_norm`): strips `yesterday`/`last week`/`3 days ago` into a recency-weight boost + `written_after`, instead of embedding it as topical noise.
- **Abstain floor + namespace exclusion**: trims a low-similarity/no-keyword tail (`AMFS_RETRIEVE_MIN_SEMANTIC`, never drops top-1) and keeps `bench-*`/`_system/*` scratch entities out of recall.
- **Visibility once, over the merged set**: `UserVisibilityFilter` is applied to the unioned candidates, so lexical-only hits are filtered exactly like semantic ones (no bypass).
- **Injectable enhancers**: `set_retrieval_enhancers()` lets the Pro layer inject a cross-encoder reranker + query rewriter into this same endpoint (wired in amfs-internal).