### PR TITLE
feat(retrieve): count top-ranked hit as reuse (fix 0 value-metrics for retrieved/extension memories)

### DIFF
--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -1225,6 +1225,27 @@ async def retrieve_entries(
             kept.append((entry, score, bd))
         scored = kept
 
+    # 10. Reuse accounting. Semantic retrieval is the primary way memories
+    #     (e.g. browser-extension clips) get surfaced and used, but it
+    #     historically incremented no counter — so value metrics (rework
+    #     avoided / memories reused) read 0 even when memory was clearly reused.
+    #     Bump recall_count for the SINGLE top-ranked hit only, so reuse tracks
+    #     real usage without inflating on every candidate returned. Best-effort:
+    #     never let accounting failure affect the response.
+    if scored:
+        top_entry = scored[0][0]
+        try:
+            if _async_adapter is not None:
+                await _async_adapter.increment_recall_count(
+                    top_entry.entity_path, top_entry.key, branch=branch
+                )
+            else:
+                _get_memory()._adapter.increment_recall_count(
+                    top_entry.entity_path, top_entry.key, branch=branch
+                )
+        except Exception:  # noqa: BLE001 - reuse accounting is best-effort
+            logger.debug("retrieve recall bump failed", exc_info=True)
+
     out: list[dict[str, Any]] = []
     for entry, score, breakdown in scored[: req.limit]:
         data = _entry_to_response(entry)


### PR DESCRIPTION
## Problem
On the agent detail page, the hero value cards (Rework avoided, Memories reused) read **0** for agents whose memories are surfaced via semantic retrieval — most visibly the **chrome/browser-extension** agent, which writes clips that are later reused via `amfs_retrieve`.

Root cause: `recall_count` is only bumped by deliberate single-key reads (`amfs_read`/`amfs_recall`/`GET /entries/{path}/{key}`). The dominant reuse path — `POST /api/v1/retrieve` (semantic search, what agents and the extension actually use) — incremented **no** counter. So reuse was invisible.

## Change
Bump `recall_count` for the **single top-ranked hit** of each `retrieve`, applied after rerank + abstain, right before building the response.
- Top-1 only → tracks real reuse without inflating on every returned candidate.
- Best-effort: wrapped in try/except so reuse accounting never affects the response.
- Uses the RLS-scoped async adapter (falls back to the sync adapter for non-Postgres deployments).

The `memory-graph` endpoint already sums `recall_count` into `totalRecalls` (and per-entry `recallCount`), which the agent page already consumes — so the hero cards light up as soon as retrieval starts accruing recalls.
