### PR TITLE
fix(mcp): scope sticky identity per client + resilient retrieve/search

### DIFF
--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -234,9 +234,28 @@ _session_metadata: SessionMetadata | None = None
 _IDENTITY_COOLDOWN_SECONDS = 30
 
 
-def _identity_file() -> Path:
-    """Path to the sticky identity file."""
+def _legacy_identity_file() -> Path:
+    """Path to the pre-per-client shared sticky identity file.
+
+    This machine-global file was shared by EVERY MCP client, so a work
+    identity set in one client (e.g. Cursor) leaked into another (e.g. Claude
+    Desktop), overriding its auto-detected identity and hiding the user's real
+    memories. We no longer read it for auto-restore; kept only so it can be
+    cleaned up on the next save/reset.
+    """
     return Path.home() / ".amfs" / ".identity"
+
+
+def _identity_file() -> Path:
+    """Path to the sticky identity file, scoped per client.
+
+    Keyed by the detected platform (cursor / claude-code / cli) so each client
+    restores its OWN last identity and Cursor work identities never leak into
+    Claude Desktop (which detects as "cli") or vice versa. Note: distinct
+    non-IDE clients (Claude Desktop, headless CLI) all map to "cli" and share
+    one file — acceptable, since the reported leak is across IDE vs desktop.
+    """
+    return Path.home() / ".amfs" / f".identity-{detect_platform()}"
 
 
 def _save_sticky_identity(name: str) -> None:
@@ -247,10 +266,22 @@ def _save_sticky_identity(name: str) -> None:
         path.write_text(name, encoding="utf-8")
     except OSError:
         logger.debug("Could not save sticky identity to %s", _identity_file(), exc_info=True)
+    # Best-effort: retire the legacy machine-global file so stale cross-client
+    # state can't be restored by an older client on this machine.
+    try:
+        legacy = _legacy_identity_file()
+        if legacy.is_file():
+            legacy.unlink()
+    except OSError:
+        logger.debug("Could not remove legacy sticky identity file", exc_info=True)
 
 
 def _load_sticky_identity() -> str | None:
-    """Load the previously set identity from disk, if it exists."""
+    """Load the previously set identity for THIS client, if it exists.
+
+    Only reads the per-client file — never the legacy shared file — so a work
+    identity set in another client cannot bleed into this session.
+    """
     try:
         path = _identity_file()
         if path.is_file():
@@ -260,6 +291,25 @@ def _load_sticky_identity() -> str | None:
     except OSError:
         logger.debug("Could not read sticky identity from %s", _identity_file(), exc_info=True)
     return None
+
+
+def _call_compat(fn: Any, **kwargs: Any) -> Any:
+    """Call ``fn(**kwargs)`` resiliently across amfs-mcp / amfs SDK version skew.
+
+    The hosted connector can run a newer amfs-mcp (whose read tools pass
+    ``include_artifacts``) against an older installed amfs SDK whose
+    ``retrieve``/``search`` predate that parameter — which otherwise raises
+    ``TypeError: ... unexpected keyword argument 'include_artifacts'`` and
+    hard-breaks recall on clients like Claude Desktop. Retry once without the
+    offending kwarg so retrieval degrades gracefully instead of failing.
+    """
+    try:
+        return fn(**kwargs)
+    except TypeError as e:
+        if "include_artifacts" in kwargs and "include_artifacts" in str(e):
+            kwargs.pop("include_artifacts", None)
+            return fn(**kwargs)
+        raise
 
 
 def _get_adapter() -> AdapterABC:
@@ -605,12 +655,12 @@ def amfs_reset_identity() -> str:
     global _active_identity
     old = _active_identity
     _active_identity = None
-    try:
-        path = _identity_file()
-        if path.is_file():
-            path.unlink()
-    except OSError:
-        logger.debug("Could not remove sticky identity file", exc_info=True)
+    for path in (_identity_file(), _legacy_identity_file()):
+        try:
+            if path.is_file():
+                path.unlink()
+        except OSError:
+            logger.debug("Could not remove sticky identity file %s", path, exc_info=True)
     return json.dumps({
         "previous_identity": old,
         "current_identity": detect_agent_id(),
@@ -796,7 +846,8 @@ def amfs_search(
     except (ValueError, TypeError) as e:
         return json.dumps({"error": f"Invalid 'since' timestamp: {e}"})
 
-    results = mem.search(
+    results = _call_compat(
+        mem.search,
         query=query,
         entity_path=entity_path,
         min_confidence=min_confidence,
@@ -879,7 +930,8 @@ def amfs_retrieve(
 
     # Prefer server-side semantic retrieval (embedder + pgvector live on the
     # server); falls back to client-side composite scoring for local adapters.
-    results = mem.retrieve(
+    results = _call_compat(
+        mem.retrieve,
         query=query,
         entity_path=entity_path,
         min_confidence=min_confidence,

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -394,6 +394,89 @@ class TestIdentityGuard:
         assert raw["entry"]["provenance"]["agent_id"] == "writer-agent"
 
 
+class TestPerClientStickyIdentity:
+    """Sticky identity is scoped per client so a work identity set in one
+    client (Cursor) never leaks into another (Claude Desktop → "cli")."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate_home(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # Neutralise inherited IDE signals so each test picks its own platform.
+        for var in ("CURSOR_SESSION_ID", "VSCODE_PID", "CLAUDE_CODE_SESSION"):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_identity_file_scoped_by_platform(self, monkeypatch) -> None:
+        import amfs_mcp.server as srv
+
+        monkeypatch.setenv("CURSOR_SESSION_ID", "x")
+        assert srv._identity_file().name == ".identity-cursor"
+
+        monkeypatch.delenv("CURSOR_SESSION_ID", raising=False)
+        # Claude Desktop / generic desktop detects as "cli".
+        assert srv._identity_file().name == ".identity-cli"
+
+    def test_no_cross_client_leak(self, monkeypatch) -> None:
+        import amfs_mcp.server as srv
+
+        # Cursor sets a work identity...
+        monkeypatch.setenv("CURSOR_SESSION_ID", "x")
+        srv._save_sticky_identity("value-metrics-agent")
+        assert srv._load_sticky_identity() == "value-metrics-agent"
+
+        # ...Claude Desktop (cli) must NOT inherit it.
+        monkeypatch.delenv("CURSOR_SESSION_ID", raising=False)
+        assert srv._load_sticky_identity() is None
+
+    def test_save_retires_legacy_shared_file(self, monkeypatch) -> None:
+        import amfs_mcp.server as srv
+
+        monkeypatch.setenv("CURSOR_SESSION_ID", "x")
+        legacy = srv._legacy_identity_file()
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text("old-shared-id", encoding="utf-8")
+
+        srv._save_sticky_identity("new-id")
+        assert not legacy.is_file()
+        assert srv._load_sticky_identity() == "new-id"
+
+
+class TestCallCompat:
+    """amfs-mcp must not hard-fail against an older amfs SDK whose
+    retrieve/search predate include_artifacts (version skew)."""
+
+    def test_drops_include_artifacts_on_typeerror(self) -> None:
+        from amfs_mcp.server import _call_compat
+
+        seen: dict = {}
+
+        def old_retrieve(**kwargs):
+            if "include_artifacts" in kwargs:
+                raise TypeError(
+                    "retrieve() got an unexpected keyword argument 'include_artifacts'"
+                )
+            seen.update(kwargs)
+            return "ok"
+
+        assert _call_compat(old_retrieve, query="q", include_artifacts=True) == "ok"
+        assert "include_artifacts" not in seen
+        assert seen["query"] == "q"
+
+    def test_passes_through_when_supported(self) -> None:
+        from amfs_mcp.server import _call_compat
+
+        result = _call_compat(lambda **kw: kw, query="q", include_artifacts=False)
+        assert result["include_artifacts"] is False
+
+    def test_reraises_unrelated_typeerror(self) -> None:
+        from amfs_mcp.server import _call_compat
+
+        def broken(**kwargs):
+            raise TypeError("something else entirely")
+
+        with pytest.raises(TypeError, match="something else"):
+            _call_compat(broken, query="q", include_artifacts=True)
+
+
 # ---------------------------------------------------------------------------
 # Transport / CLI arg parsing tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes two issues that made SenseLab break for agents on **Claude Desktop**.

### 1. Sticky identity leaked across MCP clients (empty timeline)
`~/.amfs/.identity` was **machine-global and shared by every MCP client**. Resolution order is *in-process → sticky file → auto-detect*, so a work identity set in Cursor (per the "set your identity first" rule, e.g. `value-metrics-agent`) got written to disk and then **auto-restored by Claude Desktop**, overriding its correctly-detected `agent/<user>` and pointing it at an empty brain (no writes/reads/outcomes on the timeline). This hits any user running both Cursor agents and Claude Desktop on one machine.

**Fix:** scope the sticky file per client — `~/.amfs/.identity-<platform>` (`cursor` / `claude-code` / `cli`) — so each client only ever restores its own last identity. The legacy shared file is retired on save/reset so stale cross-client state can't be picked up by an older client.

> Note: distinct non-IDE clients (Claude Desktop, headless CLI) both detect as `cli` and share one file. That's acceptable — the reported leak is IDE↔desktop, which this fully resolves.

### 2. `amfs_retrieve` hard-failed on `include_artifacts` (version skew)
The hosted connector can run a newer `amfs-mcp` (read tools pass `include_artifacts`) against an **older installed `amfs` SDK** whose `retrieve`/`search` predate that parameter → `TypeError: ... unexpected keyword argument 'include_artifacts'` on every recall. `_call_compat` retries the call once without the kwarg so retrieval degrades gracefully instead of breaking.