### PR TITLE
fix(http): repair /entities 500 for admin users + broken consolidation endpoints

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -1730,7 +1730,11 @@ class PostgresAdapter(AdapterABC):
                    MAX(written_at) AS last_updated,
                    (ARRAY_AGG(agent_id ORDER BY written_at DESC))[1] AS last_agent,
                    ARRAY_AGG(DISTINCT agent_id) AS agents,
-                   COUNT(*) FILTER (WHERE content_hash IS NOT NULL) AS hashed_count,
+                   -- The Postgres schema has no content_hash column (hashes
+                   -- live only on filesystem-backed entries), so hashed_count
+                   -- is always 0 here — matching entity_summaries_from_entries,
+                   -- which sees content_hash=None on every Postgres row.
+                   0::bigint AS hashed_count,
                    COALESCE(SUM(recall_count), 0) AS total_recalls
             FROM amfs_memory_entries
             WHERE {where}

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -5146,7 +5146,7 @@ async def run_consolidation(
 
     mem = _get_memory()
     adapter = mem._adapter
-    namespace = mem._namespace
+    namespace = mem.namespace
     branch = (body or {}).get("branch", "main")
     entity_path = (body or {}).get("entity_path")
 
@@ -5185,7 +5185,7 @@ async def list_consolidation_candidates(
 
     mem = _get_memory()
     adapter = mem._adapter
-    namespace = mem._namespace
+    namespace = mem.namespace
 
     strategy = ConsolidationStrategy(adapter, namespace=namespace)
     proposals = strategy.find_consolidation_candidates(entity_path, branch=branch)
@@ -5211,7 +5211,7 @@ async def list_consolidation_proposals(
     visible_paths = _visible_entity_paths(request)
     mem = _get_memory()
     adapter = mem._adapter
-    namespace = mem._namespace
+    namespace = mem.namespace
 
     try:
         branches = adapter.list_branches(namespace=namespace, status="active" if status != "all" else None)
@@ -5294,7 +5294,7 @@ async def consolidation_status(
     """Get consolidation health metrics for the dashboard."""
     mem = _get_memory()
     adapter = mem._adapter
-    namespace = mem._namespace
+    namespace = mem.namespace
     vis = _active_visibility_filter(request)
 
     consolidation_runs = 0


### PR DESCRIPTION
## Summary
- **Fixes the empty "What your agents know" block for account owners/admins.** `entity_summaries()` in the Postgres adapter selects a `content_hash` column that does not exist in the Postgres schema, so `GET /api/v1/entities` returned 500 (`psycopg.errors.UndefinedColumn`) whenever the request took the unfiltered branch. Before the tenant-isolation deploy every dashboard request was visibility-filtered (the `is_admin` header was ignored) and took the Python aggregation branch, which masked the broken SQL; now admins correctly bypass the filter and hit it. The dashboard swallows the error (`.catch(() => [])`) and renders the empty state. `hashed_count` is now a constant `0`, matching what `entity_summaries_from_entries` computes for Postgres rows (they never carry `content_hash`).
- **Fixes `AttributeError: 'AgentMemory' object has no attribute '_namespace'`** in the four cortex consolidation endpoints (`mem._namespace` → `mem.namespace`), which 500 in production today.