### PR TITLE
Measure recalled content size for savings estimates

### DIFF
--- a/packages/adapters/postgres/pyproject.toml
+++ b/packages/adapters/postgres/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-adapter-postgres"
-version = "0.1.7"
+version = "0.1.8"
 description = "AMFS Postgres adapter with back-propagation triggers"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -67,6 +67,21 @@ logger = logging.getLogger(__name__)
 
 _SCHEMA_SQL = (Path(__file__).parent / "schema.sql").read_text(encoding="utf-8")
 
+# SQL mirror of amfs_core.aggregates.recall_tokens_saved: per reuse, credit
+# the measured content size (~CHARS_PER_TOKEN chars/token) clamped to
+# [floor, ceil]. Constants are imported so SQL and Python can't drift.
+from amfs_core.aggregates import (  # noqa: E402
+    CHARS_PER_TOKEN as _CHARS_PER_TOKEN,
+    RECALL_TOKENS_CEIL as _RECALL_TOKENS_CEIL,
+    RECALL_TOKENS_FLOOR as _RECALL_TOKENS_FLOOR,
+)
+
+_RECALLED_TOKENS_SQL = (
+    "COALESCE(SUM(recall_count * LEAST(GREATEST("
+    f"length(value::text) / {_CHARS_PER_TOKEN}, {_RECALL_TOKENS_FLOOR}), "
+    f"{_RECALL_TOKENS_CEIL})), 0)"
+)
+
 
 class _SingleConnectionPool:
     """Minimal pool shim wrapping a single connection for environments
@@ -1735,7 +1750,8 @@ class PostgresAdapter(AdapterABC):
                    -- is always 0 here — matching entity_summaries_from_entries,
                    -- which sees content_hash=None on every Postgres row.
                    0::bigint AS hashed_count,
-                   COALESCE(SUM(recall_count), 0) AS total_recalls
+                   COALESCE(SUM(recall_count), 0) AS total_recalls,
+                   {_RECALLED_TOKENS_SQL} AS recalled_tokens_saved
             FROM amfs_memory_entries
             WHERE {where}
             GROUP BY entity_path
@@ -1756,6 +1772,7 @@ class PostgresAdapter(AdapterABC):
                 "agents": sorted(r["agents"] or []),
                 "hashed_count": r["hashed_count"],
                 "total_recalls": int(r["total_recalls"] or 0),
+                "recalled_tokens_saved": int(r["recalled_tokens_saved"] or 0),
             }
             for r in rows
         ]
@@ -1788,6 +1805,7 @@ class PostgresAdapter(AdapterABC):
                         MIN(written_at) AS oldest_entry_at,
                         MAX(written_at) AS newest_entry_at,
                         COALESCE(SUM(recall_count), 0) AS total_recalls,
+                        {_RECALLED_TOKENS_SQL} AS recalled_tokens_saved,
                         COUNT(*) FILTER (WHERE written_at >= NOW() - INTERVAL '7 days')
                             AS entries_this_week,
                         COUNT(*) FILTER (
@@ -1882,6 +1900,7 @@ class PostgresAdapter(AdapterABC):
             "oldest_entry_at": row["oldest_entry_at"] if row else None,
             "newest_entry_at": row["newest_entry_at"] if row else None,
             "total_recalls": int(row["total_recalls"]) if row else 0,
+            "recalled_tokens_saved": int(row["recalled_tokens_saved"]) if row else 0,
             "entries_this_week": row["entries_this_week"] if row else 0,
             "entries_last_week": row["entries_last_week"] if row else 0,
             "memory_type_counts": {

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-core"
-version = "0.3.8"
+version = "0.3.9"
 description = "AMFS core models, engine, and adapter ABC"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/core/src/amfs_core/aggregates.py
+++ b/packages/core/src/amfs_core/aggregates.py
@@ -8,11 +8,39 @@ Python fallback and the filtered path always agree.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from amfs_core.models import DecisionTrace, MemoryEntry
+
+
+# ── Recall-weighted "avoided re-research" token credit ─────────────────
+# Per reuse we credit the measured content size (~4 chars/token), clamped:
+# - floor: even a tiny memory replaces *some* lookup work, but a one-line
+#   preference must not be credited like a re-derived investigation;
+# - ceil: a single huge payload can't inflate the estimate — re-deriving one
+#   memory realistically costs a few file reads + searches, no more.
+# Dashboards and the MCP value ledger surface these numbers to users, so the
+# same constants are mirrored in the Postgres adapter SQL, the dashboard's
+# value-metrics.ts, and the MCP server's value_ledger.py. Keep them in sync.
+RECALL_TOKENS_FLOOR = 200
+RECALL_TOKENS_CEIL = 4000
+CHARS_PER_TOKEN = 4
+
+
+def recall_tokens_saved(entry: "MemoryEntry") -> int:
+    """Estimated tokens of re-research avoided by this entry's recalls."""
+    recalls = entry.recall_count or 0
+    if recalls <= 0:
+        return 0
+    try:
+        chars = len(json.dumps(entry.value, default=str))
+    except (TypeError, ValueError):
+        chars = len(str(entry.value))
+    per_recall = min(max(chars // CHARS_PER_TOKEN, RECALL_TOKENS_FLOOR), RECALL_TOKENS_CEIL)
+    return recalls * per_recall
 
 
 def entity_summaries_from_entries(entries: "list[MemoryEntry]") -> list[dict]:
@@ -36,6 +64,7 @@ def entity_summaries_from_entries(entries: "list[MemoryEntry]") -> list[dict]:
                 "agents": sorted({e.provenance.agent_id for e in group}),
                 "hashed_count": sum(1 for e in group if e.content_hash),
                 "total_recalls": sum(e.recall_count for e in group),
+                "recalled_tokens_saved": sum(recall_tokens_saved(e) for e in group),
             }
         )
     summaries.sort(key=lambda s: s["last_updated"], reverse=True)
@@ -54,6 +83,7 @@ def extended_stats_from_entries(entries: "list[MemoryEntry]") -> dict:
     confidences: list[float] = []
     outcome_linked = 0
     total_recalls = 0
+    recalled_tokens = 0
     this_week = 0
     last_week = 0
     oldest: datetime | None = None
@@ -69,6 +99,7 @@ def extended_stats_from_entries(entries: "list[MemoryEntry]") -> dict:
         if entry.outcome_count > 0:
             outcome_linked += 1
         total_recalls += entry.recall_count
+        recalled_tokens += recall_tokens_saved(entry)
         written = entry.provenance.written_at
         if written >= week_ago:
             this_week += 1
@@ -92,6 +123,7 @@ def extended_stats_from_entries(entries: "list[MemoryEntry]") -> dict:
         "oldest_entry_at": oldest,
         "newest_entry_at": newest,
         "total_recalls": total_recalls,
+        "recalled_tokens_saved": recalled_tokens,
         "entries_this_week": this_week,
         "entries_last_week": last_week,
         # Entries carry only a recall counter, not recall timestamps, so the

--- a/packages/http-server/pyproject.toml
+++ b/packages/http-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-http-server"
-version = "0.3.8"
+version = "0.3.9"
 description = "AMFS HTTP/REST API server with SSE support"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -2559,7 +2559,10 @@ async def agent_memory_graph(
     # How many times this agent's own saved knowledge was recalled. This is the
     # reliable reuse signal (recall_count is incremented on every read), unlike
     # timeline read events which are not recorded on every deployment.
+    from amfs_core.aggregates import recall_tokens_saved
+
     total_recalls = sum(getattr(e, "recall_count", 0) for e in written_by_agent)
+    recalled_tokens_saved = sum(recall_tokens_saved(e) for e in written_by_agent)
 
     # Build read counts from both traces (causal_entries) and timeline events.
     read_entities: dict[str, dict[str, int]] = {}
@@ -2623,6 +2626,7 @@ async def agent_memory_graph(
         "totalWritten": len(written_by_agent),
         "totalReads": total_read_events,
         "totalRecalls": total_recalls,
+        "recalledTokensSaved": recalled_tokens_saved,
         "crossAgentReads": cross_agent_reads,
     }
 

--- a/tests/unit/test_aggregate_endpoints.py
+++ b/tests/unit/test_aggregate_endpoints.py
@@ -18,8 +18,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from amfs_core.aggregates import (
+    CHARS_PER_TOKEN,
+    RECALL_TOKENS_CEIL,
+    RECALL_TOKENS_FLOOR,
     entity_summaries_from_entries,
     extended_stats_from_entries,
+    recall_tokens_saved,
     share_stats_from_traces,
 )
 from amfs_core.models import (
@@ -119,6 +123,37 @@ class TestEntitySummaries:
         assert by_path["repo/a"]["total_recalls"] == 7
         assert by_path["repo/b"]["total_recalls"] == 9
 
+    def test_sums_recalled_tokens_per_entity(self) -> None:
+        entries = [
+            _entry("repo/a", "k1", "agent-a", recall_count=3, written_at=NOW),
+            _entry("repo/a", "k2", "agent-b", recall_count=0, written_at=NOW),
+        ]
+        by_path = {s["entity_path"]: s for s in entity_summaries_from_entries(entries)}
+        # Tiny {"v": 1} values hit the per-reuse floor; unrecalled entries add 0.
+        assert by_path["repo/a"]["recalled_tokens_saved"] == 3 * RECALL_TOKENS_FLOOR
+
+
+class TestRecallTokensSaved:
+    def test_zero_when_never_recalled(self) -> None:
+        assert recall_tokens_saved(_entry(recall_count=0)) == 0
+
+    def test_floored_for_tiny_content(self) -> None:
+        # A one-line value must not be credited like a re-derived investigation,
+        # but still counts for the floor.
+        assert recall_tokens_saved(_entry(recall_count=2)) == 2 * RECALL_TOKENS_FLOOR
+
+    def test_measured_for_real_content(self) -> None:
+        entry = _entry(recall_count=1)
+        entry.value = {"doc": "x" * (3 * RECALL_TOKENS_FLOOR * CHARS_PER_TOKEN)}
+        expected = len(__import__("json").dumps(entry.value)) // CHARS_PER_TOKEN
+        assert recall_tokens_saved(entry) == expected
+        assert recall_tokens_saved(entry) > RECALL_TOKENS_FLOOR
+
+    def test_capped_for_huge_content(self) -> None:
+        entry = _entry(recall_count=1)
+        entry.value = "x" * (50 * RECALL_TOKENS_CEIL * CHARS_PER_TOKEN)
+        assert recall_tokens_saved(entry) == RECALL_TOKENS_CEIL
+
 
 class TestExtendedStats:
     def test_counts_recalls_and_weekly_delta(self) -> None:
@@ -146,6 +181,8 @@ class TestExtendedStats:
         assert stats["total_entities"] == 2
         assert stats["total_agents"] == 2
         assert stats["total_recalls"] == 7
+        # Tiny values hit the per-reuse floor: 7 recalls × floor.
+        assert stats["recalled_tokens_saved"] == 7 * RECALL_TOKENS_FLOOR
         assert stats["entries_this_week"] == 1
         assert stats["entries_last_week"] == 1
         assert stats["outcome_linked_count"] == 1


### PR DESCRIPTION
## Summary
- New `recalled_tokens_saved` aggregate: per reuse, the measured recalled content size (~4 chars/token) clamped to [200, 4,000] tokens — replaces the flat 1,000-token-per-recall assumption that inflated savings for tiny memories
- Single source of truth in `amfs_core.aggregates` (`recall_tokens_saved` + constants); Postgres SQL mirror is built from the same constants so they can't drift
- Exposed on `/api/v1/stats` (both the SQL path and the visibility-filtered Python path), `/api/v1/entities`, and `/api/v1/agents/{id}/memory-graph` (`recalledTokensSaved`)
- Version bumps (core 0.3.9, postgres adapter 0.1.8, http-server 0.3.9) so auto-publish ships the field