### PR TITLE
Surface server error detail in HttpAdapter exceptions

### DIFF
--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -39,6 +39,33 @@ def _parse_entry(data: dict[str, Any]) -> MemoryEntry:
     return MemoryEntry.model_validate(data)
 
 
+def _raise_with_detail(resp: httpx.Response) -> None:
+    """raise_for_status, but with the server's `detail` in the message.
+
+    httpx's default message is just "409 Conflict for url ..." — the API's
+    actionable guidance (e.g. "Agent identity X is already registered to a
+    different user... call amfs_set_identity...") lives in the JSON body and
+    MUST reach the caller: MCP agents read the exception text to self-correct.
+    """
+    if not resp.is_error:
+        return
+    detail = None
+    try:
+        payload = resp.json()
+        if isinstance(payload, dict):
+            detail = payload.get("detail") or payload.get("error")
+    except Exception:
+        detail = None
+    if detail:
+        raise httpx.HTTPStatusError(
+            f"{resp.status_code} {resp.reason_phrase} for "
+            f"{resp.request.method} {resp.request.url.path}: {detail}",
+            request=resp.request,
+            response=resp,
+        )
+    resp.raise_for_status()
+
+
 class HttpAdapter(AdapterABC):
     """Storage adapter that delegates to the AMFS HTTP/REST API.
 
@@ -78,7 +105,7 @@ class HttpAdapter(AdapterABC):
                 logger.debug("Rate limited on %s %s, retrying in %.1fs", method, path, wait)
                 time.sleep(wait)
                 continue
-            resp.raise_for_status()
+            _raise_with_detail(resp)
             return resp.json()
 
     def _get(self, path: str, **params: Any) -> Any:
@@ -409,7 +436,7 @@ class HttpAdapter(AdapterABC):
             f"/api/v1/agents/{quote(agent_id, safe='')}/profile",
             json=profile.model_dump(),
         )
-        resp.raise_for_status()
+        _raise_with_detail(resp)
         return Agent.model_validate(resp.json())
 
     def list_digests(

--- a/tests/unit/test_http_adapter.py
+++ b/tests/unit/test_http_adapter.py
@@ -173,3 +173,80 @@ class TestEnsureAgent:
 
         assert agent.agent_id == "my-agent"
         assert len(calls) == 0
+
+
+def _make_error_adapter(status_code: int, body: Any):
+    """Create an HttpAdapter whose transport always returns an error response."""
+    from amfs_adapter_http.adapter import HttpAdapter
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if isinstance(body, (dict, list)):
+            return httpx.Response(status_code, json=body)
+        return httpx.Response(status_code, text=body)
+
+    adapter = HttpAdapter.__new__(HttpAdapter)
+    adapter._base = "http://test"
+    adapter._api_key = "test-key"
+    adapter._client = httpx.Client(
+        base_url="http://test",
+        headers={"X-AMFS-API-Key": "test-key"},
+        transport=httpx.MockTransport(_handler),
+    )
+    return adapter
+
+
+class TestErrorDetailSurfaced:
+    """4xx/5xx responses must expose the server's `detail` in the exception
+    message so MCP agents can read the guidance and self-correct (e.g. the
+    409 agent-identity collision tells them to call amfs_set_identity)."""
+
+    def test_409_detail_in_message(self) -> None:
+        detail = (
+            "Agent identity 'agent/dai' is already registered to a different "
+            "user in this account. Set a unique agent identity and retry."
+        )
+        adapter = _make_error_adapter(409, {"detail": detail})
+
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            adapter._request("GET", "/api/v1/entries")
+
+        assert detail in str(exc_info.value)
+        assert exc_info.value.response.status_code == 409
+
+    def test_update_agent_profile_surfaces_detail(self) -> None:
+        detail = "Agent identity 'agent/dai' is already registered to a different user"
+        adapter = _make_error_adapter(409, {"detail": detail})
+
+        profile = MagicMock()
+        profile.model_dump.return_value = {"display_name": "Dai"}
+
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            adapter.update_agent_profile("agent/dai", profile)
+
+        assert detail in str(exc_info.value)
+
+    def test_error_key_used_as_fallback(self) -> None:
+        adapter = _make_error_adapter(403, {"error": "restricted member"})
+
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            adapter._request("GET", "/api/v1/entries")
+
+        assert "restricted member" in str(exc_info.value)
+
+    def test_non_json_body_falls_back_to_plain_raise(self) -> None:
+        adapter = _make_error_adapter(500, "internal server error")
+
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            adapter._request("GET", "/api/v1/entries")
+
+        assert exc_info.value.response.status_code == 500
+
+    def test_404_still_catchable_by_status_code(self) -> None:
+        # entity_summaries() and friends catch HTTPStatusError and check
+        # response.status_code == 404 — the enriched error must preserve that.
+        adapter = _make_error_adapter(404, {"detail": "not found"})
+
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            adapter._request("GET", "/api/v1/missing")
+
+        assert exc_info.value.response.status_code == 404


### PR DESCRIPTION
## Summary
- `HttpAdapter._request()` and `update_agent_profile()` now include the server's JSON `detail` (or `error`) in the raised `httpx.HTTPStatusError` message instead of the bare "409 Conflict for url ..."
- This is what blocked the invited-user flow in production: the 409 agent-identity-collision guard returns actionable guidance ("set a unique agent identity and retry"), but the MCP agent only ever saw "409 Conflict" and couldn't self-correct
- Exception type is unchanged, so existing `except httpx.HTTPStatusError` handlers that branch on `response.status_code` (404 fallbacks etc.) keep working