### PR TITLE
fix(rooms): scope shared namespaces to explicit reads, publish the SSE manager

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -65,6 +65,24 @@ except ImportError:  # pragma: no cover
 
 logger = logging.getLogger(__name__)
 
+# Entity paths of the form @<name>/<topic> denote a shared namespace: one
+# whose contents belong to a group rather than to the account reading them.
+# Access to them is granted separately, outside this adapter.
+#
+# The rule below is that they are only ever returned when they were asked for
+# by name. A query that names no entity_path is an ambient one — "what do I
+# know", "what is relevant here" — and its results land in an agent's context
+# without anyone having decided they should. Shared content reaching that
+# position means a stranger who can write to a shared namespace can put text
+# in front of an agent that is working on something else entirely, which is
+# the shape of a prompt-injection attack and does not require the attacker to
+# do anything but write an ordinary memory.
+#
+# Asking for the path explicitly is the act of deciding to trust it. So
+# read(), and any search scoped to the path, still return everything; it is
+# only the unscoped queries that filter it out.
+_EXCLUDE_SHARED_PATHS = "entity_path NOT LIKE '@%/%'"
+
 _SCHEMA_SQL = (Path(__file__).parent / "schema.sql").read_text(encoding="utf-8")
 
 # SQL mirror of amfs_core.aggregates.recall_tokens_saved: per reuse, credit
@@ -1135,6 +1153,8 @@ class PostgresAdapter(AdapterABC):
         if entity_path is not None:
             conditions.append("entity_path = %s")
             params.append(entity_path)
+        else:
+            conditions.append(_EXCLUDE_SHARED_PATHS)
 
         if not include_superseded:
             conditions.append("superseded_at IS NULL")
@@ -1182,6 +1202,8 @@ class PostgresAdapter(AdapterABC):
         if query.entity_path is not None:
             conditions.append("entity_path = %s")
             params.append(query.entity_path)
+        else:
+            conditions.append(_EXCLUDE_SHARED_PATHS)
         if query.min_confidence > 0:
             conditions.append("confidence >= %s")
             params.append(query.min_confidence)
@@ -1299,6 +1321,8 @@ class PostgresAdapter(AdapterABC):
         if query.entity_path is not None:
             conditions.append("entity_path = %s")
             params.append(query.entity_path)
+        else:
+            conditions.append(_EXCLUDE_SHARED_PATHS)
         if query.min_confidence > 0:
             conditions.append("confidence >= %s")
             params.append(query.min_confidence)
@@ -1748,6 +1772,11 @@ class PostgresAdapter(AdapterABC):
         if agent_ids is not None:
             conditions.append("agent_id = ANY(%s)")
             params.append(list(agent_ids))
+        # No entity_path argument to this one: it is unscoped by construction,
+        # so shared namespaces are always excluded. It groups by entity_path,
+        # which would otherwise list a shared namespace's topics as though
+        # they were this account's own.
+        conditions.append(_EXCLUDE_SHARED_PATHS)
         where = " AND ".join(conditions)
 
         sql = f"""

--- a/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
@@ -34,7 +34,7 @@ from amfs_core.models import (
     SemanticQuery,
 )
 
-from amfs_postgres.adapter import PostgresAdapter
+from amfs_postgres.adapter import _EXCLUDE_SHARED_PATHS, PostgresAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -402,6 +402,8 @@ class AsyncPostgresAdapter:
         if entity_path is not None:
             conditions.append("entity_path = %s")
             params.append(entity_path)
+        else:
+            conditions.append(_EXCLUDE_SHARED_PATHS)
 
         if not include_superseded:
             conditions.append("superseded_at IS NULL")
@@ -438,6 +440,8 @@ class AsyncPostgresAdapter:
         if query.entity_path is not None:
             conditions.append("entity_path = %s")
             params.append(query.entity_path)
+        else:
+            conditions.append(_EXCLUDE_SHARED_PATHS)
         if query.min_confidence > 0:
             conditions.append("confidence >= %s")
             params.append(query.min_confidence)
@@ -544,6 +548,8 @@ class AsyncPostgresAdapter:
         if query.entity_path is not None:
             conditions.append("entity_path = %s")
             params.append(query.entity_path)
+        else:
+            conditions.append(_EXCLUDE_SHARED_PATHS)
         if query.min_confidence > 0:
             conditions.append("confidence >= %s")
             params.append(query.min_confidence)

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -147,6 +147,14 @@ async def _dashboard_tenant_middleware(request: Request, call_next):
 
 _memory: AgentMemory | None = None
 _sse_manager = SSEManager()
+
+# Routers mounted onto this app from outside the package cannot reach a
+# module-level private, so the manager is published on app.state, which a
+# route reaches through its own Request. Without this the room event stream
+# has no manager to find and answers 503 on every connection, and the
+# broadcasts aimed at it are dropped in silence — which is how it behaved.
+app.state.sse_manager = _sse_manager
+
 _bg_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="amfs-bg")
 _known_agents: set[str] = set()
 # Tracks (agent, namespace, user) triples whose owner linkage was already

--- a/tests/test_shared_path_scoping.py
+++ b/tests/test_shared_path_scoping.py
@@ -1,0 +1,118 @@
+"""Shared namespaces are returned only when they are asked for by name.
+
+An entity path of the form @<name>/<topic> is a shared namespace: its
+contents belong to a group, and people outside the account reading them can
+write to it. That is the feature. The hazard is where those writes end up.
+
+An unscoped query — search with no entity_path, list() with no argument, the
+retrieval that backs "what do I know about this" — puts its results into an
+agent's context without anyone having chosen them. If shared content can
+land there, then anyone who can write to a shared namespace can put text in
+front of an agent that is working on something else entirely. They do not
+need to breach anything; they write an ordinary memory and wait. Naming the
+path is the act of deciding to trust it, so scoped reads are untouched and
+only the ambient ones filter.
+
+These are SQL-shape tests. The behaviour they protect is invisible in normal
+use and the failure is silent, so the guard is easy to drop in a refactor
+and nothing will notice.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[1] / (
+    "packages/adapters/postgres/src/amfs_postgres"
+)
+SYNC = SRC / "adapter.py"
+ASYNC = SRC / "async_adapter.py"
+
+GUARD = "_EXCLUDE_SHARED_PATHS"
+
+
+def _method(path: Path, name: str) -> str:
+    """The source of one method, up to the next def at the same indent."""
+    src = path.read_text()
+    start = src.index(f"    def {name}(") if f"    def {name}(" in src else src.index(
+        f"    async def {name}("
+    )
+    rest = src[start + 10 :]
+    end = re.search(r"\n    (?:async )?def ", rest)
+    return src[start : start + 10 + (end.start() if end else len(rest))]
+
+
+class TestTheGuardIsDefinedOnce:
+    def test_it_matches_prefixed_paths_only(self) -> None:
+        """A bare '@name' with no topic is not a shared namespace, and an
+        ordinary path that merely contains an @ must not be caught."""
+        src = SYNC.read_text()
+        assert "entity_path NOT LIKE '@%/%'" in src
+
+    def test_the_async_adapter_shares_the_definition(self) -> None:
+        """Two copies of a security rule is one copy that gets forgotten."""
+        assert f"from amfs_postgres.adapter import {GUARD}" in ASYNC.read_text()
+        assert f'{GUARD} = ' not in ASYNC.read_text()
+
+
+class TestUnscopedReadsExcludeSharedNamespaces:
+    @pytest.mark.parametrize(
+        "path,method",
+        [
+            (SYNC, "list"),
+            (SYNC, "search"),
+            (SYNC, "semantic_search"),
+            (ASYNC, "list"),
+            (ASYNC, "search"),
+            (ASYNC, "semantic_search"),
+        ],
+    )
+    def test_the_guard_is_applied_when_no_path_is_given(self, path, method) -> None:
+        body = _method(path, method)
+        assert GUARD in body, (
+            f"{path.name}:{method} can return shared-namespace entries to a "
+            f"query that never asked for them"
+        )
+
+    @pytest.mark.parametrize(
+        "path,method",
+        [
+            (SYNC, "list"),
+            (SYNC, "search"),
+            (SYNC, "semantic_search"),
+            (ASYNC, "list"),
+            (ASYNC, "search"),
+            (ASYNC, "semantic_search"),
+        ],
+    )
+    def test_it_is_the_else_of_the_entity_path_filter(self, path, method) -> None:
+        """Applying it unconditionally would break the scoped read too, which
+        is the one case that must keep working: naming the path is how a
+        caller says they want it."""
+        body = _method(path, method)
+        assert re.search(
+            r'conditions\.append\("entity_path = %s"\)\s*\n'
+            r'\s*params\.append\([^)]+\)\s*\n'
+            r'\s*else:\s*\n'
+            r'\s*conditions\.append\(' + GUARD + r'\)',
+            body,
+        ), f"{path.name}:{method} does not gate the guard on the path being absent"
+
+    def test_entity_summaries_is_always_filtered(self) -> None:
+        """It takes no entity_path at all and groups by it, so a shared
+        namespace's topics would be listed as though they were this
+        account's own."""
+        assert GUARD in _method(SYNC, "entity_summaries")
+
+
+class TestScopedReadsAreUntouched:
+    def test_read_does_not_filter(self) -> None:
+        """read() names both the path and the key. That is as explicit as a
+        request gets, and filtering it would make shared rooms unreadable."""
+        assert GUARD not in _method(SYNC, "read")
+
+    def test_read_at_version_does_not_filter(self) -> None:
+        assert GUARD not in _method(SYNC, "read_at_version")

--- a/tests/unit/test_sse_manager_is_published.py
+++ b/tests/unit/test_sse_manager_is_published.py
@@ -1,0 +1,41 @@
+"""The SSE manager is reachable from routers mounted outside this package.
+
+Room routes live in a separate distribution and are mounted onto this app.
+They cannot see a module-level private, so they look for the manager on
+`request.app.state.sse_manager` — and nothing was putting it there. The room
+event stream therefore answered 503 on every connection and every broadcast
+aimed at it was dropped without a word, because a broadcast with no
+subscribers is indistinguishable from one nobody happened to be watching.
+
+A one-line omission that disables a whole feature and produces no error is
+worth a test, even a test this small.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+
+def test_the_manager_is_published_on_app_state() -> None:
+    from amfs_http.server import app
+
+    assert getattr(app.state, "sse_manager", None) is not None
+
+
+def test_it_is_the_same_object_the_write_path_broadcasts_on() -> None:
+    """Two managers would be worse than none: writes would broadcast into one
+    while subscribers waited on the other, and nothing anywhere would fail."""
+    from amfs_http import server
+
+    assert server.app.state.sse_manager is server._sse_manager
+
+
+def test_it_can_broadcast_a_room_event() -> None:
+    """Shape check on the interface the room routes actually call."""
+    from amfs_http.server import app
+
+    app.state.sse_manager.broadcast_room_event(
+        "00000000-0000-4000-8000-000000000000", "join", {"user_id": "u1"},
+    )


### PR DESCRIPTION
Two OSS-side fixes that shared room links depend on. Both are inert until the internal `AMFS_SHARED_ROOMS_ENABLED` flag is on, but they belong here because the adapter and the HTTP server live in this repo.

## Return shared namespaces only when they are asked for by name

A room's memories live under a shared entity path that several accounts can reach. Unscoped reads — `list`, `search`, `semantic_search`, `entity_summaries` with no entity filter — were sweeping those paths into results for anyone whose RLS context allowed them.

That is a prompt-injection surface as much as a privacy one: an agent doing a broad recall would pick up text written by a stranger in a room it happens to belong to, with no signal that the content came from outside its own account.

Shared paths are now excluded from unscoped queries via a shared `_EXCLUDE_SHARED_PATHS` predicate. Reads that name the entity path still return the room's contents exactly as before, so joining a room and reading it works; only the "show me everything" queries stop volunteering it. The sync and async adapters import the same constant so the two cannot drift.

## Publish the SSE manager so mounted routers can find it

`_sse_manager` was constructed but never attached to `app.state`. Routers mounted from outside this package look it up there, so `/rooms/{id}/stream` answered 503 and every `broadcast_room_event` was a silent no-op — the room UI never received a live update.

One line assigns the existing singleton to `app.state.sse_manager`. No new object, no lifecycle change.