### PR TITLE
fix: link retrieved memories into decision traces, stop explain inflating reuse

### DIFF
--- a/packages/core/src/amfs_core/engine.py
+++ b/packages/core/src/amfs_core/engine.py
@@ -182,6 +182,10 @@ class ReadTracker:
         self._queries.clear()
         self._errors.clear()
         self._writes.clear()
+        # The window this tracker describes restarts here, so a trace committed
+        # after a clear reports the duration of its own work rather than the
+        # lifetime of the process.
+        self._session_started_at = datetime.now(timezone.utc)
 
     def contains(self, entry_key: str) -> bool:
         return entry_key in self._reads

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -641,10 +641,12 @@ class AgentMemory:
                     confidence_weight=cfg.confidence_weight,
                     include_artifacts=include_artifacts,
                 )
-                return [
+                scored = [
                     ScoredEntry(entry=entry, score=score, breakdown=breakdown or {})
                     for entry, score, breakdown in rows
                 ]
+                self._record_retrieval_reuse(query, entity_path, scored)
+                return scored
             except Exception:  # noqa: BLE001 - fall back to local scoring
                 logger.debug("Adapter server-side retrieve failed; using local scoring", exc_info=True)
 
@@ -656,7 +658,39 @@ class AgentMemory:
             recall_config=cfg,
             include_artifacts=include_artifacts,
         )
+        self._record_retrieval_reuse(query, entity_path, result)  # type: ignore[arg-type]
         return result  # type: ignore[return-value]
+
+    def _record_retrieval_reuse(
+        self,
+        query: str,
+        entity_path: str | None,
+        results: list[ScoredEntry],
+    ) -> None:
+        """Link a successful retrieval into the session's causal chain.
+
+        Retrieval is how agents mostly recall memory, but it never entered the
+        read tracker — so ``commit_outcome`` saw an empty causal chain, traces
+        recorded no reads, and no outcome ever reinforced the memory that
+        actually drove it.
+
+        Only the top-ranked entry becomes a causal read. Retrieval returns a
+        ranked candidate list, and back-propagating an outcome onto every
+        candidate would reinforce memories the agent never acted on and undo the
+        bounded-causal-set assumption commit_outcome relies on for speed. The
+        full result set is still preserved as a query event.
+
+        This is deliberately separate from ``recall_count``, which the server
+        credits to the top-K surfaced hits: reuse counts what was shown, causal
+        linkage records what an outcome should reinforce.
+        """
+        self._read_tracker.record_query(
+            "retrieve",
+            {"query": query, "entity_path": entity_path},
+            len(results),
+        )
+        if results:
+            self._read_tracker.record(results[0].entry)
 
     def stats(self) -> MemoryStats:
         """Aggregate statistics about current memory state."""
@@ -1036,6 +1070,12 @@ class AgentMemory:
         executor.submit(_bg_log_and_edges)
 
         self._last_trace = trace
+        # Start a fresh causal window. The reads, contexts and queries just
+        # snapshotted belong to this outcome; without this a second
+        # commit_outcome in the same session re-links the first task's reads and
+        # reinforces them again, and the trace's duration keeps growing from
+        # process start rather than describing the work it covers.
+        self._read_tracker.clear()
         return updated
 
     def _materialize_causal_edges(
@@ -1157,6 +1197,24 @@ class AgentMemory:
             if len(parts) != 2:
                 continue
             ep, k = parts
+            # Serve from the read-time snapshot. Re-reading through the adapter
+            # would both misreport what the agent actually saw and, over HTTP,
+            # bump recall_count — making this diagnostic inflate the reuse
+            # metric it exists to explain. Mirrors commit_outcome's snapshot-first
+            # path.
+            snapshot = self._read_tracker.entry_snapshot(ek)
+            if snapshot:
+                entries.append({
+                    "entity_path": ep,
+                    "key": k,
+                    "value": snapshot.get("value"),
+                    "confidence": snapshot.get("confidence"),
+                    "version": snapshot.get("version"),
+                    "memory_type": snapshot.get("memory_type"),
+                    "written_by": snapshot.get("written_by"),
+                    "read_version": self._read_tracker.read_version(ek),
+                })
+                continue
             entry = self._adapter.read(ep, k)
             if entry:
                 data = entry.model_dump(mode="json")

--- a/tests/unit/test_sdk.py
+++ b/tests/unit/test_sdk.py
@@ -313,6 +313,76 @@ class TestAutoCausalTracking:
         mem.clear_read_log()
         assert mem.read_log == []
 
+    def test_retrieve_links_only_top_hit(self, mem: AgentMemory) -> None:
+        """Retrieval is the main recall path, so it must feed the causal chain —
+        but only with the answer, not the whole candidate list."""
+        mem.write("svc", "runbook", "restart the worker pool when the queue backs up")
+        mem.write("svc", "invoices", "invoice totals reconcile nightly")
+
+        results = mem.retrieve("worker queue backs up")
+
+        assert results, "expected retrieval to rank at least one candidate"
+        assert len(results) > 1, "fixture should produce a candidate list, not one hit"
+        top = results[0].entry
+        assert mem.read_log == [f"{top.entity_path}/{top.key}"]
+
+    def test_commit_outcome_links_retrieved_memory(self, mem: AgentMemory) -> None:
+        """The regression that left every decision trace empty: retrieved
+        memories were never linked to the outcome they informed."""
+        mem.write("svc", "runbook", "restart the worker pool when the queue backs up")
+        results = mem.retrieve("worker queue backs up")
+        top = results[0].entry
+
+        updated = mem.commit_outcome("REL-1", OutcomeType.SUCCESS)
+
+        assert [e.key for e in updated] == [top.key]
+        trace = mem._last_trace
+        assert trace is not None
+        assert [c.key for c in trace.causal_entries] == [top.key]
+
+    def test_commit_outcome_starts_fresh_causal_window(self, mem: AgentMemory) -> None:
+        """A second outcome must not re-link (and re-reinforce) the first
+        task's reads."""
+        mem.write("svc", "k1", "v1")
+        mem.write("svc", "k2", "v2")
+
+        mem.read("svc", "k1")
+        mem.commit_outcome("TASK-1", OutcomeType.SUCCESS)
+        assert mem.read_log == []
+
+        mem.read("svc", "k2")
+        updated = mem.commit_outcome("TASK-2", OutcomeType.SUCCESS)
+
+        assert [e.key for e in updated] == ["k2"]
+
+    def test_explain_does_not_reread_entries(self, mem: AgentMemory) -> None:
+        """explain() is a diagnostic and must serve the read-time snapshot.
+
+        Over HTTP every adapter read hits the server's entry endpoint, which
+        bumps recall_count — so re-reading here would make explaining reuse
+        inflate the very metric it explains.
+        """
+        mem.write("svc", "pattern", "exponential backoff")
+        mem.read("svc", "pattern")
+
+        reads: list[tuple[str, str]] = []
+        original = mem._adapter.read
+
+        def spy(entity_path: str, key: str, **kwargs: Any) -> Any:
+            reads.append((entity_path, key))
+            return original(entity_path, key, **kwargs)
+
+        mem._adapter.read = spy  # type: ignore[method-assign]
+        try:
+            chain = mem.explain()
+        finally:
+            mem._adapter.read = original  # type: ignore[method-assign]
+
+        assert reads == []
+        assert chain["causal_chain_length"] == 1
+        assert chain["causal_entries"][0]["key"] == "pattern"
+        assert chain["causal_entries"][0]["value"] == "exponential backoff"
+
     def test_record_context(self, mem: AgentMemory) -> None:
         mem.record_context("git-log", "15 commits since last deploy", source="git")
         chain = mem.explain()


### PR DESCRIPTION
## Why

Retrieval is how agents mostly recall memory, but it never entered the read tracker. So `commit_outcome` saw an empty causal chain: traces recorded zero reads, no outcome ever reinforced the memory that actually drove it, and the dashboard's cross-agent "knowledge shared" view had nothing to draw. Verified live before this change — traces committed after retrieve-first sessions show `causal_entries: 0`.

Two smaller defects in the same path:

- `explain()` re-reads its causal entries through the adapter. Over HTTP every one of those reads bumps `recall_count`, so a diagnostic tool inflates the reuse metric it exists to explain.
- The read tracker is never cleared, so a second `commit_outcome` in the same session re-links the first task's reads and reinforces them again, and each trace's duration grows from process start rather than describing its own work.

This is complementary to #262 and #264, which credit `recall_count` on query-driven retrieval. Those fixed *counting*; this fixes *causality* — which memory an outcome should reinforce.

## What changed

- `AgentMemory.retrieve()` records the retrieval as a query event and links the **top-ranked hit** into the causal chain, on both the server-side and local-scoring paths.
- `explain()` serves entries from the read-time snapshot, falling back to an adapter read only when no snapshot exists — mirroring what `commit_outcome` already does.
- `commit_outcome()` clears the read tracker, and `ReadTracker.clear()` restarts `_session_started_at`.

Only the top hit becomes a causal read, deliberately narrower than the top-K that gets `recall_count`. Reuse counts what was shown to the agent; causal linkage records what an outcome should reinforce, and back-propagating onto every candidate would raise confidence on memories the agent never acted on.