### PR TITLE
Carry the acting user onto pooled connections

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -123,12 +123,14 @@ class _TenantRLSConnection:
             get_request_tenant_account_id,
             get_request_tenant_team_id,
             get_request_is_account_admin,
+            get_request_user_id,
         )
 
         conn = self._inner_ctx.__enter__()
         tid = get_request_tenant_account_id()
         team_id = get_request_tenant_team_id()
         is_admin = get_request_is_account_admin()
+        user_id = get_request_user_id()
 
         _TenantRLSConnection._log_counter += 1
         if _TenantRLSConnection._log_counter <= 20 or not tid:
@@ -139,11 +141,21 @@ class _TenantRLSConnection:
             )
 
         with conn.cursor() as cur:
+            # current_user_id is set unconditionally, like the others: on a
+            # pooled connection, leaving it alone would leave the previous
+            # borrower's user in place, and this is the one GUC that grants
+            # access across accounts rather than restricting within one.
             cur.execute(
                 "SELECT set_config('amfs.current_account_id', %s, false),"
                 "       set_config('amfs.current_team_id', %s, false),"
-                "       set_config('amfs.is_account_admin', %s, false)",
-                (tid if tid else "", team_id if team_id else "", "true" if is_admin else "false"),
+                "       set_config('amfs.is_account_admin', %s, false),"
+                "       set_config('amfs.current_user_id', %s, false)",
+                (
+                    tid if tid else "",
+                    team_id if team_id else "",
+                    "true" if is_admin else "false",
+                    user_id if user_id else "",
+                ),
             )
         return conn
 

--- a/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
@@ -61,16 +61,19 @@ class _AsyncTenantRLSConnection:
             get_request_tenant_account_id,
             get_request_tenant_team_id,
             get_request_is_account_admin,
+            get_request_user_id,
         )
 
         conn = await self._inner_ctx.__aenter__()
         tid = get_request_tenant_account_id()
         team_id = get_request_tenant_team_id()
         is_admin = get_request_is_account_admin()
+        user_id = get_request_user_id()
 
         guc_account = tid if tid else ""
         guc_team = team_id if team_id else ""
         guc_admin = "true" if is_admin else "false"
+        guc_user = user_id if user_id else ""
 
         if not tid:
             logger.warning(
@@ -80,11 +83,15 @@ class _AsyncTenantRLSConnection:
             )
 
         async with conn.cursor() as cur:
+            # Set unconditionally, for the same reason as the other three: a
+            # pooled connection would otherwise keep the previous borrower's
+            # user, and this is the GUC that grants access across accounts.
             await cur.execute(
                 "SELECT set_config('amfs.current_account_id', %s, false),"
                 "       set_config('amfs.current_team_id', %s, false),"
-                "       set_config('amfs.is_account_admin', %s, false)",
-                (guc_account, guc_team, guc_admin),
+                "       set_config('amfs.is_account_admin', %s, false),"
+                "       set_config('amfs.current_user_id', %s, false)",
+                (guc_account, guc_team, guc_admin, guc_user),
             )
         return conn
 

--- a/packages/adapters/postgres/src/amfs_postgres/tenant_context.py
+++ b/packages/adapters/postgres/src/amfs_postgres/tenant_context.py
@@ -9,6 +9,15 @@ Stores account_id, team_id, and is_account_admin for two-layer tenancy:
   - account_id  -> amfs.current_account_id  (outer boundary)
   - team_id     -> amfs.current_team_id     (inner boundary)
   - is_admin    -> amfs.is_account_admin    (admin bypass)
+
+and the acting user:
+  - user_id     -> amfs.current_user_id     (cross-account grants)
+
+The first three narrow what a request can see. user_id is the one that can
+widen it: a user invited to a room in someone else's account reaches it
+through permissive policies keyed on this value, and on nothing else. It is
+therefore only ever set from an authenticated identity the server resolved
+itself, never from a client-supplied header taken at face value.
 """
 
 from __future__ import annotations
@@ -18,6 +27,7 @@ from contextvars import ContextVar
 _account_id_var: ContextVar[str | None] = ContextVar("amfs_account_id", default=None)
 _team_id_var: ContextVar[str | None] = ContextVar("amfs_team_id", default=None)
 _is_admin_var: ContextVar[bool] = ContextVar("amfs_is_admin", default=False)
+_user_id_var: ContextVar[str | None] = ContextVar("amfs_user_id", default=None)
 
 
 # -- account_id --
@@ -63,3 +73,23 @@ def clear_tls_is_account_admin() -> None:
 
 def get_request_is_account_admin() -> bool:
     return _is_admin_var.get()
+
+
+# -- user_id --
+
+def set_tls_user_id(user_id: str | None) -> None:
+    """Called from HTTP middleware once the acting user is authenticated.
+
+    Only from a resolved identity — an API key's owner, or a dashboard header
+    whose proxy secret validated. Unlike the account and team vars, this one
+    grants access rather than restricting it.
+    """
+    _user_id_var.set(user_id or None)
+
+
+def clear_tls_user_id() -> None:
+    _user_id_var.set(None)
+
+
+def get_request_user_id() -> str | None:
+    return _user_id_var.get()

--- a/tests/unit/test_async_adapter.py
+++ b/tests/unit/test_async_adapter.py
@@ -40,6 +40,7 @@ class TestAsyncTenantRLSConnection:
             patch("amfs_postgres.tenant_context.get_request_tenant_account_id", return_value="acct-123"),
             patch("amfs_postgres.tenant_context.get_request_tenant_team_id", return_value="team-456"),
             patch("amfs_postgres.tenant_context.get_request_is_account_admin", return_value=True),
+            patch("amfs_postgres.tenant_context.get_request_user_id", return_value="user-789"),
         ):
             rls = _AsyncTenantRLSConnection(inner_ctx)
             conn = await rls.__aenter__()
@@ -49,7 +50,8 @@ class TestAsyncTenantRLSConnection:
         assert "set_config('amfs.current_account_id'" in sql
         assert "set_config('amfs.current_team_id'" in sql
         assert "set_config('amfs.is_account_admin'" in sql
-        assert params == ("acct-123", "team-456", "true")
+        assert "set_config('amfs.current_user_id'" in sql
+        assert params == ("acct-123", "team-456", "true", "user-789")
 
     async def test_no_tenant_sets_empty_strings(self, _make_conn):
         from amfs_postgres.async_adapter import _AsyncTenantRLSConnection
@@ -60,13 +62,14 @@ class TestAsyncTenantRLSConnection:
             patch("amfs_postgres.tenant_context.get_request_tenant_account_id", return_value=None),
             patch("amfs_postgres.tenant_context.get_request_tenant_team_id", return_value=None),
             patch("amfs_postgres.tenant_context.get_request_is_account_admin", return_value=False),
+            patch("amfs_postgres.tenant_context.get_request_user_id", return_value=None),
         ):
             rls = _AsyncTenantRLSConnection(inner_ctx)
             await rls.__aenter__()
 
         assert len(executed) == 1
         _, params = executed[0]
-        assert params == ("", "", "false")
+        assert params == ("", "", "false", "")
 
     async def test_admin_false(self, _make_conn):
         from amfs_postgres.async_adapter import _AsyncTenantRLSConnection
@@ -77,12 +80,43 @@ class TestAsyncTenantRLSConnection:
             patch("amfs_postgres.tenant_context.get_request_tenant_account_id", return_value="acct-x"),
             patch("amfs_postgres.tenant_context.get_request_tenant_team_id", return_value="team-y"),
             patch("amfs_postgres.tenant_context.get_request_is_account_admin", return_value=False),
+            patch("amfs_postgres.tenant_context.get_request_user_id", return_value=None),
         ):
             rls = _AsyncTenantRLSConnection(inner_ctx)
             await rls.__aenter__()
 
         _, params = executed[0]
-        assert params == ("acct-x", "team-y", "false")
+        assert params == ("acct-x", "team-y", "false", "")
+
+    async def test_a_pooled_connection_never_inherits_the_last_users_identity(
+        self, _make_conn
+    ):
+        """The GUC that grants cross-account access must be reset, not skipped.
+
+        Every other GUC here narrows what a request can see, so leaving a
+        stale one behind fails closed. current_user_id is the opposite: it is
+        what lets an invited user reach a room in someone else's account. A
+        connection handed on with the previous borrower's user still set
+        would grant the next request their room access.
+        """
+        from amfs_postgres.async_adapter import _AsyncTenantRLSConnection
+
+        inner_ctx, executed = _make_conn
+
+        with (
+            patch("amfs_postgres.tenant_context.get_request_tenant_account_id", return_value="acct-x"),
+            patch("amfs_postgres.tenant_context.get_request_tenant_team_id", return_value=None),
+            patch("amfs_postgres.tenant_context.get_request_is_account_admin", return_value=False),
+            patch("amfs_postgres.tenant_context.get_request_user_id", return_value=None),
+        ):
+            await _AsyncTenantRLSConnection(inner_ctx).__aenter__()
+
+        sql, params = executed[0]
+        assert "set_config('amfs.current_user_id'" in sql, (
+            "current_user_id is left untouched on checkout, so it keeps "
+            "whatever the previous borrower of this pooled connection set"
+        )
+        assert params[3] == ""
 
     async def test_aexit_delegates(self, _make_conn):
         from amfs_postgres.async_adapter import _AsyncTenantRLSConnection
@@ -93,6 +127,7 @@ class TestAsyncTenantRLSConnection:
             patch("amfs_postgres.tenant_context.get_request_tenant_account_id", return_value=None),
             patch("amfs_postgres.tenant_context.get_request_tenant_team_id", return_value=None),
             patch("amfs_postgres.tenant_context.get_request_is_account_admin", return_value=False),
+            patch("amfs_postgres.tenant_context.get_request_user_id", return_value=None),
         ):
             rls = _AsyncTenantRLSConnection(inner_ctx)
             await rls.__aenter__()

--- a/tests/unit/test_tenant_rls_connection.py
+++ b/tests/unit/test_tenant_rls_connection.py
@@ -1,0 +1,105 @@
+"""The sync pooled-connection RLS wrapper.
+
+Four session variables decide what a request can see. Three of them narrow:
+account, team, and the admin flag. A stale value there fails closed — the
+next borrower of the connection sees less than they should, which is a bug
+but not a leak.
+
+amfs.current_user_id is the one that widens. Permissive policies use it to
+let a user reach rooms in accounts that are not theirs, so a connection
+handed on with the previous borrower's user still set grants the next
+request that person's room access. Hence: set on every checkout, never
+conditionally.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def _make_conn():
+    executed: list = []
+
+    cur = MagicMock()
+    cur.execute = MagicMock(side_effect=lambda sql, params=None: executed.append((sql, params)))
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=None)
+
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=cur)
+
+    inner_ctx = MagicMock()
+    inner_ctx.__enter__ = MagicMock(return_value=conn)
+    inner_ctx.__exit__ = MagicMock(return_value=None)
+
+    return inner_ctx, executed
+
+
+def _checkout(inner_ctx, *, account="acct-1", team=None, admin=False, user=None):
+    from amfs_postgres.adapter import _TenantRLSConnection
+
+    with (
+        patch("amfs_postgres.tenant_context.get_request_tenant_account_id", return_value=account),
+        patch("amfs_postgres.tenant_context.get_request_tenant_team_id", return_value=team),
+        patch("amfs_postgres.tenant_context.get_request_is_account_admin", return_value=admin),
+        patch("amfs_postgres.tenant_context.get_request_user_id", return_value=user),
+    ):
+        return _TenantRLSConnection(inner_ctx).__enter__()
+
+
+class TestTheActingUserReachesTheDatabase:
+    def test_the_user_guc_is_set_from_context(self, _make_conn):
+        """Without this, the cross-account room policies match nothing and an
+        invited user sees an empty room rather than its contents."""
+        inner_ctx, executed = _make_conn
+
+        _checkout(inner_ctx, account="acct-1", user="user-42")
+
+        sql, params = executed[0]
+        assert "set_config('amfs.current_user_id'" in sql
+        assert "user-42" in params
+
+    def test_all_four_gucs_are_set_in_one_statement(self, _make_conn):
+        # One round trip per checkout; this is on every request's hot path.
+        inner_ctx, executed = _make_conn
+
+        _checkout(inner_ctx, account="a", team="t", admin=True, user="u")
+
+        assert len(executed) == 1
+        sql, params = executed[0]
+        for guc in (
+            "amfs.current_account_id",
+            "amfs.current_team_id",
+            "amfs.is_account_admin",
+            "amfs.current_user_id",
+        ):
+            assert f"set_config('{guc}'" in sql
+        assert params == ("a", "t", "true", "u")
+
+
+class TestAPooledConnectionCarriesNothingOver:
+    def test_no_user_still_writes_an_empty_string(self, _make_conn):
+        """Skipping the set when there is no user is what would make this
+        dangerous: the connection keeps the last borrower's identity, and the
+        permissive room policies would grant their access to whoever holds
+        the connection next."""
+        inner_ctx, executed = _make_conn
+
+        _checkout(inner_ctx, account="acct-2", user=None)
+
+        sql, params = executed[0]
+        assert "set_config('amfs.current_user_id'" in sql
+        assert params[3] == "", "must clear, not leave the previous value"
+
+    def test_an_unauthenticated_checkout_clears_everything(self, _make_conn):
+        inner_ctx, executed = _make_conn
+
+        _checkout(inner_ctx, account=None, team=None, admin=False, user=None)
+
+        _sql, params = executed[0]
+        # NULLIF in the policies turns each empty string into NULL, which
+        # matches no rows.
+        assert params == ("", "", "false", "")


### PR DESCRIPTION
## What

Both RLS connection wrappers set `amfs.current_account_id`, `amfs.current_team_id` and `amfs.is_account_admin` on every checkout, but never the user. The cross-account room policies on the server side are keyed on `amfs.current_user_id`, so they only ever fired on connections the rooms service opened for itself and set the variable on by hand. Anything reaching the database through the adapter — which is the whole memory path — saw those policies match nothing.

This adds a `user_id` contextvar alongside the existing three and sets the GUC in both the sync and async wrappers.
