### PR TITLE
ci(mcp): publish-time smoke tests + always-fresh installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,50 @@ on:
       - "v*"
 
 jobs:
+  # Gate: build the release wheels and invoke the whole MCP tool surface against
+  # the installed set (siblings resolved from the just-built wheels, everything
+  # else from PyPI). Catches the class of bug where a published release crashes
+  # the instant a tool is called — invisible to unit tests that run against
+  # editable source. `publish-python` depends on this.
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build the wheels the smoke needs
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade build
+          mkdir -p /tmp/wheels
+          # Minimal set the MCP tool surface imports; other siblings satisfy
+          # their `>=` floors from PyPI.
+          for pkg in packages/core packages/sdk-python packages/adapters/filesystem packages/mcp-server; do
+            echo "Building $pkg..."
+            python -m build "$pkg" --outdir /tmp/wheels
+          done
+          ls -l /tmp/wheels
+
+      - name: Install the release set (built wheels + PyPI) and run the smoke
+        run: |
+          set -euo pipefail
+          python -m venv /tmp/smoke-venv
+          /tmp/smoke-venv/bin/pip install --upgrade pip
+          # --find-links makes the about-to-be-published packages resolve from
+          # the locally built wheels (matching versions), the rest from PyPI.
+          /tmp/smoke-venv/bin/pip install --find-links /tmp/wheels amfs-mcp-server amfs-adapter-filesystem pytest
+          # Run from a copy OUTSIDE the repo so the installed wheels (not the
+          # source tree) are imported.
+          mkdir -p /tmp/smoke-run
+          cp tests/unit/test_mcp_tools_smoke.py /tmp/smoke-run/
+          cd /tmp/smoke-run
+          /tmp/smoke-venv/bin/python -m pytest test_mcp_tools_smoke.py -v
+
   publish-python:
+    needs: smoke
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -60,3 +103,69 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public || echo "Skipping npm publish (already published or error)"
+
+  # Post-publish live smoke: drive the *just-published* server the way a real
+  # client does — `uvx amfs-mcp-server@<version>` (deps resolved from PyPI),
+  # speaking the MCP protocol over stdio against a real backend. Proves the
+  # published artifact works end-to-end, not just that it builds.
+  #
+  # Runs against BOTH dev and prod. Each leg self-skips until its URL variable +
+  # API-key secret are configured, so this is safe to merge before the secrets
+  # exist.
+  #
+  # Configure per environment (repo Settings → Secrets and variables → Actions):
+  #   dev:  variable SMOKE_MCP_DEV_URL   + secret SMOKE_MCP_DEV_API_KEY
+  #   prod: variable SMOKE_MCP_PROD_URL  + secret SMOKE_MCP_PROD_API_KEY
+  # The API key must be a test-account key valid in THAT environment's database.
+  live-smoke:
+    needs: publish-python
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [dev, prod]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv (provides uvx) + mcp client
+        run: python -m pip install --upgrade uv mcp
+
+      - name: Derive version from the release tag
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for the new version to be installable from PyPI
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/amfs-mcp-server/${VERSION}/json")
+            if [ "$CODE" = "200" ]; then echo "amfs-mcp-server ${VERSION} is live on PyPI."; exit 0; fi
+            echo "Waiting for PyPI to index ${VERSION} (attempt $i, HTTP ${CODE})..."
+            sleep 10
+          done
+          echo "Timed out waiting for amfs-mcp-server ${VERSION} on PyPI." >&2
+          exit 1
+
+      - name: Live smoke ${{ matrix.environment }} over MCP
+        env:
+          ENVIRONMENT: ${{ matrix.environment }}
+          MCP_PACKAGE: amfs-mcp-server
+          MCP_VERSION: ${{ steps.ver.outputs.version }}
+          DEV_URL: ${{ vars.SMOKE_MCP_DEV_URL }}
+          DEV_KEY: ${{ secrets.SMOKE_MCP_DEV_API_KEY }}
+          PROD_URL: ${{ vars.SMOKE_MCP_PROD_URL }}
+          PROD_KEY: ${{ secrets.SMOKE_MCP_PROD_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ "$ENVIRONMENT" = "dev" ]; then URL="$DEV_URL"; KEY="$DEV_KEY"; else URL="$PROD_URL"; KEY="$PROD_KEY"; fi
+          if [ -z "$URL" ]; then
+            echo "No SMOKE_MCP_${ENVIRONMENT^^}_URL configured — skipping $ENVIRONMENT live smoke."
+            exit 0
+          fi
+          AMFS_HTTP_URL="$URL" AMFS_API_KEY="$KEY" python scripts/mcp_live_smoke.py

--- a/install-mcp.sh
+++ b/install-mcp.sh
@@ -118,13 +118,15 @@ ensure_uv() {
 # ── Step 2: Pre-install amfs-mcp-server ──────────────────────────────────────
 
 ensure_amfs_mcp() {
+    # `--refresh` so the warm-up pulls the latest published build, matching the
+    # `--refresh` the generated client config uses at launch.
     if [[ -n "$API_KEY" ]]; then
         info "Installing amfs-mcp-server-pro (SaaS)..."
-        uvx --from amfs-mcp-server-pro amfs-mcp-server-pro --help &>/dev/null || true
+        uvx --refresh --from amfs-mcp-server-pro amfs-mcp-server-pro --help &>/dev/null || true
         success "amfs-mcp-server-pro is ready"
     else
         info "Installing amfs-mcp-server..."
-        uvx --from amfs-mcp-server amfs-mcp-server --help &>/dev/null || true
+        uvx --refresh --from amfs-mcp-server amfs-mcp-server --help &>/dev/null || true
         success "amfs-mcp-server is ready"
     fi
 }
@@ -177,10 +179,15 @@ ENVJSON
 )
     fi
 
+    # `--refresh` forces uvx to re-resolve from PyPI on each launch instead of
+    # reusing a stale cached environment. Without it, a user who ever ran an
+    # older build keeps getting it forever — even after we publish a fix — so
+    # retrieval can stay broken across releases. The small per-launch re-resolve
+    # cost is worth never serving a stale MCP server.
     cat <<MCPJSON
 {
         "command": "$UVX_PATH",
-        "args": ["$pkg"],
+        "args": ["--refresh", "$pkg"],
         "env": $env_block
     }
 MCPJSON
@@ -431,10 +438,13 @@ configure_client() {
                 resolve_uvx_path
                 local pkg="amfs-mcp-server"
                 if [[ -n "$API_KEY" ]]; then pkg="amfs-mcp-server-pro"; fi
-                local args=("mcp" "add" "senselab" "--" "$UVX_PATH" "$pkg")
+                # `--refresh` (a uvx flag, before the package) forces a fresh
+                # re-resolve each launch so users never get stuck on a stale
+                # cached build after we publish a fix.
+                local args=("mcp" "add" "senselab" "--" "$UVX_PATH" "--refresh" "$pkg")
                 if [[ -n "$API_KEY" ]]; then
                     local url="${API_URL:-$AMFS_DEFAULT_API_URL}"
-                    args=("mcp" "add" "senselab" "-e" "AMFS_HTTP_URL=$url" "-e" "AMFS_API_KEY=$API_KEY" "--" "$UVX_PATH" "$pkg")
+                    args=("mcp" "add" "senselab" "-e" "AMFS_HTTP_URL=$url" "-e" "AMFS_API_KEY=$API_KEY" "--" "$UVX_PATH" "--refresh" "$pkg")
                 fi
                 claude "${args[@]}"
                 success "Configured Claude Code"
@@ -459,10 +469,13 @@ configure_client() {
                 local pkg="amfs-mcp-server"
                 if [[ -n "$API_KEY" ]]; then pkg="amfs-mcp-server-pro"; fi
                 # codex mcp add <name> [--env KEY=VAL]... -- <command> [args...]
-                local args=("mcp" "add" "senselab" "--" "$UVX_PATH" "$pkg")
+                # `--refresh` (uvx flag, before the package) forces a fresh
+                # re-resolve each launch so a stale cache can't pin users to an
+                # old build after we publish a fix.
+                local args=("mcp" "add" "senselab" "--" "$UVX_PATH" "--refresh" "$pkg")
                 if [[ -n "$API_KEY" ]]; then
                     local url="${API_URL:-$AMFS_DEFAULT_API_URL}"
-                    args=("mcp" "add" "senselab" "--env" "AMFS_HTTP_URL=$url" "--env" "AMFS_API_KEY=$API_KEY" "--" "$UVX_PATH" "$pkg")
+                    args=("mcp" "add" "senselab" "--env" "AMFS_HTTP_URL=$url" "--env" "AMFS_API_KEY=$API_KEY" "--" "$UVX_PATH" "--refresh" "$pkg")
                 fi
                 # Replace any existing entry so re-runs stay idempotent.
                 codex mcp remove senselab 2>/dev/null || true

--- a/scripts/mcp_live_smoke.py
+++ b/scripts/mcp_live_smoke.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Post-publish live smoke test for a published MCP server.
+
+Unlike the in-process tool-surface smoke (which imports the package directly),
+this drives the *published* server exactly as a real client does:
+
+  1. spawns it with ``uvx <package>[@<version>]`` — resolving the package and
+     all of its dependencies from PyPI, the same resolution end users get;
+  2. speaks the real MCP protocol over stdio (initialize + list_tools +
+     call_tool); and
+  3. calls a handful of read tools against a real backend (AMFS_HTTP_URL +
+     AMFS_API_KEY), asserting each returns without an error.
+
+This is the only layer that proves "the thing we just published actually works
+when a client runs it", catching dependency-resolution skew, missing tools,
+transport/schema breakage, and backend-auth regressions that in-process tests
+cannot see.
+
+Env:
+  MCP_PACKAGE       PyPI package to run (e.g. amfs-mcp-server-pro). Required.
+  MCP_VERSION       Optional exact version to pin (e.g. 0.1.23). Recommended in
+                    CI so the smoke targets the release just published.
+  AMFS_HTTP_URL     Backend URL the server should talk to. Required.
+  AMFS_API_KEY      API key for that backend. Required.
+  MCP_SMOKE_TIMEOUT Per-call timeout seconds (default 60).
+
+Exit code 0 = all probed tools responded without error; non-zero = failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+
+try:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+except ImportError:  # pragma: no cover - dependency is installed in CI
+    sys.stderr.write(
+        "The 'mcp' package is required. Install it with: pip install mcp\n"
+    )
+    raise
+
+
+def _require(name: str) -> str:
+    val = os.environ.get(name, "").strip()
+    if not val:
+        sys.stderr.write(f"Missing required env var: {name}\n")
+        sys.exit(2)
+    return val
+
+
+# Read tools that must respond without error against a live backend. These are
+# side-effect-free and exercise identity, aggregate stats, semantic recall
+# (the include_artifacts path), and keyword search (the search-recall path).
+_PROBES: list[tuple[str, dict]] = [
+    ("amfs_whoami", {}),
+    ("amfs_stats", {}),
+    ("amfs_retrieve", {"query": "live smoke test probe", "limit": 3}),
+    ("amfs_search", {"query": "smoke", "limit": 3}),
+]
+
+
+def _extract_text(result) -> str:
+    """Best-effort flatten of a call_tool result's content into text."""
+    parts = []
+    for block in getattr(result, "content", []) or []:
+        text = getattr(block, "text", None)
+        if text is not None:
+            parts.append(text)
+    return "\n".join(parts)
+
+
+async def _run() -> int:
+    package = _require("MCP_PACKAGE")
+    version = os.environ.get("MCP_VERSION", "").strip()
+    spec = f"{package}@{version}" if version else package
+    timeout = float(os.environ.get("MCP_SMOKE_TIMEOUT", "60"))
+
+    # Pass the backend creds through to the spawned server. --refresh forces uvx
+    # to re-resolve from PyPI instead of serving a stale cached build.
+    child_env = dict(os.environ)
+    child_env["AMFS_HTTP_URL"] = _require("AMFS_HTTP_URL")
+    child_env["AMFS_API_KEY"] = _require("AMFS_API_KEY")
+
+    params = StdioServerParameters(
+        command="uvx",
+        args=["--refresh", spec],
+        env=child_env,
+    )
+
+    print(f"[live-smoke] launching: uvx --refresh {spec}")
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await asyncio.wait_for(session.initialize(), timeout=timeout)
+
+            listed = await asyncio.wait_for(session.list_tools(), timeout=timeout)
+            tool_names = {t.name for t in listed.tools}
+            print(f"[live-smoke] server advertised {len(tool_names)} tools")
+
+            missing = [name for name, _ in _PROBES if name not in tool_names]
+            if missing:
+                sys.stderr.write(
+                    f"[live-smoke] FAIL: published server is missing tools: {missing}\n"
+                )
+                return 1
+
+            failures: list[str] = []
+            for name, args in _PROBES:
+                try:
+                    result = await asyncio.wait_for(
+                        session.call_tool(name, args), timeout=timeout
+                    )
+                except Exception as exc:  # noqa: BLE001 - report any transport/tool error
+                    failures.append(f"{name}: raised {type(exc).__name__}: {exc}")
+                    continue
+
+                if getattr(result, "isError", False):
+                    failures.append(f"{name}: isError=True -> {_extract_text(result)[:300]}")
+                    continue
+
+                text = _extract_text(result)
+                try:
+                    json.loads(text)  # tools return JSON strings
+                except (json.JSONDecodeError, TypeError):
+                    failures.append(f"{name}: non-JSON response -> {text[:200]!r}")
+                    continue
+
+                print(f"[live-smoke] OK  {name}")
+
+            if failures:
+                sys.stderr.write("[live-smoke] FAIL:\n  " + "\n  ".join(failures) + "\n")
+                return 1
+
+    print("[live-smoke] all probes passed")
+    return 0
+
+
+def main() -> None:
+    try:
+        sys.exit(asyncio.run(_run()))
+    except asyncio.TimeoutError:
+        sys.stderr.write("[live-smoke] FAIL: timed out talking to the server\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_mcp_tools_smoke.py
+++ b/tests/unit/test_mcp_tools_smoke.py
@@ -1,0 +1,125 @@
+"""Publish-time smoke test for the whole MCP tool surface.
+
+Regression guard for the class of bug where a *published* release of the MCP
+server crashes the instant a tool is invoked — even though every other unit
+test (which exercises tools in isolation against local source) is green.
+
+The concrete failure this targets: ``amfs_retrieve`` began forwarding an
+``include_artifacts`` kwarg down the stack to a ``retrieve`` that — in the
+dependency combination ``uvx`` actually resolved from PyPI — did not accept it,
+raising ``TypeError: ... unexpected keyword argument 'include_artifacts'`` and
+hard-breaking recall on real clients (Claude Desktop). Nothing caught it because
+no test *invoked the tool end-to-end against the resolved dependency set*.
+
+This test does exactly that: it seeds a filesystem-backed store and calls every
+core read/query/write tool the way a client would, asserting each returns
+well-formed JSON without raising. Run in the release workflow against the
+*installed wheel* (deps resolved from PyPI, as ``uvx`` resolves them), it turns
+that class of version skew into a red build instead of a broken release.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from amfs_filesystem.adapter import FilesystemAdapter
+
+
+@pytest.fixture
+def srv(tmp_path: Path):
+    """A server module wired to a filesystem-backed, pre-seeded store.
+
+    Importing the tools by attribute doubles as a registration guard: if a core
+    tool is renamed or dropped, the accessor in a test below fails loudly.
+    """
+    import amfs_mcp.server as server
+
+    server._adapter = FilesystemAdapter(root=tmp_path / ".amfs", namespace="smoke")
+    server._active_identity = "smoke-agent"
+    server._memories = {}
+    server._last_activity = 0.0
+
+    # Seed enough that read / search / retrieve have something to return.
+    server.amfs_write("smoke/db", "retry-policy", '{"max_retries": 3, "backoff": "exponential"}')
+    server.amfs_write("smoke/ops", "runbook", "the deploy runbook lives in the ops wiki")
+
+    yield server
+
+    for m in server._memories.values():
+        m.close()
+    server._memories = {}
+    server._adapter = None
+    server._active_identity = None
+
+
+def _ok(name: str, raw: object) -> dict | list:
+    """Assert a tool returned well-formed JSON and did not report an error.
+
+    The regression surfaced as an unhandled ``TypeError`` (so merely *calling*
+    the tool without an exception is the primary guard), but a tool that caught
+    its own failure and serialized ``{"error": ...}`` is equally broken from a
+    client's point of view, so we reject that too.
+    """
+    assert isinstance(raw, str), f"{name} did not return a str, got {type(raw).__name__}"
+    payload = json.loads(raw)  # invalid JSON → JSONDecodeError → test fails
+    if isinstance(payload, dict):
+        assert "error" not in payload, f"{name} returned an error payload: {payload.get('error')!r}"
+    return payload
+
+
+class TestReadSurfaceSmoke:
+    """Every core read/query tool answers with well-formed JSON, no exception.
+
+    A failure here means a client (Cursor / Claude Desktop / CLI) would hit a
+    broken tool the moment it calls it.
+    """
+
+    def test_whoami(self, srv):
+        _ok("amfs_whoami", srv.amfs_whoami())
+
+    def test_read(self, srv):
+        _ok("amfs_read", srv.amfs_read("smoke/db", "retry-policy"))
+
+    def test_recall(self, srv):
+        _ok("amfs_recall", srv.amfs_recall("smoke/db", "retry-policy"))
+
+    def test_list(self, srv):
+        _ok("amfs_list", srv.amfs_list())
+
+    def test_my_entries(self, srv):
+        _ok("amfs_my_entries", srv.amfs_my_entries())
+
+    def test_search_query(self, srv):
+        _ok("amfs_search", srv.amfs_search(query="runbook"))
+
+    def test_search_browse(self, srv):
+        _ok("amfs_search", srv.amfs_search(entity_path="smoke/db"))
+
+    def test_stats(self, srv):
+        _ok("amfs_stats", srv.amfs_stats())
+
+    def test_retrieve(self, srv):
+        # THE regression: retrieve forwards include_artifacts down the stack.
+        _ok("amfs_retrieve", srv.amfs_retrieve(query="retry policy"))
+
+    def test_retrieve_include_artifacts_toggle(self, srv):
+        # Both toggles must reach the downstream retrieve without a kwarg crash —
+        # this is the exact code path that broke on a stale published dependency.
+        _ok("amfs_retrieve", srv.amfs_retrieve(query="runbook", include_artifacts=False))
+        _ok("amfs_retrieve", srv.amfs_retrieve(query="runbook", include_artifacts=True))
+
+
+class TestWriteSurfaceSmoke:
+    """The core write / trace tools accept a call and return well-formed JSON."""
+
+    def test_write(self, srv):
+        _ok("amfs_write", srv.amfs_write("smoke/x", "k", "v"))
+
+    def test_record_context(self, srv):
+        _ok("amfs_record_context", srv.amfs_record_context("smoke-label", "a summary", source="smoke"))
+
+    def test_commit_outcome(self, srv):
+        _ok("amfs_commit_outcome", srv.amfs_commit_outcome("smoke-outcome", "success"))


### PR DESCRIPTION
## Why

Broken MCP releases have reached users because **every test runs against local editable source**, never the dependency set `uvx` resolves from PyPI — so a version skew (e.g. `amfs_retrieve` forwarding `include_artifacts` to a published OSS build that lacked it) shipped invisibly. Separately, `uvx <pkg>` reuses a **stale cached build**, so even after a fix is published, existing users stay broken until their cache changes.

This PR closes both gaps for the OSS `amfs-mcp-server`.

## What

**Layer 1 — in-process tool-surface smoke** (`tests/unit/test_mcp_tools_smoke.py`)
Seeds a filesystem store and invokes the full read/write tool surface — `whoami`, `read`, `recall`, `list`, `my_entries`, `search`, `stats`, **`retrieve`** (incl. the `include_artifacts` toggle), `write`, `record_context`, `commit_outcome` — asserting well-formed JSON and no error payload. Also runs on every PR via the existing `test-python.yml`.

**Layer 2 — pre-publish gate** (`release.yml`)
New `smoke` job builds the release wheels and runs the smoke against the **installed set** (siblings resolved from the built wheels via `--find-links`, the rest from PyPI). `publish-python` now `needs: smoke`, so a skew fails the build instead of shipping.

**Layer 3 — post-publish live smoke** (`release.yml` + `scripts/mcp_live_smoke.py`)
Drives `uvx amfs-mcp-server@<version>` over the **real MCP protocol** (initialize → list_tools → call_tool) against **dev and prod**. Each leg self-skips until its `SMOKE_MCP_<ENV>_URL` variable + `SMOKE_MCP_<ENV>_API_KEY` secret are configured.

**Installer fix** (`install-mcp.sh`)
Emits `uvx --refresh …` in every generated client config (Claude Desktop, Cursor, Claude Code, Codex, Windsurf, VS Code, manual fallback) and the warm-up step, so a fresh install always resolves the latest server and never gets stuck on a stale cached build.