### PR TITLE
fix(core): stop filing prose about code as code

### DIFF
--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-core"
-version = "0.3.10"
+version = "0.3.11"
 description = "AMFS core models, engine, and adapter ABC"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/core/src/amfs_core/content.py
+++ b/packages/core/src/amfs_core/content.py
@@ -9,13 +9,16 @@ preference on a query like "what do I prefer".
 This module is the single source of truth for that distinction. It is used to:
 
 * set ``MemoryEntry.is_artifact`` at persistence time (adapter write chokepoint),
-* choose what text to embed (a clean descriptor for artifacts, so the vector
-  represents *what the file is* rather than its noisy, truncated body), and
+* choose what text to embed (a clean descriptor for *file-keyed* artifacts, so
+  the vector represents what the file is rather than its noisy, truncated
+  body), and
 * demote artifacts in the retrieve/search/briefing read paths.
 
 The heuristics are intentionally narrow (precision over recall): a genuine
-natural-language fact that happens to contain a word like ``return`` must not be
-misread as code.
+natural-language fact that happens to contain a word like ``return`` — or a path
+glob, a quoted tag, or an arrow — must not be misread as code. Prose *about*
+code is the common case in an agent's memory, so markers only count at the start
+of a line, and the weak ones need corroboration.
 """
 
 from __future__ import annotations
@@ -62,13 +65,24 @@ _LANGUAGE_BY_EXT = {
     "r": "R", "pl": "Perl", "proto": "Protobuf", "gradle": "Gradle",
 }
 
-# Strong, code-specific markers. Deliberately narrow so prose is not misread as
-# code. Mirrors amfs_security.detectors.poisoning._CODE_MARKERS.
-_CODE_MARKERS = re.compile(
+# Declarations that open a line. One is enough: prose does not begin a line with
+# `def foo(` or `export default function`.
+_STRONG_CODE_MARKERS = re.compile(
     r"(?m)^\s*(?:import\s|from\s+\S+\s+import\b|export\s+(?:default\s+|const\s+|function\b)|"
     r"def\s+\w+\s*\(|class\s+\w+|function\s+\w*\s*\(|#include\b|package\s+\w|@\w+\s*$)"
-    r"|=>|</[A-Za-z]|/\*|\bconsole\.\w|\brequire\("
 )
+
+# Weaker hints, which turn up constantly in prose *about* code: a path glob
+# (`packages/*/src`), a quoted tag (`<span>x</span>`), an arrow meaning "leads
+# to", a mentioned `console.error(...)`. Matched as bare substrings these filed
+# genuine knowledge as code — every flagged row in production was a technical
+# note, not a file. So they count only when they open a line, and two separate
+# lines must carry one before content alone decides.
+_WEAK_CODE_MARKERS = re.compile(
+    r"(?m)^\s*(?:/\*|\*/|</?[A-Za-z][\w.-]*(?:\s|/?>)|(?:const|let|var)\s+\w+\s*=|"
+    r"console\.\w+\s*\(|require\s*\(|\)\s*=>|[})\]];?\s*$)"
+)
+_WEAK_MARKERS_REQUIRED = 2
 
 # Top-level symbol declarations, used to summarise an artifact in its descriptor.
 _SYMBOL_RE = re.compile(
@@ -111,7 +125,10 @@ def is_code_like(value: Any) -> bool:
     text = _stringify(value).strip()
     if len(text) < 24:
         return False
-    return bool(_CODE_MARKERS.search(text[:_SCAN_LIMIT]))
+    head = text[:_SCAN_LIMIT]
+    if _STRONG_CODE_MARKERS.search(head):
+        return True
+    return len(_WEAK_CODE_MARKERS.findall(head)) >= _WEAK_MARKERS_REQUIRED
 
 
 def classify_artifact(key: str, value: Any) -> bool:
@@ -152,11 +169,19 @@ def artifact_descriptor(key: str, value: Any) -> str:
 def embedding_input(key: str, value: Any) -> tuple[bool, str]:
     """Return ``(is_artifact, text_to_embed)`` for an entry's key/value.
 
-    Artifacts embed their descriptor; everything else embeds its value text.
     Every embed site (SDK write, HTTP write handler, adapter fallback, backfill,
     Pro retriever) routes through this so the classification and the embedded
     text never diverge.
+
+    A descriptor replaces the value only when the key actually names a file. It
+    is built from the filename, language and symbols, so under a prose-style key
+    it collapses to "source file <key>." and the entry's meaning never reaches
+    its vector — the entry stays listed and readable by exact key while becoming
+    unfindable by meaning. Content-only classification therefore still demotes,
+    but no longer decides what gets embedded.
     """
-    if classify_artifact(key, value):
-        return True, artifact_descriptor(key, value)
-    return False, _stringify(value)
+    if not classify_artifact(key, value):
+        return False, _stringify(value)
+    if not is_artifact_key(key):
+        return True, _stringify(value)
+    return True, artifact_descriptor(key, value)

--- a/tests/unit/test_content_classification.py
+++ b/tests/unit/test_content_classification.py
@@ -61,6 +61,65 @@ class TestClassifyArtifact:
         assert not classify_artifact("prefs", {"food": "pizza", "drink": "water"})
 
 
+class TestProseAboutCodeIsNotCode:
+    """Every one of these is a real production memory that got filed as code.
+
+    All seven rows flagged ``is_artifact`` in the production store were technical
+    notes, not files, and each was caught by a bare substring appearing mid
+    sentence. Left unfixed, an entry's meaning is replaced by "source file
+    <key>." in its vector and it stops being findable by meaning.
+    """
+
+    def test_path_globs(self):
+        assert not is_code_like(
+            "Reads keyed by entry_key, keyword signal in blend, exclude "
+            "bench-*/_system/* (_is_excluded_entity), UserVisibilityFilter applied ONCE."
+        )
+        assert not is_code_like(
+            "Ran the main checkout's .venv pytest with PYTHONPATH listing worktree "
+            "packages/*/src to shadow the installed copies."
+        )
+        assert not is_code_like(
+            "auto-publish.yml triggers on push to main touching "
+            "packages/**/pyproject.toml or packages/sdk-typescript/package.json."
+        )
+        assert not is_code_like(
+            "CRITICAL: the /api/v1/pro/tenant/* provisioning router has no auth "
+            "dependency and the tenant middleware passes it through."
+        )
+
+    def test_quoted_markup_inside_a_sentence(self):
+        assert not is_code_like(
+            "POPUP LOGO: replaced the text <span class='logo'>SenseLab</span> in "
+            "the popup Header with an image tag pointing at the bundled logo."
+        )
+
+    def test_arrow_used_as_prose(self):
+        assert not is_code_like(
+            "Pro forwards include_artifacts to an OSS retrieve that lacks it => "
+            "TypeError on every call, even when the caller omits the argument."
+        )
+
+    def test_quoted_function_call(self):
+        assert not is_code_like(
+            "sendTeamInviteEmail has no success log line — only "
+            "console.error('[invite] Email failed for %s') on failure, so verify from logs."
+        )
+
+    def test_still_catches_real_code(self):
+        # The tightening must not cost genuine detection.
+        assert is_code_like("import React from 'react'\nexport const App = () => <div/>\n")
+        assert is_code_like("def compute(x):\n    return x * 2\n")
+        assert is_code_like(
+            "<div className='wrapper'>\n  <span>hi</span>\n</div>\n"
+        )
+
+    def test_weak_hints_corroborate(self):
+        # One line-anchored weak hint is not enough; two are.
+        assert not is_code_like("/* a note that opens with a comment marker and then prose */")
+        assert is_code_like("const total = 1\nconsole.log(total)\n")
+
+
 class TestArtifactDescriptor:
     def test_includes_language_filename_and_symbols(self):
         code = (
@@ -94,6 +153,21 @@ class TestEmbeddingInput:
         is_art, text = embedding_input("food-pref", "I love pizza")
         assert is_art is False
         assert text == "I love pizza"
+
+    def test_code_under_a_prose_key_embeds_its_content(self):
+        # A descriptor built from a prose key collapses to "source file <key>."
+        # and erases the entry's meaning, so it is reserved for file keys. The
+        # entry is still reported as an artifact, so ranking still demotes it.
+        value = "export default function App() { return null }"
+        is_art, text = embedding_input("notes", value)
+
+        assert is_art is True
+        assert text == value
+
+    def test_descriptor_requires_a_file_key(self):
+        _, text = embedding_input("decision-use-jwt", "const token = sign(payload)\nconsole.log(token)\n")
+
+        assert "source file" not in text
 
     def test_penalty_in_range(self):
         assert 0.0 < ARTIFACT_PENALTY < 1.0


### PR DESCRIPTION
## What changed

- Markers split into strong declarations (one line-anchored hit suffices: `import`, `def foo(`, `class X`, `export default function`) and weak hints (`/*`, `*/`, a tag, `const x =`, `console.x(`, `require(`, `) =>`, a lone closing brace) which must open a line and appear on two separate lines.
- `embedding_input()` reserves the descriptor for keys that name a file. Content-only classification still returns `is_artifact=True` so ranking still demotes, but the value is what gets embedded.

## Validation against the production store (2,148 live rows)

```
the 7 currently-flagged rows:   0 of 7 still classify as artifacts, none meaning-erased
the 223 real source files:      223 of 223 still classify (on the key, as intended)
would-be new flags:             239 -> 223, all by file key, 0 by content
```