### PR TITLE
feat(install): PowerShell installer for native Windows MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,18 @@ Drop AMFS into whatever you're already using. No rewrites. Your agents start sha
 <details>
 <summary><strong>MCP — Cursor, Claude Desktop, Claude Code</strong></summary>
 
-One command to give any MCP-compatible client persistent agent memory:
+One command to give any MCP-compatible client persistent agent memory.
+
+macOS / Linux:
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/raia-live/amfs/main/install-mcp.sh | bash
+```
+
+Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/raia-live/amfs/main/install-mcp.ps1 | iex
 ```
 
 Or add manually to your MCP config:

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -21,16 +21,27 @@ AMFS provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)
 
 ## Quick Install
 
-The fastest way to set up AMFS MCP — one command that installs everything and configures your IDE automatically:
+The fastest way to set up AMFS MCP — one command that installs everything and configures your IDE automatically.
+
+**macOS / Linux:**
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/raia-live/amfs/main/install-mcp.sh | bash
 ```
 
-This will:
+**Windows (PowerShell):**
+
+```powershell
+irm https://raw.githubusercontent.com/raia-live/amfs/main/install-mcp.ps1 | iex
+```
+
+Either script will:
 1. Install [`uv`](https://docs.astral.sh/uv/) if you don't have it
 2. Install the `amfs-mcp-server` package
 3. Detect your installed MCP clients (Cursor, Claude Desktop, Claude Code, Windsurf, VS Code) and configure them
+
+{: .note }
+Windows users running Claude Code under WSL should use the macOS/Linux command instead — WSL is a Linux environment. Use the PowerShell script only for native Windows installs.
 
 ### Connecting to AMFS SaaS
 
@@ -38,6 +49,18 @@ Pass your API key to connect to hosted AMFS:
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/raia-live/amfs/main/install-mcp.sh | bash -s -- --api-key <your-key>
+```
+
+On Windows, `irm | iex` cannot forward arguments, so pass the key through the environment:
+
+```powershell
+$env:AMFS_API_KEY="<your-key>"; irm https://raw.githubusercontent.com/raia-live/amfs/main/install-mcp.ps1 | iex
+```
+
+Or invoke the script as a scriptblock to pass parameters explicitly:
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/raia-live/amfs/main/install-mcp.ps1))) -ApiKey <your-key>
 ```
 
 ### Non-interactive / CI
@@ -55,6 +78,15 @@ curl -sSL ... | bash -s -- --uninstall
 ```
 
 Supported `--client` values: `claude-desktop`, `cursor`, `claude-code`, `windsurf`, `vscode`, `all`.
+
+On Windows the same options are PowerShell parameters (`-Client`, `-ApiKey`, `-Yes`, `-Uninstall`), which requires downloading the script first so arguments can be passed:
+
+```powershell
+irm https://raw.githubusercontent.com/raia-live/amfs/main/install-mcp.ps1 -OutFile install-mcp.ps1
+.\install-mcp.ps1 -Client cursor
+.\install-mcp.ps1 -Client all -Yes -ApiKey <your-key>
+.\install-mcp.ps1 -Uninstall
+```
 
 {: .note }
 Prefer the quick installer above. The manual sections below are for advanced setups or unsupported clients.
@@ -114,7 +146,10 @@ After setup, your AI agents have tools across five categories:
 
 ## AMFS Pro (SaaS) and Cursor
 
-On **Sense Lab**, the AMFS dashboard (**Agents** page, MCP Connection card) is the source of truth. Cursor talks to hosted AMFS by running the **`amfs-mcp-server`** process locally with **stdio** (e.g. `uvx`), while the server uses **`AMFS_HTTP_URL`** (dashboard **Server URL**, e.g. `https://amfs-login.sense-lab.ai`) and **`AMFS_API_KEY`** to call the HTTP API. That URL is the **API base**, not an MCP Streamable HTTP path—there is **no `/mcp`** on it for this setup. The `/mcp` path applies only when you run the MCP server in **HTTP transport mode** as its own listening service (see [Streamable HTTP](#streamable-http-team--remote) below).
+On **Sense Lab**, the AMFS dashboard (**Agents** page, MCP Connection card) is the source of truth. Cursor talks to hosted AMFS by running the **`amfs-mcp-server`** process locally with **stdio** (e.g. `uvx`), while the server uses **`AMFS_HTTP_URL`** (dashboard **Server URL**, e.g. `https://amfs-login.sense-lab.ai`) and **`AMFS_API_KEY`** to call the HTTP API. In this setup `AMFS_HTTP_URL` is the **API base** and must not include a path.
+
+{: .note }
+The hosted API *does* also serve a Streamable HTTP MCP endpoint at **`/mcp`** (authenticate with `Authorization: Bearer <amfs_key>` or `X-AMFS-API-Key`), which needs no local process at all. It exposes a **minimal tool set** intended for app-building sessions, so features such as **Rooms**, negotiations, identity, and trace browsing are **not** available there. Use the stdio setup below for the full tool set.
 
 Use the official **[Cursor plugin](https://github.com/raia-live/cursor-plugin)** (same shape as the dashboard JSON) or copy the snippet from the dashboard. Set **`AMFS_API_KEY`** in your environment and reference it with [Cursor interpolation](https://cursor.com/docs/mcp.md#config-interpolation). See also [SaaS / hosted AMFS](https://raia-live.github.io/amfs/guides/saas/).
 

--- a/install-mcp.ps1
+++ b/install-mcp.ps1
@@ -1,0 +1,642 @@
+# AMFS / SenseLab MCP Installer (Windows)
+#
+# One-line install:
+#   powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/raia-live/amfs/main/install-mcp.ps1 | iex"
+#
+# With a SaaS API key (simplest form — set the env var first, the script picks it up):
+#   $env:AMFS_API_KEY="amfs_sk_your_key"
+#   powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/raia-live/amfs/main/install-mcp.ps1 | iex"
+#
+# Or pass parameters explicitly (needed because `irm | iex` cannot forward args):
+#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/raia-live/amfs/main/install-mcp.ps1))) -ApiKey amfs_sk_your_key
+#
+# This is the Windows counterpart of install-mcp.sh and is kept behaviourally in
+# sync with it: same "senselab" server name, same client list, same
+# marker-delimited instruction blocks.
+
+param(
+    [string]$Client = "",
+    [string]$ApiKey = "",
+    [string]$ApiUrl = "",
+    [switch]$Uninstall,
+    [switch]$Yes,
+    [switch]$Help
+)
+
+$ErrorActionPreference = "Stop"
+
+$AmfsDefaultApiUrl = "https://amfs-login.sense-lab.ai"
+$AmfsServerName    = "senselab"
+
+# Env-var fallbacks so the plain `irm | iex` form can still reach SaaS.
+if ([string]::IsNullOrWhiteSpace($ApiKey)) { $ApiKey = "$env:AMFS_API_KEY" }
+if ([string]::IsNullOrWhiteSpace($ApiUrl)) { $ApiUrl = "$env:AMFS_HTTP_URL" }
+if ([string]::IsNullOrWhiteSpace($ApiUrl)) { $ApiUrl = $AmfsDefaultApiUrl }
+
+# ── Output helpers ───────────────────────────────────────────────────────────
+
+function Write-Info    { param([string]$Message) Write-Host "==> " -ForegroundColor Blue   -NoNewline; Write-Host $Message }
+function Write-Ok      { param([string]$Message) Write-Host "==> " -ForegroundColor Green  -NoNewline; Write-Host $Message }
+function Write-Warn    { param([string]$Message) Write-Host "==> " -ForegroundColor Yellow -NoNewline; Write-Host $Message }
+function Write-Err     { param([string]$Message) Write-Host "==> " -ForegroundColor Red    -NoNewline; Write-Host $Message }
+function Stop-WithError { param([string]$Message) Write-Err $Message; exit 1 }
+
+if ($Help) {
+    Write-Host @"
+AMFS / SenseLab MCP Installer (Windows)
+
+Usage:
+  powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/raia-live/amfs/main/install-mcp.ps1 | iex"
+  .\install-mcp.ps1 [OPTIONS]
+
+Options:
+  -Client <name|all>   Configure a specific client: claude-desktop, cursor,
+                       claude-code, codex, windsurf, vscode, or "all"
+  -ApiKey <key>        Connect to AMFS SaaS with this API key
+                       (or set `$env:AMFS_API_KEY)
+  -ApiUrl <url>        SaaS API URL (default: $AmfsDefaultApiUrl)
+  -Uninstall           Remove AMFS MCP config from clients
+  -Yes                 Skip confirmation prompts
+  -Help                Show this help
+"@
+    exit 0
+}
+
+if ($PSVersionTable.PSVersion.Major -lt 5) {
+    Stop-WithError "PowerShell 5.1 or newer is required (found $($PSVersionTable.PSVersion))."
+}
+
+$HasApiKey = -not [string]::IsNullOrWhiteSpace($ApiKey)
+$AmfsPackage = if ($HasApiKey) { "amfs-mcp-server-pro" } else { "amfs-mcp-server" }
+
+$KnownClients = @("claude-desktop", "cursor", "claude-code", "codex", "windsurf", "vscode")
+if (-not [string]::IsNullOrWhiteSpace($Client) -and $Client -ne "all" -and $KnownClients -notcontains $Client) {
+    Stop-WithError "Unknown client '$Client'. Valid values: $($KnownClients -join ', '), all"
+}
+
+# ── Step 1: ensure uv is installed ───────────────────────────────────────────
+
+function Update-SessionPath {
+    # uv's installer writes to the *user* PATH in the registry; the running
+    # process won't see it without this refresh.
+    $machine = [Environment]::GetEnvironmentVariable("Path", "Machine")
+    $user    = [Environment]::GetEnvironmentVariable("Path", "User")
+    $env:Path = (@($machine, $user, "$env:USERPROFILE\.local\bin") | Where-Object { $_ }) -join ";"
+}
+
+function Get-UvxPath {
+    $cmd = Get-Command uvx -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+
+    # Fall back to the default install location in case PATH is still stale.
+    $fallback = Join-Path $env:USERPROFILE ".local\bin\uvx.exe"
+    if (Test-Path $fallback) { return $fallback }
+
+    return $null
+}
+
+function Install-UvIfMissing {
+    if (Get-UvxPath) {
+        Write-Ok "uv is already installed ($(& (Get-UvxPath) --version 2>$null))"
+        return
+    }
+
+    Write-Info "uv not found - installing..."
+    try {
+        Invoke-RestMethod https://astral.sh/uv/install.ps1 | Invoke-Expression
+    } catch {
+        Stop-WithError @"
+Failed to install uv automatically: $($_.Exception.Message)
+
+Install it manually with one of these, then re-run this script:
+  winget install --id=astral-sh.uv -e
+  scoop install uv
+"@
+    }
+
+    Update-SessionPath
+
+    if (-not (Get-UvxPath)) {
+        Stop-WithError "uv was installed but uvx could not be found on PATH. Open a new PowerShell window and run this script again."
+    }
+
+    Write-Ok "uv installed successfully ($(& (Get-UvxPath) --version 2>$null))"
+}
+
+# ── Step 2: pre-warm the amfs-mcp-server package ─────────────────────────────
+
+function Install-AmfsPackage {
+    $uvx = Get-UvxPath
+    Write-Info "Installing $AmfsPackage..."
+    try {
+        # --refresh so the warm-up pulls the latest published build, matching the
+        # --refresh the generated client config uses at launch.
+        & $uvx --refresh --from $AmfsPackage $AmfsPackage --help *> $null
+    } catch {
+        # Non-fatal: the client will fetch it on first launch. Warn only.
+        Write-Warn "Could not pre-install $AmfsPackage - it will be fetched on first use."
+        return
+    }
+    Write-Ok "$AmfsPackage is ready"
+}
+
+# ── Client config paths ──────────────────────────────────────────────────────
+
+function Get-ClaudeDesktopConfigPath { Join-Path $env:APPDATA "Claude\claude_desktop_config.json" }
+function Get-CursorConfigPath        { Join-Path $env:USERPROFILE ".cursor\mcp.json" }
+function Get-WindsurfConfigPath      { Join-Path $env:USERPROFILE ".windsurf\mcp.json" }
+function Get-VSCodeConfigPath        { Join-Path $env:USERPROFILE ".vscode\mcp.json" }
+
+# ── MCP server block ─────────────────────────────────────────────────────────
+
+function Get-McpServerBlock {
+    $uvx = Get-UvxPath
+    if (-not $uvx) { $uvx = "uvx" }
+
+    # --refresh forces uvx to re-resolve from PyPI on each launch instead of
+    # reusing a stale cached environment. Without it, a user who ever ran an
+    # older build keeps getting it forever - even after we publish a fix - so
+    # retrieval can stay broken across releases. The small per-launch re-resolve
+    # cost is worth never serving a stale MCP server.
+    $block = [ordered]@{
+        command = $uvx
+        args    = @("--refresh", $AmfsPackage)
+    }
+
+    if ($HasApiKey) {
+        $block["env"] = [ordered]@{
+            AMFS_HTTP_URL = $ApiUrl
+            AMFS_API_KEY  = $ApiKey
+        }
+    } else {
+        $block["env"] = [ordered]@{}
+    }
+
+    return $block
+}
+
+# ── JSON merge ───────────────────────────────────────────────────────────────
+
+function ConvertTo-OrderedHashtable {
+    # ConvertFrom-Json returns PSCustomObjects and PS 5.1 has no -AsHashtable,
+    # so convert manually to keep existing config keys editable and ordered.
+    param($InputObject)
+
+    if ($null -eq $InputObject) { return $null }
+
+    if ($InputObject -is [System.Management.Automation.PSCustomObject]) {
+        $result = [ordered]@{}
+        foreach ($property in $InputObject.PSObject.Properties) {
+            $result[$property.Name] = ConvertTo-OrderedHashtable $property.Value
+        }
+        return $result
+    }
+
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        $result = [ordered]@{}
+        foreach ($key in $InputObject.Keys) {
+            $result[$key] = ConvertTo-OrderedHashtable $InputObject[$key]
+        }
+        return $result
+    }
+
+    if ($InputObject -is [object[]]) {
+        $items = @(foreach ($item in $InputObject) { ConvertTo-OrderedHashtable $item })
+        # The comma stops PowerShell unrolling a one-element array back into a
+        # scalar on return, which would rewrite a neighbouring server's
+        # "args": ["x"] as "args": "x" and break it.
+        return ,$items
+    }
+
+    return $InputObject
+}
+
+function Read-JsonFile {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) { return [ordered]@{} }
+
+    $raw = Get-Content -Path $Path -Raw -Encoding UTF8
+    if ([string]::IsNullOrWhiteSpace($raw)) { return [ordered]@{} }
+
+    $parsed = $null
+    try {
+        $parsed = ConvertTo-OrderedHashtable (ConvertFrom-Json $raw)
+    } catch {
+        $parsed = $null
+    }
+
+    if ($parsed -isnot [System.Collections.IDictionary]) {
+        Write-Warn "$Path is not a valid JSON object - backing it up to $Path.amfs-backup and starting fresh."
+        Copy-Item -Path $Path -Destination "$Path.amfs-backup" -Force
+        return [ordered]@{}
+    }
+
+    return $parsed
+}
+
+function Write-JsonFile {
+    param([string]$Path, $Data)
+
+    $directory = Split-Path -Parent $Path
+    if ($directory -and -not (Test-Path $directory)) {
+        New-Item -ItemType Directory -Force -Path $directory | Out-Null
+    }
+
+    $json = ConvertTo-Json $Data -Depth 20
+    # Write UTF-8 without BOM: some MCP clients reject a BOM'd config file.
+    [System.IO.File]::WriteAllText($Path, $json + "`n", (New-Object System.Text.UTF8Encoding($false)))
+}
+
+function Set-McpConfig {
+    param([string]$Path)
+
+    $config = Read-JsonFile -Path $Path
+    if (-not $config.Contains("mcpServers") -or $config["mcpServers"] -isnot [System.Collections.IDictionary]) {
+        $config["mcpServers"] = [ordered]@{}
+    }
+    $config["mcpServers"][$AmfsServerName] = Get-McpServerBlock
+    Write-JsonFile -Path $Path -Data $config
+}
+
+function Remove-McpConfig {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) { return }
+
+    $config = Read-JsonFile -Path $Path
+    if ($config.Contains("mcpServers") -and
+        $config["mcpServers"] -is [System.Collections.IDictionary] -and
+        $config["mcpServers"].Contains($AmfsServerName)) {
+        $config["mcpServers"].Remove($AmfsServerName)
+        Write-JsonFile -Path $Path -Data $config
+    }
+}
+
+# ── SenseLab memory instructions ─────────────────────────────────────────────
+#
+# Mirrors install-mcp.sh: a recall-first guide is written into the clients that
+# auto-load on-disk instructions (Claude Code skill + ~/.claude/CLAUDE.md, and
+# ~/.codex/AGENTS.md). Marker-delimited so re-runs replace rather than duplicate.
+
+$SenseLabMarkerBegin = "<!-- >>> senselab-memory >>> -->"
+$SenseLabMarkerEnd   = "<!-- <<< senselab-memory <<< -->"
+
+$SenseLabInstructions = @'
+## SenseLab memory (recall-first)
+
+You are connected to SenseLab (AMFS), a persistent memory shared across all your
+tools and sessions. Use it proactively:
+
+- **Start of session:** call `amfs_set_identity`, then `amfs_briefing(entity_path="repo/module")` for compiled context before working in a codebase.
+- **RECALL-FIRST (do not skip):** whenever the user asks what you know / remember / have saved about ANYTHING - including personal facts and preferences ("what food do I like?") - call `amfs_retrieve(query="<the user's words>")` BEFORE answering. `entity_path`/`key` are optional; it searches by meaning across everything you can see. Never tell the user you have no memory of something without running `amfs_retrieve` first.
+- **Remember things:** when the user shares a durable fact, preference, or decision, or says "remember...", call `amfs_write(entity_path, key, value)`.
+- `amfs_read`/`amfs_recall` need an EXACT key - a miss there means "try `amfs_retrieve`", NOT "nothing is stored".
+'@
+
+function Remove-SenseLabBlockText {
+    param([string]$Content)
+
+    if ($Content.Contains($SenseLabMarkerBegin) -and $Content.Contains($SenseLabMarkerEnd)) {
+        $before = $Content.Substring(0, $Content.IndexOf($SenseLabMarkerBegin))
+        $endIndex = $Content.IndexOf($SenseLabMarkerEnd) + $SenseLabMarkerEnd.Length
+        $after = $Content.Substring($endIndex)
+        return ($before.TrimEnd("`r", "`n") + "`n`n" + $after.TrimStart("`r", "`n")).Trim("`r", "`n")
+    }
+    return $Content
+}
+
+function Set-SenseLabBlock {
+    param([string]$Path)
+
+    $directory = Split-Path -Parent $Path
+    if ($directory -and -not (Test-Path $directory)) {
+        New-Item -ItemType Directory -Force -Path $directory | Out-Null
+    }
+
+    $content = ""
+    if (Test-Path $Path) {
+        $content = Get-Content -Path $Path -Raw -Encoding UTF8
+        if ($null -eq $content) { $content = "" }
+        $content = Remove-SenseLabBlockText -Content $content
+    }
+
+    $block = $SenseLabMarkerBegin + "`n" + $SenseLabInstructions.TrimEnd() + "`n" + $SenseLabMarkerEnd
+    $prefix = if ($content.Trim()) { $content.TrimEnd("`r", "`n") + "`n`n" } else { "" }
+
+    [System.IO.File]::WriteAllText($Path, $prefix + $block + "`n", (New-Object System.Text.UTF8Encoding($false)))
+}
+
+function Remove-SenseLabBlock {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) { return }
+
+    $content = Get-Content -Path $Path -Raw -Encoding UTF8
+    if ($null -eq $content) { return }
+
+    $cleaned = Remove-SenseLabBlockText -Content $content
+    if ($cleaned -ne $content) {
+        $suffix = if ($cleaned) { "`n" } else { "" }
+        [System.IO.File]::WriteAllText($Path, $cleaned + $suffix, (New-Object System.Text.UTF8Encoding($false)))
+    }
+}
+
+function Install-ClaudeCodeSkill {
+    $skillDirectory = Join-Path $env:USERPROFILE ".claude\skills\senselab-memory"
+    if (-not (Test-Path $skillDirectory)) {
+        New-Item -ItemType Directory -Force -Path $skillDirectory | Out-Null
+    }
+
+    $frontmatter = @'
+---
+name: senselab-memory
+description: Use SenseLab (AMFS) as persistent memory. When the user asks what you know/remember/have saved about anything (including personal preferences), call amfs_retrieve BEFORE answering; save durable facts with amfs_write.
+---
+'@
+
+    $skillPath = Join-Path $skillDirectory "SKILL.md"
+    $body = $frontmatter + "`n`n" + $SenseLabInstructions.TrimEnd() + "`n"
+    [System.IO.File]::WriteAllText($skillPath, $body, (New-Object System.Text.UTF8Encoding($false)))
+}
+
+function Remove-ClaudeCodeSkill {
+    $skillDirectory = Join-Path $env:USERPROFILE ".claude\skills\senselab-memory"
+    if (Test-Path $skillDirectory) {
+        Remove-Item -Path $skillDirectory -Recurse -Force
+    }
+}
+
+# ── CLI client helpers (Claude Code / Codex) ─────────────────────────────────
+
+function Invoke-Cli {
+    # `claude` and `codex` are usually .cmd shims on Windows, which need to be
+    # invoked through cmd.exe rather than spawned directly.
+    param([string]$Exe, [string[]]$CliArgs)
+
+    $command = Get-Command $Exe -ErrorAction SilentlyContinue
+    if (-not $command) { return $false }
+
+    $target = $command.Source
+    if ($target -match '\.(cmd|bat)$') {
+        & cmd.exe /c $target @CliArgs
+    } else {
+        & $target @CliArgs
+    }
+    return ($LASTEXITCODE -eq 0)
+}
+
+function Test-CliExists {
+    param([string]$Exe)
+    return [bool](Get-Command $Exe -ErrorAction SilentlyContinue)
+}
+
+# ── Client detection ─────────────────────────────────────────────────────────
+
+function Get-DetectedClients {
+    $detected = @()
+
+    if (Test-Path (Split-Path -Parent (Get-ClaudeDesktopConfigPath))) { $detected += "claude-desktop" }
+    if (Test-Path (Join-Path $env:USERPROFILE ".cursor"))             { $detected += "cursor" }
+    if (Test-CliExists "claude")                                      { $detected += "claude-code" }
+    if (Test-CliExists "codex")                                       { $detected += "codex" }
+    if (Test-Path (Split-Path -Parent (Get-WindsurfConfigPath)))       { $detected += "windsurf" }
+    if (Test-Path (Join-Path $env:USERPROFILE ".vscode"))             { $detected += "vscode" }
+
+    return $detected
+}
+
+# ── Configure a single client ────────────────────────────────────────────────
+
+function Set-ClientConfig {
+    param([string]$Name)
+
+    switch ($Name) {
+        "claude-desktop" {
+            $path = Get-ClaudeDesktopConfigPath
+            if ($Uninstall) { Remove-McpConfig $path; Write-Ok "Removed AMFS from Claude Desktop config" }
+            else            { Set-McpConfig $path;    Write-Ok "Configured Claude Desktop ($path)" }
+        }
+        "cursor" {
+            $path = Get-CursorConfigPath
+            if ($Uninstall) { Remove-McpConfig $path; Write-Ok "Removed AMFS from Cursor config" }
+            else            { Set-McpConfig $path;    Write-Ok "Configured Cursor ($path)" }
+        }
+        "claude-code" {
+            if ($Uninstall) {
+                if (Test-CliExists "claude") {
+                    Invoke-Cli "claude" @("mcp", "remove", $AmfsServerName, "--scope", "user") | Out-Null
+                    Write-Ok "Removed AMFS from Claude Code"
+                }
+                Remove-ClaudeCodeSkill
+                Remove-SenseLabBlock (Join-Path $env:USERPROFILE ".claude\CLAUDE.md")
+                break
+            }
+
+            if (-not (Test-CliExists "claude")) {
+                Write-Warn "Claude Code CLI (claude) not found on PATH - skipping"
+                break
+            }
+
+            $uvx = Get-UvxPath
+            if (-not $uvx) { $uvx = "uvx" }
+
+            # Replace any existing entry so re-runs stay idempotent.
+            Invoke-Cli "claude" @("mcp", "remove", $AmfsServerName, "--scope", "user") | Out-Null
+
+            $cliArgs = @("mcp", "add", $AmfsServerName, "--scope", "user")
+            if ($HasApiKey) {
+                $cliArgs += @("-e", "AMFS_HTTP_URL=$ApiUrl", "-e", "AMFS_API_KEY=$ApiKey")
+            }
+            # --refresh is a uvx flag, so it goes before the package name.
+            $cliArgs += @("--", $uvx, "--refresh", $AmfsPackage)
+
+            if (Invoke-Cli "claude" $cliArgs) {
+                Write-Ok "Configured Claude Code (user scope)"
+            } else {
+                Write-Warn "claude mcp add failed - check 'claude mcp list' and retry"
+            }
+
+            Install-ClaudeCodeSkill
+            Set-SenseLabBlock (Join-Path $env:USERPROFILE ".claude\CLAUDE.md")
+            Write-Ok "Installed SenseLab recall-first memory guide (skill + ~\.claude\CLAUDE.md)"
+        }
+        "codex" {
+            if ($Uninstall) {
+                if (Test-CliExists "codex") {
+                    Invoke-Cli "codex" @("mcp", "remove", $AmfsServerName) | Out-Null
+                    Write-Ok "Removed AMFS from Codex"
+                }
+                Remove-SenseLabBlock (Join-Path $env:USERPROFILE ".codex\AGENTS.md")
+                break
+            }
+
+            if (-not (Test-CliExists "codex")) {
+                Write-Warn "Codex CLI (codex) not found on PATH - skipping"
+                break
+            }
+
+            $uvx = Get-UvxPath
+            if (-not $uvx) { $uvx = "uvx" }
+
+            $cliArgs = @("mcp", "add", $AmfsServerName)
+            if ($HasApiKey) {
+                $cliArgs += @("--env", "AMFS_HTTP_URL=$ApiUrl", "--env", "AMFS_API_KEY=$ApiKey")
+            }
+            # --refresh is a uvx flag, so it goes before the package name.
+            $cliArgs += @("--", $uvx, "--refresh", $AmfsPackage)
+
+            Invoke-Cli "codex" @("mcp", "remove", $AmfsServerName) | Out-Null
+            if (Invoke-Cli "codex" $cliArgs) {
+                Write-Ok "Configured Codex"
+            } else {
+                Write-Warn "codex mcp add failed - check 'codex mcp list' and retry"
+            }
+
+            Set-SenseLabBlock (Join-Path $env:USERPROFILE ".codex\AGENTS.md")
+            Write-Ok "Installed SenseLab recall-first memory guide (~\.codex\AGENTS.md)"
+        }
+        "windsurf" {
+            $path = Get-WindsurfConfigPath
+            if ($Uninstall) { Remove-McpConfig $path; Write-Ok "Removed AMFS from Windsurf config" }
+            else            { Set-McpConfig $path;    Write-Ok "Configured Windsurf ($path)" }
+        }
+        "vscode" {
+            $path = Get-VSCodeConfigPath
+            if ($Uninstall) { Remove-McpConfig $path; Write-Ok "Removed AMFS from VS Code config" }
+            else            { Set-McpConfig $path;    Write-Ok "Configured VS Code ($path)" }
+        }
+        default {
+            Write-Err "Unknown client: $Name"
+        }
+    }
+}
+
+function Show-ManualSnippet {
+    Write-Host ""
+    Write-Host "Add this to your MCP client config manually:"
+    Write-Host ""
+    Write-Host (ConvertTo-Json ([ordered]@{ mcpServers = [ordered]@{ $AmfsServerName = (Get-McpServerBlock) } }) -Depth 20)
+    Write-Host ""
+}
+
+# ── Interactive selection ────────────────────────────────────────────────────
+
+function Read-Answer {
+    param([string]$Prompt)
+    try   { return (Read-Host -Prompt $Prompt) }
+    catch { return "" }   # Non-interactive host: fall through to the default.
+}
+
+function Invoke-ClientSelection {
+    $detected = @(Get-DetectedClients)
+
+    if ($detected.Count -eq 0) {
+        Write-Warn "No supported MCP clients detected."
+        Show-ManualSnippet
+        return
+    }
+
+    Write-Host ""
+    Write-Host "Detected MCP clients:" -ForegroundColor White
+    Write-Host ""
+    for ($i = 0; $i -lt $detected.Count; $i++) {
+        Write-Host ("  {0}) {1}" -f ($i + 1), $detected[$i]) -ForegroundColor Green
+    }
+    Write-Host ""
+
+    if ($Yes) {
+        Write-Info "Configuring all detected clients (-Yes)"
+        foreach ($name in $detected) { Set-ClientConfig $name }
+        return
+    }
+
+    $action = if ($Uninstall) { "Remove AMFS from" } else { "Configure" }
+    $answer = (Read-Answer "$action all detected clients? [Y/n/list]").Trim().ToLower()
+
+    switch ($answer) {
+        { $_ -in @("", "y", "yes") } {
+            foreach ($name in $detected) { Set-ClientConfig $name }
+        }
+        { $_ -in @("n", "no") } {
+            Write-Info "Skipped client configuration."
+            Show-ManualSnippet
+        }
+        default {
+            $selections = (Read-Answer "Enter client numbers separated by spaces (e.g. 1 3)").Split(" ")
+            foreach ($selection in $selections) {
+                $index = 0
+                if ([int]::TryParse($selection.Trim(), [ref]$index) -and $index -ge 1 -and $index -le $detected.Count) {
+                    Set-ClientConfig $detected[$index - 1]
+                } elseif ($selection.Trim()) {
+                    Write-Warn "Invalid selection: $selection"
+                }
+            }
+        }
+    }
+}
+
+function Invoke-RequestedClients {
+    if ([string]::IsNullOrWhiteSpace($Client)) {
+        Invoke-ClientSelection
+        return
+    }
+
+    if ($Client -eq "all") {
+        foreach ($name in @(Get-DetectedClients)) { Set-ClientConfig $name }
+    } else {
+        Set-ClientConfig $Client
+    }
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+Write-Host ""
+Write-Host "AMFS MCP Installer" -ForegroundColor White
+Write-Host "------------------"
+Write-Host ""
+
+if ($Uninstall) {
+    Write-Info "Uninstall mode"
+    Invoke-RequestedClients
+    Write-Host ""
+    Write-Ok "AMFS MCP config removed. Restart your IDE to apply."
+    exit 0
+}
+
+Install-UvIfMissing
+Write-Host ""
+
+Install-AmfsPackage
+Write-Host ""
+
+Invoke-RequestedClients
+
+Write-Host ""
+Write-Host "------------------"
+Write-Ok "Done! Restart your IDE/app to connect to AMFS."
+Write-Host ""
+
+if ($HasApiKey) {
+    Write-Info "Connected to AMFS SaaS ($ApiUrl)"
+} else {
+    Write-Info "Using local filesystem storage (~\.amfs\)"
+    Write-Host "  To connect to AMFS SaaS, re-run with -ApiKey <key>"
+}
+Write-Host ""
+
+# Claude Desktop has no writable instructions file, so surface the one manual
+# step that makes it recall proactively like the file-based clients do.
+if (Test-Path (Split-Path -Parent (Get-ClaudeDesktopConfigPath))) {
+    Write-Warn "Claude Desktop: paste this into Settings -> General -> `"Instructions for Claude`" for proactive recall:"
+    Write-Host @'
+  SenseLab is my personal + work memory, connected as the "senselab" MCP connector
+  (tools start with amfs_). It stores everything I ask it to remember - personal facts,
+  preferences, people, plans - not just code. Whenever I ask what I like, prefer, know,
+  remember, or have saved about anything, you MUST call amfs_retrieve with my question
+  first, then answer from what it returns. Never answer from your own memory, and never
+  say something "hasn't come up" or that SenseLab "isn't for that" until you have called
+  amfs_retrieve. When I say "remember..." or share a durable fact, call amfs_write.
+'@
+    Write-Host ""
+}

--- a/install-mcp.ps1
+++ b/install-mcp.ps1
@@ -103,6 +103,13 @@ function Install-UvIfMissing {
 
     Write-Info "uv not found - installing..."
     try {
+        # PowerShell 5.1 can still default to TLS 1.0, which astral.sh refuses.
+        try {
+            [Net.ServicePointManager]::SecurityProtocol =
+                [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+        } catch {
+            # PowerShell 7+ negotiates TLS itself and may not expose Tls12 here.
+        }
         Invoke-RestMethod https://astral.sh/uv/install.ps1 | Invoke-Expression
     } catch {
         Stop-WithError @"
@@ -378,12 +385,20 @@ function Invoke-Cli {
     if (-not $command) { return $false }
 
     $target = $command.Source
+    # Capture stdout instead of letting it flow into this function's output,
+    # which would otherwise be returned alongside the boolean and make every
+    # call look successful. stderr is left alone so real errors stay visible.
+    $global:LASTEXITCODE = 0
     if ($target -match '\.(cmd|bat)$') {
-        & cmd.exe /c $target @CliArgs
+        $output = & cmd.exe /c $target @CliArgs
     } else {
-        & $target @CliArgs
+        $output = & $target @CliArgs
     }
-    return ($LASTEXITCODE -eq 0)
+    $succeeded = ($LASTEXITCODE -eq 0)
+    if (-not $succeeded -and $output) {
+        Write-Verbose ($output -join [Environment]::NewLine)
+    }
+    return $succeeded
 }
 
 function Test-CliExists {

--- a/tests/install-mcp.Tests.ps1
+++ b/tests/install-mcp.Tests.ps1
@@ -1,0 +1,292 @@
+# Tests for install-mcp.ps1
+#
+# Runs the installer against throwaway sandbox directories with stubbed uvx /
+# claude / codex executables, so nothing touches a real MCP client config.
+#
+# Usage (from the repo root):
+#   pwsh -NoProfile -File tests/install-mcp.Tests.ps1
+#
+# The installer is Windows-targeted but the logic under test (JSON merging,
+# idempotency, instruction blocks, exit codes) is platform independent, so this
+# suite also runs on Linux/macOS PowerShell in CI. On non-Windows the Windows
+# path separators become literal characters in file names, which is harmless
+# here because only file *contents* are asserted on.
+
+param([string]$ScriptPath = (Join-Path $PSScriptRoot ".." | Join-Path -ChildPath "install-mcp.ps1"))
+
+$ErrorActionPreference = "Stop"
+$ScriptPath = (Resolve-Path $ScriptPath).Path
+
+$script:pass = 0
+$script:fail = 0
+$script:failures = @()
+
+function Check {
+    param([string]$Name, $Condition, [string]$Detail = "")
+    if ($Condition) {
+        Write-Host "  PASS  $Name" -ForegroundColor Green
+        $script:pass++
+    } else {
+        Write-Host "  FAIL  $Name $Detail" -ForegroundColor Red
+        $script:fail++
+        $script:failures += $Name
+    }
+}
+
+function Write-Section { param([string]$Name) Write-Host "`n=== $Name ===" -ForegroundColor Cyan }
+
+# ── Stub executables ────────────────────────────────────────────────────────
+
+$stubBin = Join-Path ([System.IO.Path]::GetTempPath()) "amfs-test-bin"
+New-Item -ItemType Directory -Force -Path $stubBin | Out-Null
+
+function Set-Stub {
+    param([string]$Name, [string]$Body)
+    $path = Join-Path $stubBin $Name
+    Set-Content -Path $path -Value $Body -NoNewline
+    if (-not $IsWindows) { & chmod +x $path }
+}
+
+Set-Stub -Name "uvx" -Body "#!/bin/sh`necho 'uv 0.9.9'`nexit 0`n"
+$env:PATH = $stubBin + [System.IO.Path]::PathSeparator + $env:PATH
+
+# Mimics the real CLI: chatty on stdout, and `mcp remove` fails when there is
+# nothing to remove (the state of every fresh machine).
+function Set-ClaudeStub {
+    param([int]$AddExit = 0)
+    Set-Stub -Name "claude" -Body @"
+#!/bin/sh
+if [ "`$2" = "remove" ]; then
+  echo "No MCP server named senselab found" >&2
+  exit 1
+fi
+if [ "`$2" = "add" ]; then
+  echo "Added stdio MCP server senselab to user config"
+  exit $AddExit
+fi
+exit 0
+"@
+}
+
+function Set-CodexStub {
+    Set-Stub -Name "codex" -Body "#!/bin/sh`necho 'codex output'`nexit 0`n"
+}
+
+function New-Sandbox {
+    $path = Join-Path ([System.IO.Path]::GetTempPath()) ("amfs-sandbox-" + [guid]::NewGuid().ToString("N").Substring(0, 8))
+    New-Item -ItemType Directory -Force -Path (Join-Path $path ".cursor") | Out-Null
+    $env:USERPROFILE = $path
+    $env:APPDATA = Join-Path $path "AppData"
+    $env:AMFS_API_KEY = ""
+    $env:AMFS_HTTP_URL = ""
+    return $path
+}
+
+function Get-CursorRaw {
+    param([string]$Sandbox)
+    $file = Get-ChildItem -Path (Join-Path $Sandbox ".cursor") -File -Force | Select-Object -First 1
+    if (-not $file) { return $null }
+    return (Get-Content $file.FullName -Raw)
+}
+
+function Invoke-Installer {
+    # Named parameters must be splatted from a hashtable; splatting an array
+    # binds the values positionally, so "-Client" would arrive as a value.
+    # 6>&1 captures Write-Host (information stream) so output can be asserted on.
+    param([hashtable]$Parameters)
+    return (& $ScriptPath @Parameters 6>&1 2>&1 | Out-String)
+}
+
+# ── Configuration writing ───────────────────────────────────────────────────
+
+Write-Section "SaaS install selects the pro package and injects credentials"
+$sandbox = New-Sandbox
+Invoke-Installer @{ Client = "cursor"; ApiKey = "amfs_sk_test"; Yes = $true } | Out-Null
+$config = Get-CursorRaw $sandbox | ConvertFrom-Json
+$server = $config.mcpServers.senselab
+Check "senselab server written" ($null -ne $server)
+Check "uses pro package for SaaS" ($server.args -contains "amfs-mcp-server-pro")
+Check "--refresh precedes the package" ($server.args[0] -eq "--refresh" -and $server.args[1] -eq "amfs-mcp-server-pro") "got $($server.args -join ' ')"
+Check "API key injected" ($server.env.AMFS_API_KEY -eq "amfs_sk_test")
+Check "default API url used" ($server.env.AMFS_HTTP_URL -eq "https://amfs-login.sense-lab.ai")
+Check "command resolves to uvx" ($server.command -like "*uvx*") "got $($server.command)"
+
+Write-Section "Local install selects the free package with an empty env"
+$sandbox = New-Sandbox
+Invoke-Installer @{ Client = "cursor"; Yes = $true } | Out-Null
+$raw = Get-CursorRaw $sandbox
+Check "uses free package" ((($raw | ConvertFrom-Json).mcpServers.senselab.args) -contains "amfs-mcp-server")
+Check "env serialized as an empty object" ($raw -match '"env":\s*\{\s*\}') "got $raw"
+
+Write-Section "API key is read from the environment"
+$sandbox = New-Sandbox
+$env:AMFS_API_KEY = "amfs_sk_fromenv"
+Invoke-Installer @{ Client = "cursor"; Yes = $true } | Out-Null
+$server = (Get-CursorRaw $sandbox | ConvertFrom-Json).mcpServers.senselab
+Check "env var key used" ($server.env.AMFS_API_KEY -eq "amfs_sk_fromenv")
+Check "env var key selects pro package" ($server.args -contains "amfs-mcp-server-pro")
+$env:AMFS_API_KEY = ""
+
+Write-Section "Custom API url overrides the default"
+$sandbox = New-Sandbox
+Invoke-Installer @{ Client = "cursor"; ApiKey = "k"; ApiUrl = "https://amfs.internal"; Yes = $true } | Out-Null
+Check "custom url used" (((Get-CursorRaw $sandbox | ConvertFrom-Json).mcpServers.senselab.env.AMFS_HTTP_URL) -eq "https://amfs.internal")
+
+# ── Merging into an existing config ─────────────────────────────────────────
+
+Write-Section "Merging preserves unrelated servers and keys"
+$sandbox = New-Sandbox
+$existing = @'
+{
+    "someTopLevelSetting": true,
+    "mcpServers": {
+        "github": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"], "env": { "TOKEN": "abc" } },
+        "postgres": { "command": "uvx", "args": ["postgres-mcp"] }
+    }
+}
+'@
+$cursorConfig = Join-Path (Join-Path $sandbox ".cursor") "mcp.json"
+Set-Content -Path $cursorConfig -Value $existing -NoNewline
+Invoke-Installer @{ Client = "cursor"; ApiKey = "amfs_sk_merge"; Yes = $true } | Out-Null
+$raw = Get-Content $cursorConfig -Raw
+$config = $raw | ConvertFrom-Json
+Check "multi-element args preserved" ($config.mcpServers.github.args.Count -eq 2) "got $($config.mcpServers.github.args.Count)"
+Check "nested env preserved" ($config.mcpServers.github.env.TOKEN -eq "abc")
+Check "single-element args stays an array" ($config.mcpServers.postgres.args -is [array]) "collapsed to $($config.mcpServers.postgres.args.GetType().Name)"
+Check "single-element args value intact" ($config.mcpServers.postgres.args[0] -eq "postgres-mcp")
+Check "unrelated top-level key preserved" ($config.someTopLevelSetting -eq $true)
+Check "senselab added alongside" ($config.mcpServers.senselab.env.AMFS_API_KEY -eq "amfs_sk_merge")
+
+Write-Section "Re-running is idempotent"
+Invoke-Installer @{ Client = "cursor"; ApiKey = "amfs_sk_merge2"; Yes = $true } | Out-Null
+$config = Get-Content $cursorConfig -Raw | ConvertFrom-Json
+Check "server count unchanged" ((@($config.mcpServers.PSObject.Properties).Count) -eq 3) "got $(@($config.mcpServers.PSObject.Properties).Count)"
+Check "credentials updated in place" ($config.mcpServers.senselab.env.AMFS_API_KEY -eq "amfs_sk_merge2")
+Check "neighbours still intact" ($config.mcpServers.github.env.TOKEN -eq "abc")
+
+Write-Section "Uninstall removes only the senselab entry"
+Invoke-Installer @{ Client = "cursor"; Uninstall = $true; Yes = $true } | Out-Null
+$config = Get-Content $cursorConfig -Raw | ConvertFrom-Json
+Check "senselab removed" ($null -eq $config.mcpServers.senselab)
+Check "github survived" ($config.mcpServers.github.command -eq "npx")
+Check "postgres survived" ($null -ne $config.mcpServers.postgres)
+Check "top-level key survived" ($config.someTopLevelSetting -eq $true)
+
+Write-Section "Malformed config is backed up rather than lost"
+$sandbox = New-Sandbox
+$cursorConfig = Join-Path (Join-Path $sandbox ".cursor") "mcp.json"
+Set-Content -Path $cursorConfig -Value "{ not json ,,," -NoNewline
+Invoke-Installer @{ Client = "cursor"; ApiKey = "amfs_sk_bad"; Yes = $true } | Out-Null
+Check "backup written" (Test-Path "$cursorConfig.amfs-backup")
+Check "config rebuilt" (((Get-Content $cursorConfig -Raw | ConvertFrom-Json).mcpServers.senselab.env.AMFS_API_KEY) -eq "amfs_sk_bad")
+
+Write-Section "Config is written without a BOM"
+$sandbox = New-Sandbox
+Invoke-Installer @{ Client = "cursor"; ApiKey = "k"; Yes = $true } | Out-Null
+$file = Get-ChildItem -Path (Join-Path $sandbox ".cursor") -File -Force | Select-Object -First 1
+$bytes = [System.IO.File]::ReadAllBytes($file.FullName)
+Check "no UTF-8 BOM" (-not ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF))
+
+# ── Instruction blocks ──────────────────────────────────────────────────────
+
+Write-Section "Instruction block is idempotent and preserves user content"
+Set-CodexStub
+$sandbox = New-Sandbox
+Invoke-Installer @{ Client = "codex"; ApiKey = "k"; Yes = $true } | Out-Null
+$agents = Get-ChildItem -Path $sandbox -Recurse -File -Force | Where-Object { $_.Name -like "*AGENTS.md" } | Select-Object -First 1
+Check "AGENTS.md created" ($null -ne $agents)
+if ($agents) {
+    $marker = "<!-- >>> senselab-memory >>> -->"
+    $content = Get-Content $agents.FullName -Raw
+    Check "exactly one marker" (([regex]::Matches($content, [regex]::Escape($marker))).Count -eq 1)
+
+    Set-Content -Path $agents.FullName -Value ("# My own notes`nkeep this line`n`n" + $content) -NoNewline
+    Invoke-Installer @{ Client = "codex"; ApiKey = "k"; Yes = $true } | Out-Null
+    $content = Get-Content $agents.FullName -Raw
+    Check "still one marker after re-run" (([regex]::Matches($content, [regex]::Escape($marker))).Count -eq 1)
+    Check "user content preserved" ($content -match "keep this line")
+
+    Invoke-Installer @{ Client = "codex"; Uninstall = $true; Yes = $true } | Out-Null
+    $content = Get-Content $agents.FullName -Raw
+    Check "block removed on uninstall" (-not ($content -match "senselab-memory"))
+    Check "user content survived uninstall" ($content -match "keep this line")
+}
+
+Write-Section "Claude Code skill is written with valid frontmatter"
+Set-ClaudeStub
+$sandbox = New-Sandbox
+Invoke-Installer @{ Client = "claude-code"; ApiKey = "k"; Yes = $true } | Out-Null
+$skill = Get-ChildItem -Path $sandbox -Recurse -File -Force | Where-Object { $_.Name -like "*SKILL.md" } | Select-Object -First 1
+Check "SKILL.md created" ($null -ne $skill)
+if ($skill) {
+    $content = Get-Content $skill.FullName -Raw
+    Check "frontmatter starts the file" ($content.StartsWith("---"))
+    Check "declares its name" ($content -match "name: senselab-memory")
+    Check "contains the recall-first rule" ($content -match "RECALL-FIRST")
+}
+
+# ── CLI handling and exit codes ─────────────────────────────────────────────
+
+Write-Section "Fresh machine: a failing 'mcp remove' must not abort the install"
+Set-ClaudeStub -AddExit 0
+$sandbox = New-Sandbox
+$output = Invoke-Installer @{ Client = "claude-code"; ApiKey = "k"; Yes = $true }
+Check "install completed" ($output -match "Done!")
+Check "reported as configured" ($output -match "Configured Claude Code")
+Check "exit code 0" ($LASTEXITCODE -eq 0) "got $LASTEXITCODE"
+
+Write-Section "A failing 'mcp add' must be reported, never masked as success"
+Set-ClaudeStub -AddExit 1
+$sandbox = New-Sandbox
+$output = Invoke-Installer @{ Client = "claude-code"; ApiKey = "k"; Yes = $true }
+Check "failure surfaced" ($output -match "mcp add failed")
+Check "success not claimed" (-not ($output -match "Configured Claude Code"))
+
+Write-Section "CLI stdout must not leak into the success check"
+Set-ClaudeStub -AddExit 0
+$sandbox = New-Sandbox
+$output = Invoke-Installer @{ Client = "claude-code"; ApiKey = "k"; Yes = $true }
+Check "CLI chatter not echoed" (-not ($output -match "Added stdio MCP server"))
+Check "still reported as configured" ($output -match "Configured Claude Code")
+
+Write-Section "Missing CLI is skipped rather than fatal"
+Remove-Item (Join-Path $stubBin "claude") -Force
+$sandbox = New-Sandbox
+$output = Invoke-Installer @{ Client = "claude-code"; ApiKey = "k"; Yes = $true }
+Check "warns CLI is absent" ($output -match "not found on PATH")
+Check "install still completes" ($output -match "Done!")
+Set-ClaudeStub
+
+Write-Section "Unknown client fails loudly"
+$sandbox = New-Sandbox
+$output = Invoke-Installer @{ Client = "notaclient"; Yes = $true }
+Check "names the bad client" ($output -match "Unknown client")
+Check "exit code non-zero" ($LASTEXITCODE -ne 0) "got $LASTEXITCODE"
+Check "success not claimed" (-not ($output -match "Done!"))
+
+Write-Section "-Help exits cleanly without writing anything"
+$sandbox = New-Sandbox
+$output = Invoke-Installer @{ Help = $true }
+Check "exit code 0" ($LASTEXITCODE -eq 0) "got $LASTEXITCODE"
+Check "shows usage" ($output -match "Usage:")
+Check "wrote no config" (-not (Get-ChildItem -Path (Join-Path $sandbox ".cursor") -File -Force))
+
+# ── Portability guards ──────────────────────────────────────────────────────
+
+Write-Section "Script avoids PowerShell 7-only syntax (must run on Windows 5.1)"
+# Strip comment-only lines so prose mentioning a construct isn't a false positive.
+$source = ((Get-Content $ScriptPath) | Where-Object { $_.TrimStart() -notmatch '^#' }) -join [Environment]::NewLine
+Check "no null-coalescing operator" (-not ($source -match '\?\?'))
+Check "no ternary operator" (-not ($source -match '\)\s*\?\s*[^\s]+\s*:\s'))
+Check "no -AsHashtable usage" (-not ($source -match 'ConvertFrom-Json[^\r\n]*-AsHashtable'))
+Check "no utf8NoBOM encoding name" (-not ($source -match 'utf8NoBOM'))
+Check "no && or || chaining" (-not ($source -match '(\s&&\s|\s\|\|\s)'))
+Check "no #Requires (breaks irm | iex)" (-not ($source -match '#Requires'))
+
+Write-Host "`n----------------------------------------"
+if ($script:fail -gt 0) {
+    Write-Host "FAILED: $($script:fail)   PASSED: $($script:pass)" -ForegroundColor Red
+    $script:failures | ForEach-Object { Write-Host "  - $_" -ForegroundColor Red }
+    exit 1
+}
+Write-Host "ALL PASSED: $($script:pass) assertions" -ForegroundColor Green


### PR DESCRIPTION
## Why

A SenseLab signup on native Windows has no supported install path today. `install-mcp.sh` is bash-only and hard-fails on anything that isn't Darwin/Linux, so those users have to hand-assemble the `uv` install, the `claude mcp add` invocation, and the recall-first instruction files. This came up with a real customer who wanted Rooms, which are only available on the stdio `amfs-mcp-server-pro` surface.

## What

- **`install-mcp.ps1`** — Windows counterpart to `install-mcp.sh`, kept behaviourally in sync: same `senselab` server name, same client list (Claude Desktop, Cursor, Claude Code, Codex, Windsurf, VS Code), same marker-delimited instruction blocks, same `--refresh` so uvx never serves a stale cached build, plus `-Uninstall`.
- **Docs** — documents the Windows one-liner in the README and MCP guide, including the `$env:AMFS_API_KEY` form (since `irm | iex` can't forward arguments) and a note steering WSL users to the bash script.
- **Docs correction** — the MCP guide asserted in bold that the hosted API has **no** `/mcp` path. It does serve Streamable HTTP MCP there, but with a minimal tool set that excludes Rooms, negotiations, identity, and trace browsing, so stdio stays the documented default.

## Windows-specific decisions

- `claude mcp add` uses `--scope user`, so memory works across all projects instead of only the directory the installer happened to run in.
- The `claude`/`codex` CLIs are invoked through `cmd.exe` when they resolve to `.cmd` shims, which Windows cannot spawn directly.
- Config JSON is written UTF-8 **without** BOM, as some MCP clients reject a BOM'd config.