### PR TITLE
Add histograms toggle to enriched agents endpoint

### DIFF
--- a/packages/http-server/pyproject.toml
+++ b/packages/http-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-http-server"
-version = "0.3.9"
+version = "0.3.10"
 description = "AMFS HTTP/REST API server with SSE support"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -2936,9 +2936,15 @@ async def upsert_graph_edge_endpoint(
 @app.get("/api/v1/agents/enriched")
 async def list_agents_enriched(
     request: Request,
+    histograms: bool = True,
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
-    """Return enriched agent info with activity histograms."""
+    """Return enriched agent info with activity histograms.
+
+    Pass histograms=false to skip the per-agent activity histogram queries —
+    summary consumers (e.g. the dashboard overview's agent count) only need
+    the roster, and the histograms cost up to 100 extra queries per call.
+    """
     mem = _get_memory()
     agents = mem._adapter.list_agents_enriched(namespace=mem.namespace)
     allowed = _visible_agent_ids(request)
@@ -2947,12 +2953,13 @@ async def list_agents_enriched(
             a for a in agents
             if (a.get("agent_id") or a.get("agentId", "")) in allowed
         ]
-    for agent in agents[:100]:
-        aid = agent.get("agent_id") or agent.get("agentId", "")
-        if aid:
-            agent["activity_histogram"] = mem._adapter.get_agent_activity_histogram(
-                aid, days=7, namespace=mem.namespace,
-            )
+    if histograms:
+        for agent in agents[:100]:
+            aid = agent.get("agent_id") or agent.get("agentId", "")
+            if aid:
+                agent["activity_histogram"] = mem._adapter.get_agent_activity_histogram(
+                    aid, days=7, namespace=mem.namespace,
+                )
     return {"agents": agents}
 
 


### PR DESCRIPTION
## Summary
- Adds a `histograms` query param (default `true`) to `GET /api/v1/agents/enriched` so lightweight consumers can skip the per-agent activity-histogram queries (up to 100 extra queries per call).
- Needed by the dashboard overview, which is being switched to the registry-backed agent roster so its "Agents remembering" count matches the Agents page (they currently disagree: entries-derived writers vs registered agents).
- Bumps `amfs-http-server` to 0.3.10.
