### PR TITLE
fix(reuse): credit the memory an agent took, not the list it was shown

### DIFF
--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-core"
-version = "0.3.11"
+version = "0.3.12"
 description = "AMFS core models, engine, and adapter ABC"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/core/src/amfs_core/aggregates.py
+++ b/packages/core/src/amfs_core/aggregates.py
@@ -29,6 +29,15 @@ RECALL_TOKENS_FLOOR = 200
 RECALL_TOKENS_CEIL = 4000
 CHARS_PER_TOKEN = 4
 
+# How many hits of a query-driven lookup (retrieve/search) count as reuse.
+# One: reuse should count the memory an agent took, not the candidate list it
+# was shown. Crediting the top three inflated the number roughly threefold —
+# one real session made 4 lookups, was credited 16 reuses, and exactly 1 of
+# those memories changed what the agent did. Mirrored by the MCP server's
+# value_ledger.py (REUSE_CREDIT_K) so the chat recap and the dashboard describe
+# the same query identically.
+REUSE_CREDIT_K = 1
+
 
 def recall_tokens_saved(entry: "MemoryEntry") -> int:
     """Estimated tokens of re-research avoided by this entry's recalls."""

--- a/packages/http-server/pyproject.toml
+++ b/packages/http-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-http-server"
-version = "0.3.10"
+version = "0.3.11"
 description = "AMFS HTTP/REST API server with SSE support"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -35,6 +35,7 @@ from sse_starlette.sse import EventSourceResponse
 from amfs import AgentMemory, MemoryType, OutcomeType
 from amfs.config import load_config_or_default
 from pydantic import BaseModel, Field
+from amfs_core.aggregates import REUSE_CREDIT_K
 from amfs_core.models import (
     AgentGroup,
     AMFSConfig,
@@ -1135,14 +1136,21 @@ async def search_entries(
     # counter, leaving reuse metrics (memories reused / rework avoided) reading
     # 0 even when memory was clearly used. Only credit *query-driven* searches
     # (recall intent), not pure filter/browse (agent_id/entity_path listings),
-    # and only the top-K surfaced hits so we don't inflate on the long tail.
+    # and only the TOP hit: the rest of a ranked list is a candidate set the
+    # agent scrolls past, and crediting three per query inflated reuse roughly
+    # threefold (one real session: 4 lookups booked as 16 reuses).
     # Skip system/bench scratch namespaces. Best-effort: never let accounting
     # failure affect the response.
     if req.query and req.query.strip():
-        reuse_credit_k = min(3, req.limit or 3)
-        for entry in results[:reuse_credit_k]:
+        credited = 0
+        for entry in results:
+            if credited >= REUSE_CREDIT_K:
+                break
+            # Scratch namespaces don't consume the credit: a telemetry row
+            # ranking first would otherwise silently swallow the whole budget.
             if entry.entity_path.startswith(("_system/", "bench/", "bench-")):
                 continue
+            credited += 1
             try:
                 if _async_adapter is not None:
                     await _async_adapter.increment_recall_count(
@@ -1372,12 +1380,13 @@ async def retrieve_entries(
     #     (e.g. browser-extension clips) get surfaced and used, but it
     #     historically incremented no counter — so value metrics (rework
     #     avoided / memories reused) read 0 even when memory was clearly reused.
-    #     Bump recall_count for the top-K returned hits (not every candidate),
-    #     so reuse reflects the memories actually surfaced to the caller without
-    #     inflating on the long tail. Best-effort: never let accounting failure
-    #     affect the response.
-    reuse_credit_k = min(3, req.limit)
-    for entry, _score, _bd in scored[:reuse_credit_k]:
+    #     Bump recall_count for the TOP hit only. Reuse should count what the
+    #     agent took, not what it was shown: the rest of a ranked list is a
+    #     candidate set, and crediting the top three booked reuse that never
+    #     happened (a real session: 4 lookups, 16 credited reuses, 1 that
+    #     changed the agent's behavior). Best-effort: never let accounting
+    #     failure affect the response.
+    for entry, _score, _bd in scored[:REUSE_CREDIT_K]:
         try:
             if _async_adapter is not None:
                 await _async_adapter.increment_recall_count(

--- a/tests/unit/test_hybrid_retrieve.py
+++ b/tests/unit/test_hybrid_retrieve.py
@@ -283,7 +283,7 @@ def _run_search(request, req):
 
 
 class TestSearchReuseAccounting:
-    def test_query_driven_search_bumps_top_k(self, monkeypatch):
+    def test_query_driven_search_bumps_only_the_top_hit(self, monkeypatch):
         hits = [
             _entry("invoicehub", "deferred-decisions", "recurring invoices deferred"),
             _entry("invoicehub", "schema", "client and invoice entities"),
@@ -294,12 +294,10 @@ class TestSearchReuseAccounting:
         monkeypatch.setattr(server, "_async_adapter", fake)
 
         _run_search(_request(), SearchRequest(query="invoicehub decisions", limit=20))
-        # Only the top-3 surfaced hits are credited (no long-tail inflation).
-        assert fake.bumped == [
-            ("invoicehub", "deferred-decisions"),
-            ("invoicehub", "schema"),
-            ("invoicehub", "layout"),
-        ]
+        # Reuse counts the memory the agent took, not the list it was shown.
+        # Crediting the head of the list inflated reuse ~3x — one real session
+        # made 4 lookups and was credited 16 reuses, of which 1 was used.
+        assert fake.bumped == [("invoicehub", "deferred-decisions")]
 
     def test_browse_without_query_does_not_bump(self, monkeypatch):
         hits = [_entry("invoicehub", "deferred-decisions", "recurring invoices deferred")]
@@ -311,6 +309,9 @@ class TestSearchReuseAccounting:
         assert fake.bumped == []
 
     def test_system_and_bench_namespaces_skipped(self, monkeypatch):
+        # Scratch rows outranking the real hit must not consume the credit —
+        # with a single credit to give, skipping them has to mean "keep
+        # looking", not "spend it here".
         hits = [
             _entry("_system/telemetry", "row", "system row matches query"),
             _entry("bench-run-1/obs", "row", "benchmark row matches query"),


### PR DESCRIPTION
## The change

- `REUSE_CREDIT_K = 1` in `amfs_core.aggregates`, imported by `/search` and `/retrieve` so there is one definition instead of two inline `min(3, limit)` expressions. The MCP ledger and dashboard copy mirror it (internal PR).
- Scratch namespaces (`_system/`, `bench/`, `bench-`) no longer consume the credit. With three credits a skipped telemetry row was free; with one, skipping has to mean "keep looking" or a scratch row ranking first silently swallows the whole budget.

## Impact

Query-driven recall counts grow ~3x slower from now on, and dashboard savings shrink accordingly. Exact reads (`amfs_read`/`recall`/`read_from`) are unchanged — those were always one memory, deliberately fetched. Historical counts are left alone; this is not a backfill.