### PR TITLE
fix(http): forward include_artifacts on search + release adapter 0.1.7

### DIFF
--- a/packages/adapters/http/pyproject.toml
+++ b/packages/adapters/http/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-adapter-http"
-version = "0.1.6"
+version = "0.1.7"
 description = "AMFS HTTP adapter — routes memory operations through the authenticated REST API"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -206,6 +206,11 @@ class HttpAdapter(AdapterABC):
             body["since"] = query.since.isoformat()
         if query.pattern_ref:
             body["pattern_ref"] = query.pattern_ref
+        # Without this the server applies its own default and every SaaS caller's
+        # include_artifacts=False is silently ignored, so a single search can come
+        # back carrying whole source files.
+        if getattr(query, "include_artifacts", True) is False:
+            body["include_artifacts"] = False
         branch = kwargs.get("branch")
         if branch:
             body["branch"] = branch

--- a/tests/unit/test_http_adapter.py
+++ b/tests/unit/test_http_adapter.py
@@ -87,6 +87,25 @@ class TestSearchForwardsDepth:
 
         assert calls[0]["body"]["branch"] == "feature-x"
 
+    def test_include_artifacts_false_forwarded(self) -> None:
+        # Dropping this flag made every SaaS caller's include_artifacts=False a
+        # no-op, so a search could come back carrying whole source files.
+        adapter, calls = _make_adapter({
+            "POST /api/v1/search": {"entries": []},
+        })
+        adapter.search(SearchQuery(entity_path="svc", include_artifacts=False))
+
+        assert calls[0]["body"]["include_artifacts"] is False
+
+    def test_include_artifacts_omitted_when_default(self) -> None:
+        # Left out when True so older servers keep their own default.
+        adapter, calls = _make_adapter({
+            "POST /api/v1/search": {"entries": []},
+        })
+        adapter.search(SearchQuery(entity_path="svc"))
+
+        assert "include_artifacts" not in calls[0]["body"]
+
 
 class TestGraphNeighbors:
     def test_proxies_to_server(self) -> None:


### PR DESCRIPTION
## Why

`HttpAdapter.search()` builds its request body field by field and never includes `include_artifacts`, so the server always applied its own default. Every SaaS caller passing `include_artifacts=False` — including the MCP `amfs_search` tool — was silently ignored.

Measured against production: one `amfs_search(query="shipped this week fixes improvements", limit=20)` returned **348,221 characters (~87K tokens)** across 17 entries, and passing `include_artifacts=False` changed the payload by exactly one character. The three largest entries were stored source files:

```
51,294 chars  project/…/src/pages/AICoachPage.tsx
36,370 chars  project/…/src/pages/HomePage.tsx
31,080 chars  project/…/src/pages/DashboardPage.tsx
```

`retrieve` forwards the flag correctly; only `search` was affected.

## What changed

- `HttpAdapter.search()` sends `include_artifacts: false` when the `SearchQuery` asks for it, and omits the key otherwise so older servers keep their current behavior.
- Released as `amfs-adapter-http` 0.1.7. `amfs-mcp-server-pro` floors at `>=0.1.4`, so uvx picks it up on the next resolve without a Pro bump.

## Testing

`tests/unit/test_http_adapter.py` — 15 passed, including new coverage that `include_artifacts=False` reaches the body and that the key stays absent by default.