### PR TITLE
fix(extension): give each user on an account their own clipper identity

### DIFF
--- a/packages/browser-extension/README.md
+++ b/packages/browser-extension/README.md
@@ -2,7 +2,7 @@
 
 Chrome/Edge/Firefox extension that saves web pages and text selections into
 SenseLab agent memory. Clips are written through the hosted REST API
-(`POST /api/v1/entries`) under the `web-clipper` agent and are immediately
+(`POST /api/v1/entries`) under a `web-clipper` agent and are immediately
 retrievable by every agent on the account.
 
 ## Quick start
@@ -19,11 +19,19 @@ Load unpacked: `chrome://extensions` → Developer mode → Load unpacked →
 
 ## Agent identity convention
 
-Every clip is authored under the canonical `web-clipper` agent id
-(`CLIPPER_AGENT_ID` in `utils/config.ts`). This is the single identity for all
-extension-related memory.
+Clips are authored under `web-clipper` (`CLIPPER_AGENT_ID` in
+`utils/config.ts`) — but an agent identity is owned by exactly one user per
+account, and the API answers 409 to a write carrying somebody else's identity.
+On a shared account the first person to save claims `web-clipper`, so each
+further user falls back to a derived variant (`web-clipper-<name>`, see
+`utils/identity.ts`). The resolved id is stored in settings and shown in
+Options.
 
-When working on this extension with AMFS memory, set your identity to the same
+The fallbacks are derived from the account email rather than random, so a
+reinstall returns to the same identity: AMFS has no agent rename/merge, and a
+split identity can only be reconciled by a costly multi-table migration.
+
+When working on this extension with AMFS memory, set your identity to the
 canonical id so build notes and real user clips stay on one agent page (and
 reuse/recall metrics don't get split):
 

--- a/packages/browser-extension/entrypoints/background.ts
+++ b/packages/browser-extension/entrypoints/background.ts
@@ -1,9 +1,19 @@
 import { browser, type Browser } from "wxt/browser";
 import { defineBackground } from "wxt/utils/define-background";
 import { track } from "@/utils/analytics";
-import { AuthError, QuotaExceededError, fetchRoomsState, retrieve, writeClip } from "@/utils/api";
+import {
+  AgentIdentityConflictError,
+  AuthError,
+  QuotaExceededError,
+  fetchRoomsState,
+  retrieve,
+  whoami,
+  writeClip,
+  type WriteResult,
+} from "@/utils/api";
 import { isBlockedHost, isUnsupportedUrl } from "@/utils/blocklist";
-import { CLIPS_ENTITY, MAX_TEXT_BYTES } from "@/utils/config";
+import { CLIPPER_AGENT_ID, CLIPS_ENTITY, MAX_TEXT_BYTES } from "@/utils/config";
+import { type IdentitySeed, nextAgentId } from "@/utils/identity";
 import { clipKey, entityForUrl } from "@/utils/slug";
 import {
   getRoomsState,
@@ -18,6 +28,7 @@ import type {
   SaveOutcome,
   SaveRequest,
   SaveTrigger,
+  Settings,
 } from "@/utils/types";
 
 const MENU_SAVE_PAGE = "senselab-save-page";
@@ -78,9 +89,14 @@ export default defineBackground(() => {
   browser.runtime.onMessageExternal.addListener((message, _sender, sendResponse) => {
     void (async () => {
       if (message?.type === "amfs-connect" && typeof message.apiKey === "string") {
+        const email = typeof message.email === "string" ? message.email : null;
+        const previous = await getSettings();
         await updateSettings({
           apiKey: message.apiKey,
-          accountEmail: typeof message.email === "string" ? message.email : null,
+          accountEmail: email,
+          // Someone else connecting on this browser profile must not inherit
+          // the previous person's agent identity.
+          ...(email === previous.accountEmail ? {} : { agentId: null }),
         });
         await track("extension_connected");
         void refreshRooms();
@@ -184,7 +200,7 @@ async function performSave(
 
   const key = clipKey(clip.title, clip.url);
   try {
-    const result = await writeClip(settings.apiKey, entityPath, key, clip);
+    const result = await writeClipAsUser(settings.apiKey, settings, entityPath, key, clip);
     const lastSave = {
       url: clip.url,
       title: clip.title,
@@ -223,6 +239,55 @@ async function performSave(
     }
     await track("extension_save_failed", { error: (e as Error).message?.slice(0, 120) });
     return { ok: false, error: (e as Error).message };
+  }
+}
+
+/**
+ * Write the clip under an agent identity this user owns.
+ *
+ * An identity is owned by one user per account, so on a shared account the
+ * default `web-clipper` is already taken by whoever saved first and every
+ * teammate's write comes back 409. Moving to the next candidate identity and
+ * persisting the one that lands keeps that a silent one-time reassignment
+ * instead of an error the user can do nothing about.
+ */
+async function writeClipAsUser(
+  apiKey: string,
+  settings: Settings,
+  entityPath: string,
+  key: string,
+  clip: ClipContent,
+): Promise<WriteResult> {
+  let agentId = settings.agentId ?? CLIPPER_AGENT_ID;
+  let seed: IdentitySeed = { email: settings.accountEmail };
+  const tried: string[] = [];
+
+  for (;;) {
+    try {
+      const result = await writeClip(apiKey, entityPath, key, clip, agentId);
+      if (settings.agentId !== agentId) await updateSettings({ agentId });
+      return result;
+    } catch (e) {
+      if (!(e instanceof AgentIdentityConflictError)) throw e;
+      tried.push(agentId);
+      // No email means the key was pasted by hand in Options; whoami gives us
+      // something stable to derive the next identity from.
+      if (!seed.email && !seed.userId) seed = { ...seed, userId: await fetchUserId(apiKey) };
+      const next = nextAgentId(seed, tried);
+      if (!next) throw e;
+      agentId = next;
+      await track("extension_identity_reassigned", { attempt: tried.length });
+    }
+  }
+}
+
+async function fetchUserId(apiKey: string): Promise<string | null> {
+  try {
+    const info = await whoami(apiKey);
+    const id = info.user_id ?? info.actor_id;
+    return typeof id === "string" ? id : null;
+  } catch {
+    return null;
   }
 }
 

--- a/packages/browser-extension/entrypoints/options/Options.tsx
+++ b/packages/browser-extension/entrypoints/options/Options.tsx
@@ -54,7 +54,14 @@ export default function Options() {
             </p>
             <button
               className="danger"
-              onClick={() => void patch({ apiKey: null, accountEmail: null, firstSaveDone: false })}
+              onClick={() =>
+                void patch({
+                  apiKey: null,
+                  accountEmail: null,
+                  agentId: null,
+                  firstSaveDone: false,
+                })
+              }
             >
               Disconnect
             </button>
@@ -82,6 +89,12 @@ export default function Options() {
             {keyStatus === "checking" ? "Checking…" : "Save key"}
           </button>
         </div>
+        {settings.agentId && (
+          <p className="muted">
+            Clips are filed under the agent <code>{settings.agentId}</code>. Each person on an
+            account saves under their own identity, so your clips stay yours.
+          </p>
+        )}
         {keyStatus === "ok" && <p className="ok">Key verified and saved.</p>}
         {keyStatus === "bad" && <p className="err">That key didn’t work — check it in your dashboard (Settings → API Keys).</p>}
       </section>

--- a/packages/browser-extension/scripts/e2e-save.mjs
+++ b/packages/browser-extension/scripts/e2e-save.mjs
@@ -6,9 +6,13 @@
  * rooms tier endpoint.
  *
  * Usage: AMFS_API_KEY=amfs_… node scripts/e2e-save.mjs [base-url]
+ *
+ * Set AMFS_AGENT_ID when the key's user doesn't own `web-clipper` on the
+ * account — writes under another user's identity are rejected with 409.
  */
 const API_URL = process.argv[2] ?? process.env.AMFS_HTTP_URL ?? "https://amfs-login.sense-lab.ai";
 const API_KEY = process.env.AMFS_API_KEY;
+const AGENT_ID = process.env.AMFS_AGENT_ID ?? "web-clipper";
 if (!API_KEY) {
   console.error("Set AMFS_API_KEY");
   process.exit(1);
@@ -49,7 +53,7 @@ const writeBody = {
   value: clip,
   confidence: 1.0,
   memory_type: "experience",
-  agent_id: "web-clipper",
+  agent_id: AGENT_ID,
   shared: true,
 };
 
@@ -89,7 +93,7 @@ const r = await fetch(`${API_URL}/api/v1/entries/${entityPath}/${key}`, { header
 const rBody = await r.json();
 check(
   "read back clip",
-  r.ok && rBody.value?.url === testUrl && rBody.provenance?.agent_id === "web-clipper",
+  r.ok && rBody.value?.url === testUrl && rBody.provenance?.agent_id === AGENT_ID,
   `agent_id=${rBody.provenance?.agent_id}`,
 );
 

--- a/packages/browser-extension/utils/analytics.ts
+++ b/packages/browser-extension/utils/analytics.ts
@@ -14,7 +14,8 @@ export type AnalyticsEvent =
   | "extension_upgrade_cta_clicked"
   | "extension_rooms_cta_clicked"
   | "extension_connected"
-  | "extension_first_save";
+  | "extension_first_save"
+  | "extension_identity_reassigned";
 
 export async function track(
   event: AnalyticsEvent,

--- a/packages/browser-extension/utils/api.ts
+++ b/packages/browser-extension/utils/api.ts
@@ -1,4 +1,4 @@
-import { API_URL, CLIPPER_AGENT_ID, OPS_PER_SAVE, ROOMS_TIERS, UPGRADE_URL } from "./config";
+import { API_URL, OPS_PER_SAVE, ROOMS_TIERS, UPGRADE_URL } from "./config";
 import { bumpLocalUsage, setUsageFromHeaders } from "./storage";
 import type { ClipContent, Room, RoomsState } from "./types";
 
@@ -18,7 +18,18 @@ export class AuthError extends Error {
   }
 }
 
-interface WriteResult {
+/**
+ * The agent identity on the write is owned by another user in the account.
+ * Recoverable: the caller retries under the next candidate identity.
+ */
+export class AgentIdentityConflictError extends Error {
+  constructor(message = "Another member of this account already uses this saving identity.") {
+    super(message);
+    this.name = "AgentIdentityConflictError";
+  }
+}
+
+export interface WriteResult {
   version: number;
   [k: string]: unknown;
 }
@@ -75,7 +86,11 @@ async function request(
     throw new AuthError();
   }
   if (!resp.ok) {
-    throw new Error(`API error ${resp.status}: ${await resp.text()}`);
+    const detail = await resp.text();
+    if (resp.status === 409 && /agent identity/i.test(detail)) {
+      throw new AgentIdentityConflictError();
+    }
+    throw new Error(`API error ${resp.status}: ${detail}`);
   }
   return resp;
 }
@@ -85,6 +100,7 @@ export async function writeClip(
   entityPath: string,
   key: string,
   clip: ClipContent,
+  agentId: string,
 ): Promise<WriteResult> {
   const resp = await request(
     apiKey,
@@ -96,7 +112,7 @@ export async function writeClip(
       value: clip,
       confidence: 1.0,
       memory_type: "experience",
-      agent_id: CLIPPER_AGENT_ID,
+      agent_id: agentId,
       shared: true,
     },
     OPS_PER_SAVE,

--- a/packages/browser-extension/utils/config.ts
+++ b/packages/browser-extension/utils/config.ts
@@ -14,7 +14,10 @@ export const UPGRADE_URL = `${DASHBOARD_URL}/settings/usage`;
  */
 export const ROOMS_URL = `${DASHBOARD_URL}/rooms`;
 
-/** Agent identity every clip is attributed to. */
+/**
+ * Base agent identity clips are attributed to. Only one user per account can
+ * own it, so teammates get a derived variant — see `utils/identity.ts`.
+ */
 export const CLIPPER_AGENT_ID = "web-clipper";
 
 /** Catch-all entity for selections and notes without a clean domain. */

--- a/packages/browser-extension/utils/identity.ts
+++ b/packages/browser-extension/utils/identity.ts
@@ -1,0 +1,51 @@
+import { CLIPPER_AGENT_ID } from "./config";
+import { slugify, urlHash } from "./slug";
+
+export interface IdentitySeed {
+  /** Account email from the connect handshake, when we have one. */
+  email?: string | null;
+  /** User id from /auth/whoami — the fallback when a key was pasted manually. */
+  userId?: string | null;
+}
+
+/**
+ * An agent identity belongs to exactly one user per account: the API rejects a
+ * write with 409 when the identity it carries is owned by somebody else. A
+ * single shared `web-clipper` therefore locks every member of a team account
+ * except whoever saved first.
+ *
+ * These are tried in order and the one that works is persisted, so a solo
+ * account keeps the plain `web-clipper` (and the clips already filed under it)
+ * and only colliding users take a suffix. Each candidate is derived rather
+ * than random: a reinstall lands on the same identity instead of scattering
+ * someone's clips over several agent pages, which AMFS cannot merge back.
+ */
+export function agentIdCandidates(seed: IdentitySeed): string[] {
+  const label = seedLabel(seed);
+  const fingerprint = (seed.email ?? seed.userId ?? "").trim().toLowerCase();
+  const candidates = [CLIPPER_AGENT_ID];
+  if (label) candidates.push(`${CLIPPER_AGENT_ID}-${label}`);
+  if (fingerprint) {
+    // Two members can share a local part (bruno@a.com, bruno@b.com), so the
+    // readable candidate alone isn't guaranteed to be free.
+    const suffix = label ? `${label}-${urlHash(fingerprint)}` : urlHash(fingerprint);
+    candidates.push(`${CLIPPER_AGENT_ID}-${suffix}`);
+  }
+  return [...new Set(candidates)];
+}
+
+/** First candidate not already rejected by the API, or null when exhausted. */
+export function nextAgentId(seed: IdentitySeed, tried: Iterable<string>): string | null {
+  const used = new Set(tried);
+  return agentIdCandidates(seed).find((id) => !used.has(id)) ?? null;
+}
+
+function seedLabel({ email, userId }: IdentitySeed): string | null {
+  const localPart = email?.trim().toLowerCase().split("@")[0];
+  if (localPart) {
+    const slug = slugify(localPart, 24);
+    if (slug !== "untitled") return slug;
+  }
+  const id = userId?.trim().toLowerCase().replace(/[^a-z0-9]/g, "");
+  return id ? id.slice(0, 8) : null;
+}

--- a/packages/browser-extension/utils/storage.ts
+++ b/packages/browser-extension/utils/storage.ts
@@ -10,6 +10,7 @@ const ROOMS_KEY = "roomsState";
 export const DEFAULT_SETTINGS: Settings = {
   apiKey: null,
   accountEmail: null,
+  agentId: null,
   defaultDestination: null,
   disabledSites: [],
   customBlocklist: [],

--- a/packages/browser-extension/utils/types.ts
+++ b/packages/browser-extension/utils/types.ts
@@ -12,6 +12,13 @@ export interface ClipContent {
 export interface Settings {
   apiKey: string | null;
   accountEmail: string | null;
+  /**
+   * Agent identity clips are authored under, resolved on first save and kept
+   * for the life of the connection. null = not resolved yet (also the state of
+   * every install that predates per-user identities, which keeps them on the
+   * shared `web-clipper` until the API says it belongs to someone else).
+   */
+  agentId: string | null;
   /** null = personal memory; otherwise a room id from the rooms list */
   defaultDestination: string | null;
   /** hostnames the user disabled saving on ("never save here") */


### PR DESCRIPTION
## The bug

A user on a shared account reported this on every save:

> API error 409: {"detail":"Agent identity 'web-clipper' is already registered to a different user in this account. Set a unique agent identity (e.g. call amfs_set_identity with a new name) and retry."}

The extension shipped one hardcoded identity for everybody (`CLIPPER_AGENT_ID = "web-clipper"`), and the API enforces that an agent identity belongs to exactly one user per account ([`_link_agent_owner_once`](https://github.com/raia-live/amfs/blob/main/packages/http-server/src/amfs_http/server.py)). So the first person on an account to save a page claims `web-clipper` permanently, and the extension is dead for every teammate after them — the advice in the error message is for MCP agents and there is nothing the user can act on from the popup.

## The fix

The identity is resolved per install and persisted in settings, escalating only when the API says the current one is taken:

1. `web-clipper` — unchanged for solo accounts, so existing clips stay on the same agent page
2. `web-clipper-<name>` — from the account email's local part
3. `web-clipper-<name>-<hash>` — tiebreaker, since two members can share a local part across domains

Fallbacks are derived, never random, so a reinstall returns to the same identity. That matters because AMFS has no agent rename/merge: a random suffix would scatter one person's clips over several agent pages permanently.

Because the base id is still tried first, nobody's history moves and only colliding users are reassigned — silently, on the save that would otherwise have failed. Users already broken today are fixed by the retry without reinstalling or reconnecting.

Supporting changes:
- `AgentIdentityConflictError` distinguishes this 409 from any other, and carries a message a user can read if the ladder is ever exhausted (instead of raw JSON in the popup, as in the report)
- connecting a different email on the same browser profile clears the stored identity, so one person can't inherit another's
- Options shows which identity clips are filed under, which is the first thing to ask for in a support thread
- `scripts/e2e-save.mjs` takes `AMFS_AGENT_ID`, since the smoke test hits the same wall when its key belongs to a user who doesn't own `web-clipper`