### PR TITLE
chore(release): amfs 0.5.5, amfs-core 0.3.10

### DIFF
--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-core"
-version = "0.3.9"
+version = "0.3.10"
 description = "AMFS core models, engine, and adapter ABC"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs"
-version = "0.5.4"
+version = "0.5.5"
 description = "AMFS Python SDK — Agent Memory File System"
 requires-python = ">=3.11"
 license = "Apache-2.0"


### PR DESCRIPTION
Ships the causal-tracing fixes from #276.

The MCP server runs client-side (`uvx amfs-mcp-server-pro`), so those fixes only reach agents through PyPI. `release.yml` publishes whatever versions are in each pyproject at the tagged commit and skips anything already published — and the repo currently matches PyPI exactly (`amfs` 0.5.4, `amfs-core` 0.3.9), so a tag without this bump would publish nothing.