### PR TITLE
fix(mcp): preview long values in multi-result responses

### DIFF
--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-mcp-server"
-version = "0.7.8"
+version = "0.7.9"
 description = "AMFS MCP Server — expose Agent Memory as MCP tools for Cursor and Claude Code"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -27,6 +27,7 @@ import logging
 import os
 import time
 from pathlib import Path
+from collections.abc import Iterable
 from typing import Any
 
 from fastmcp import Context, FastMCP
@@ -466,6 +467,31 @@ def _serialize_entry(entry: Any) -> dict[str, Any]:
     return data
 
 
+# A stored source file can run past 50K characters, so a 20-result list response
+# can reach ~87K tokens — more context than the memories it recalls are worth.
+# List responses carry a preview instead; the exact-read tools stay whole.
+LIST_VALUE_CHAR_LIMIT = 2000
+
+
+def _serialize_entries(entries: Iterable[Any]) -> list[dict[str, Any]]:
+    """Serialize entries for a multi-result response, previewing long values."""
+    out: list[dict[str, Any]] = []
+    for entry in entries:
+        data = _serialize_entry(entry)
+        value = data.get("value")
+        if isinstance(value, str) and len(value) > LIST_VALUE_CHAR_LIMIT:
+            data["value"] = value[:LIST_VALUE_CHAR_LIMIT]
+            data["value_truncated"] = True
+            data["value_chars"] = len(value)
+            data["full_value"] = (
+                f"Preview only — {LIST_VALUE_CHAR_LIMIT} of {len(value)} characters. "
+                f"Call amfs_read(entity_path=\"{data.get('entity_path')}\", "
+                f"key=\"{data.get('key')}\") for the whole value."
+            )
+        out.append(data)
+    return out
+
+
 # ──────────────────────────────────────────────────────────────────────
 # MCP Tools
 # ──────────────────────────────────────────────────────────────────────
@@ -837,6 +863,9 @@ def amfs_search(
             (they are demoted by default)
 
     Example: amfs_search(entity_path="checkout-service", min_confidence=0.5)
+
+    Long values come back as a 2000-character preview with `value_truncated`
+    and `full_value` set; call amfs_read for the whole value.
     """
     from datetime import datetime as dt
 
@@ -875,7 +904,7 @@ def amfs_search(
         })
     return json.dumps({
         "count": len(results),
-        "entries": [_serialize_entry(e) for e in results],
+        "entries": _serialize_entries(results),
     }, default=str)
 
 
@@ -918,6 +947,9 @@ def amfs_retrieve(
 
     Returns ranked results with score breakdowns showing how each
     signal contributed to the final ranking.
+
+    Long values come back as a 2000-character preview with `value_truncated`
+    and `full_value` set; call amfs_read for the whole value.
     """
     from amfs_core.models import RecallConfig
 
@@ -941,8 +973,7 @@ def amfs_retrieve(
     )
 
     serialized = []
-    for scored in results:
-        data = _serialize_entry(scored.entry)
+    for scored, data in zip(results, _serialize_entries(s.entry for s in results)):
         data["_score"] = round(scored.score, 4)
         data["_breakdown"] = {k: round(v, 4) for k, v in scored.breakdown.items()}
         serialized.append(data)
@@ -986,7 +1017,7 @@ def amfs_list(entity_path: str | None = None) -> str:
         })
     return json.dumps({
         "count": len(entries),
-        "entries": [_serialize_entry(e) for e in entries],
+        "entries": _serialize_entries(entries),
     }, default=str)
 
 
@@ -1223,7 +1254,7 @@ def amfs_my_entries(entity_path: str | None = None) -> str:
     return json.dumps({
         "agent_id": mem.agent_id,
         "count": len(entries),
-        "entries": [_serialize_entry(e) for e in entries],
+        "entries": _serialize_entries(entries),
     }, default=str)
 
 
@@ -1430,7 +1461,7 @@ def amfs_briefing(
             "avg_confidence": round(avg_conf, 2),
             "contributing_agents": agents,
             "keys": keys,
-            "entries": [_serialize_entry(e) for e in entries[:limit]],
+            "entries": _serialize_entries(entries[:limit]),
         }, default=str)
 
     hint = (

--- a/tests/unit/test_mcp_tools_smoke.py
+++ b/tests/unit/test_mcp_tools_smoke.py
@@ -123,3 +123,51 @@ class TestWriteSurfaceSmoke:
 
     def test_commit_outcome(self, srv):
         _ok("amfs_commit_outcome", srv.amfs_commit_outcome("smoke-outcome", "success"))
+
+
+class TestListValuePreview:
+    """Multi-result responses preview long values instead of inlining them.
+
+    A stored source file can exceed 50K characters, and a 20-result search of
+    such a store measured ~348K characters (~87K tokens) — more context spent
+    than the recalled memories are worth, and enough to push anything appended
+    after the entries out of what a client keeps.
+    """
+
+    def test_search_previews_long_values(self, srv):
+        srv.amfs_write("smoke/big", "huge-file", "x" * 60_000)
+        entry = next(
+            e for e in _ok("amfs_search", srv.amfs_search(entity_path="smoke/big"))["entries"]
+            if e["key"] == "huge-file"
+        )
+
+        assert entry["value_truncated"] is True
+        assert entry["value_chars"] == 60_000
+        assert len(entry["value"]) == srv.LIST_VALUE_CHAR_LIMIT
+        assert "amfs_read" in entry["full_value"]
+
+    def test_short_values_are_untouched(self, srv):
+        entry = next(
+            e for e in _ok("amfs_list", srv.amfs_list("smoke/ops"))["entries"]
+            if e["key"] == "runbook"
+        )
+
+        assert entry["value"] == "the deploy runbook lives in the ops wiki"
+        assert "value_truncated" not in entry
+
+    def test_exact_reads_return_the_whole_value(self, srv):
+        # Truncation is a list-response concern only: amfs_read is how an agent
+        # recovers what a preview left out, so it must never be abbreviated.
+        srv.amfs_write("smoke/big", "huge-file", "x" * 60_000)
+
+        assert len(_ok("amfs_read", srv.amfs_read("smoke/big", "huge-file"))["value"]) == 60_000
+
+    def test_retrieve_previews_and_keeps_scores(self, srv):
+        srv.amfs_write("smoke/big", "huge-file", "runbook " * 8_000)
+        payload = _ok(
+            "amfs_retrieve", srv.amfs_retrieve(query="runbook", entity_path="smoke/big")
+        )
+        entry = next(e for e in payload["entries"] if e["key"] == "huge-file")
+
+        assert entry["value_truncated"] is True
+        assert "_score" in entry and "_breakdown" in entry


### PR DESCRIPTION
## Why

Measured against production, a single `amfs_search(query=..., limit=20)` returned:

```
payload chars: 348,221 (~87,055 tokens), 17 entries
    51,294 chars  project/…/src/pages/AICoachPage.tsx
    36,370 chars  project/…/src/pages/HomePage.tsx
    31,080 chars  project/…/src/pages/DashboardPage.tsx
```

Two consequences. The call spends far more context than the memories it recalls are worth — that same search reported "saved about 12K tokens" while delivering 87K. And anything serialized after the entries is what a client drops first, which is how the `senselab_value` line stopped reaching users.

`include_artifacts=False` does not help here: those `.tsx` entries are stored with `is_artifact = false`, so the artifact filter correctly excludes nothing. The classification gap is worth fixing separately; capping list payloads fixes the bloat regardless of how entries are labelled.

## What changed

- New `_serialize_entries()` previews values over 2000 characters, setting `value_truncated`, `value_chars`, and a `full_value` string naming the exact `amfs_read(entity_path, key)` call that returns the rest.
- Applied to the multi-result recall paths: `amfs_search`, `amfs_retrieve`, `amfs_list`, `amfs_my_entries`, `amfs_briefing`.
- Deliberately **not** applied to `amfs_read`, `amfs_recall`, or `amfs_history` — exact reads must stay whole, since that is how an agent recovers what a preview left out.
- Documented in the `amfs_search` / `amfs_retrieve` docstrings so agents know to follow up with `amfs_read`.
- Bumped `amfs-mcp-server` to 0.7.9.

## Testing

Full OSS unit suite: 591 passed, 1 pre-existing unrelated failure (`test_explicit_env_var`, sticky identity file). New coverage in `test_mcp_tools_smoke.py` asserts long values are previewed with a working pointer, short values are untouched, `amfs_read` still returns the whole value, and retrieve keeps its `_score`/`_breakdown` fields alongside the preview.