### PR TITLE
Bump amfs-adapter-http to 0.1.6

### DIFF
--- a/packages/adapters/http/pyproject.toml
+++ b/packages/adapters/http/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-adapter-http"
-version = "0.1.5"
+version = "0.1.6"
 description = "AMFS HTTP adapter — routes memory operations through the authenticated REST API"
 requires-python = ">=3.11"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Version bump to release the error-detail surfacing from #271 to PyPI (auto-publish only fires on pyproject.toml changes on main)
- Once merged, `uvx --refresh amfs-mcp-server-pro` clients pick up 0.1.6 automatically via the `amfs-adapter-http>=0.1.4` floor