### PR TITLE
feat(search): credit reuse on query-driven /api/v1/search (top-K)

### DIFF
--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -1012,6 +1012,32 @@ async def search_entries(
     if vis is not None and vis.should_filter():
         results = vis.filter_entries(results)
 
+    # Reuse accounting. `amfs_search` is the read surface some agent profiles
+    # (e.g. the Base44 builder profile) expose instead of /retrieve, so a
+    # text-driven search is a real recall — but historically it incremented no
+    # counter, leaving reuse metrics (memories reused / rework avoided) reading
+    # 0 even when memory was clearly used. Only credit *query-driven* searches
+    # (recall intent), not pure filter/browse (agent_id/entity_path listings),
+    # and only the top-K surfaced hits so we don't inflate on the long tail.
+    # Skip system/bench scratch namespaces. Best-effort: never let accounting
+    # failure affect the response.
+    if req.query and req.query.strip():
+        reuse_credit_k = min(3, req.limit or 3)
+        for entry in results[:reuse_credit_k]:
+            if entry.entity_path.startswith(("_system/", "bench/", "bench-")):
+                continue
+            try:
+                if _async_adapter is not None:
+                    await _async_adapter.increment_recall_count(
+                        entry.entity_path, entry.key, branch=branch
+                    )
+                else:
+                    _get_memory()._adapter.increment_recall_count(
+                        entry.entity_path, entry.key, branch=branch
+                    )
+            except Exception:  # noqa: BLE001 - reuse accounting is best-effort
+                logger.debug("search recall bump failed", exc_info=True)
+
     return [_entry_to_response(e) for e in results]
 
 

--- a/tests/unit/test_hybrid_retrieve.py
+++ b/tests/unit/test_hybrid_retrieve.py
@@ -22,7 +22,7 @@ import amfs_http.server as server
 import pytest
 from amfs_core.models import MemoryEntry, Provenance
 from amfs_core.query_norm import normalize_temporal
-from amfs_http.models import RetrieveRequest
+from amfs_http.models import RetrieveRequest, SearchRequest
 from amfs_postgres._fts import or_tsquery
 
 # ──────────────────────────────────────────────────────────────────────
@@ -255,3 +255,69 @@ class TestHybridUnion:
         keys = {d["entity_path"] + "/" + d["key"] for d in out}
         assert target.entry_key in keys
         assert junk.entry_key not in keys
+
+
+# ──────────────────────────────────────────────────────────────────────
+# search_entries reuse accounting
+#
+# `amfs_search` is the read surface some agent profiles (e.g. the Base44
+# builder profile) expose instead of /retrieve. A text-driven search is a real
+# recall and must bump recall_count, or reuse metrics read 0 even when memory
+# was used. Browse/filter calls (no query) must NOT bump.
+# ──────────────────────────────────────────────────────────────────────
+
+class _RecordingSearchAdapter:
+    def __init__(self, hits):
+        self._hits = hits
+        self.bumped: list[tuple[str, str]] = []
+
+    async def search(self, query, *, branch="main"):
+        return list(self._hits)
+
+    async def increment_recall_count(self, entity_path, key, *, branch="main"):
+        self.bumped.append((entity_path, key))
+
+
+def _run_search(request, req):
+    return asyncio.run(server.search_entries(request, req, _auth=None))
+
+
+class TestSearchReuseAccounting:
+    def test_query_driven_search_bumps_top_k(self, monkeypatch):
+        hits = [
+            _entry("invoicehub", "deferred-decisions", "recurring invoices deferred"),
+            _entry("invoicehub", "schema", "client and invoice entities"),
+            _entry("invoicehub", "layout", "sidebar clients invoices"),
+            _entry("invoicehub", "extra", "fourth hit should not be credited"),
+        ]
+        fake = _RecordingSearchAdapter(hits)
+        monkeypatch.setattr(server, "_async_adapter", fake)
+
+        _run_search(_request(), SearchRequest(query="invoicehub decisions", limit=20))
+        # Only the top-3 surfaced hits are credited (no long-tail inflation).
+        assert fake.bumped == [
+            ("invoicehub", "deferred-decisions"),
+            ("invoicehub", "schema"),
+            ("invoicehub", "layout"),
+        ]
+
+    def test_browse_without_query_does_not_bump(self, monkeypatch):
+        hits = [_entry("invoicehub", "deferred-decisions", "recurring invoices deferred")]
+        fake = _RecordingSearchAdapter(hits)
+        monkeypatch.setattr(server, "_async_adapter", fake)
+
+        # Pure filter/browse (no query text) is not a recall — must not bump.
+        _run_search(_request(), SearchRequest(agent_id="base44-builder", limit=20))
+        assert fake.bumped == []
+
+    def test_system_and_bench_namespaces_skipped(self, monkeypatch):
+        hits = [
+            _entry("_system/telemetry", "row", "system row matches query"),
+            _entry("bench-run-1/obs", "row", "benchmark row matches query"),
+            _entry("invoicehub", "deferred-decisions", "real recall target"),
+        ]
+        fake = _RecordingSearchAdapter(hits)
+        monkeypatch.setattr(server, "_async_adapter", fake)
+
+        _run_search(_request(), SearchRequest(query="matches query", limit=20))
+        assert fake.bumped == [("invoicehub", "deferred-decisions")]


### PR DESCRIPTION
## Summary
- `amfs_search` is the read surface some agent profiles (notably the Base44 **builder profile**) expose instead of `/retrieve`, but `/api/v1/search` bumped no counter. So a Base44 agent could read all day and every SenseLab surface (recall_count, "memories reused", "rework avoided") stayed 0 — the exact instrumentation gap behind the `base44-builder` "0 tokens" report.
- This credits reuse for **query-driven** searches (recall intent) only: bump `recall_count` for the top-K surfaced hits, skip pure filter/browse calls (no `query`) and `_system/`/`bench` namespaces. Best-effort — accounting failure never affects the response. Mirrors the existing `/retrieve` top-3 bump (#262).