### PR TITLE
fix(mcp): preview structured values too

### DIFF
--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-mcp-server"
-version = "0.7.9"
+version = "0.7.10"
 description = "AMFS MCP Server — expose Agent Memory as MCP tools for Cursor and Claude Code"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -479,12 +479,18 @@ def _serialize_entries(entries: Iterable[Any]) -> list[dict[str, Any]]:
     for entry in entries:
         data = _serialize_entry(entry)
         value = data.get("value")
-        if isinstance(value, str) and len(value) > LIST_VALUE_CHAR_LIMIT:
-            data["value"] = value[:LIST_VALUE_CHAR_LIMIT]
+        # Structured values are the biggest ones in practice (investigations and
+        # design plans reach 20K characters as objects), so measure what a client
+        # actually receives rather than only checking plain strings.
+        rendered = value if isinstance(value, str) else json.dumps(value, default=str)
+        if len(rendered) > LIST_VALUE_CHAR_LIMIT:
+            data["value"] = rendered[:LIST_VALUE_CHAR_LIMIT]
             data["value_truncated"] = True
-            data["value_chars"] = len(value)
+            data["value_chars"] = len(rendered)
+            if not isinstance(value, str):
+                data["value_format"] = "json"
             data["full_value"] = (
-                f"Preview only — {LIST_VALUE_CHAR_LIMIT} of {len(value)} characters. "
+                f"Preview only — {LIST_VALUE_CHAR_LIMIT} of {len(rendered)} characters. "
                 f"Call amfs_read(entity_path=\"{data.get('entity_path')}\", "
                 f"key=\"{data.get('key')}\") for the whole value."
             )

--- a/tests/unit/test_mcp_tools_smoke.py
+++ b/tests/unit/test_mcp_tools_smoke.py
@@ -146,6 +146,20 @@ class TestListValuePreview:
         assert len(entry["value"]) == srv.LIST_VALUE_CHAR_LIMIT
         assert "amfs_read" in entry["full_value"]
 
+    def test_structured_values_are_previewed_too(self, srv):
+        # The largest values in a real store are objects, not strings —
+        # investigations and design plans reach 20K characters as JSON — so a
+        # plain isinstance(str) check would leave the worst offenders whole.
+        srv.amfs_write("smoke/big", "plan", {"steps": ["do a thing"] * 2_000})
+        entry = next(
+            e for e in _ok("amfs_search", srv.amfs_search(entity_path="smoke/big"))["entries"]
+            if e["key"] == "plan"
+        )
+
+        assert entry["value_truncated"] is True
+        assert entry["value_format"] == "json"
+        assert len(entry["value"]) == srv.LIST_VALUE_CHAR_LIMIT
+
     def test_short_values_are_untouched(self, srv):
         entry = next(
             e for e in _ok("amfs_list", srv.amfs_list("smoke/ops"))["entries"]


### PR DESCRIPTION
## Why

Follow-up to #279, which cut a production search from 348K to 192K characters but left more on the table than expected. Field breakdown of the remaining payload:

```
179,072 chars total  value
  2,141 chars total  provenance
  1,083 chars total  full_value
```

Only 6 of 17 entries had been previewed. The untruncated ones were all objects:

```
20,382 chars  type=dict  truncated=False  investigation-75c069da
19,245 chars  type=dict  truncated=False  investigation-d73dcb54
18,250 chars  type=dict  truncated=False  design-plan
```

`_serialize_entries` guarded on `isinstance(value, str)`, so structured memories — the largest ones in practice — skipped the preview entirely.

## What changed

- Measure `json.dumps(value)` length when the value is not a string, and preview on that.
- Object previews carry `value_format: "json"` so an agent knows the preview is truncated JSON rather than the stored shape.
- Bumped `amfs-mcp-server` to 0.7.10.

## Testing

Full OSS unit suite: 592 passed, 1 pre-existing unrelated failure (`test_explicit_env_var`). New test asserts a dict value over the limit is previewed and tagged `value_format: "json"`.