### PR TITLE
Promote to main: shared-room scoping, SSE manager, and per-user tenant context

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -123,12 +123,14 @@ class _TenantRLSConnection:
             get_request_tenant_account_id,
             get_request_tenant_team_id,
             get_request_is_account_admin,
+            get_request_user_id,
         )
 
         conn = self._inner_ctx.__enter__()
         tid = get_request_tenant_account_id()
         team_id = get_request_tenant_team_id()
         is_admin = get_request_is_account_admin()
+        user_id = get_request_user_id()
 
         _TenantRLSConnection._log_counter += 1
         if _TenantRLSConnection._log_counter <= 20 or not tid:
@@ -139,11 +141,21 @@ class _TenantRLSConnection:
             )
 
         with conn.cursor() as cur:
+            # current_user_id is set unconditionally, like the others: on a
+            # pooled connection, leaving it alone would leave the previous
+            # borrower's user in place, and this is the one GUC that grants
+            # access across accounts rather than restricting within one.
             cur.execute(
                 "SELECT set_config('amfs.current_account_id', %s, false),"
                 "       set_config('amfs.current_team_id', %s, false),"
-                "       set_config('amfs.is_account_admin', %s, false)",
-                (tid if tid else "", team_id if team_id else "", "true" if is_admin else "false"),
+                "       set_config('amfs.is_account_admin', %s, false),"
+                "       set_config('amfs.current_user_id', %s, false)",
+                (
+                    tid if tid else "",
+                    team_id if team_id else "",
+                    "true" if is_admin else "false",
+                    user_id if user_id else "",
+                ),
             )
         return conn
 

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -65,6 +65,24 @@ except ImportError:  # pragma: no cover
 
 logger = logging.getLogger(__name__)
 
+# Entity paths of the form @<name>/<topic> denote a shared namespace: one
+# whose contents belong to a group rather than to the account reading them.
+# Access to them is granted separately, outside this adapter.
+#
+# The rule below is that they are only ever returned when they were asked for
+# by name. A query that names no entity_path is an ambient one — "what do I
+# know", "what is relevant here" — and its results land in an agent's context
+# without anyone having decided they should. Shared content reaching that
+# position means a stranger who can write to a shared namespace can put text
+# in front of an agent that is working on something else entirely, which is
+# the shape of a prompt-injection attack and does not require the attacker to
+# do anything but write an ordinary memory.
+#
+# Asking for the path explicitly is the act of deciding to trust it. So
+# read(), and any search scoped to the path, still return everything; it is
+# only the unscoped queries that filter it out.
+_EXCLUDE_SHARED_PATHS = "entity_path NOT LIKE '@%/%'"
+
 _SCHEMA_SQL = (Path(__file__).parent / "schema.sql").read_text(encoding="utf-8")
 
 # SQL mirror of amfs_core.aggregates.recall_tokens_saved: per reuse, credit
@@ -1135,6 +1153,8 @@ class PostgresAdapter(AdapterABC):
         if entity_path is not None:
             conditions.append("entity_path = %s")
             params.append(entity_path)
+        else:
+            conditions.append(_EXCLUDE_SHARED_PATHS)
 
         if not include_superseded:
             conditions.append("superseded_at IS NULL")
@@ -1182,6 +1202,8 @@ class PostgresAdapter(AdapterABC):
         if query.entity_path is not None:
             conditions.append("entity_path = %s")
             params.append(query.entity_path)
+        else:
+            conditions.append(_EXCLUDE_SHARED_PATHS)
         if query.min_confidence > 0:
             conditions.append("confidence >= %s")
             params.append(query.min_confidence)
@@ -1299,6 +1321,8 @@ class PostgresAdapter(AdapterABC):
         if query.entity_path is not None:
             conditions.append("entity_path = %s")
             params.append(query.entity_path)
+        else:
+            conditions.append(_EXCLUDE_SHARED_PATHS)
         if query.min_confidence > 0:
             conditions.append("confidence >= %s")
             params.append(query.min_confidence)
@@ -1748,6 +1772,11 @@ class PostgresAdapter(AdapterABC):
         if agent_ids is not None:
             conditions.append("agent_id = ANY(%s)")
             params.append(list(agent_ids))
+        # No entity_path argument to this one: it is unscoped by construction,
+        # so shared namespaces are always excluded. It groups by entity_path,
+        # which would otherwise list a shared namespace's topics as though
+        # they were this account's own.
+        conditions.append(_EXCLUDE_SHARED_PATHS)
         where = " AND ".join(conditions)
 
         sql = f"""

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -81,7 +81,12 @@ logger = logging.getLogger(__name__)
 # Asking for the path explicitly is the act of deciding to trust it. So
 # read(), and any search scoped to the path, still return everything; it is
 # only the unscoped queries that filter it out.
-_EXCLUDE_SHARED_PATHS = "entity_path NOT LIKE '@%/%'"
+# The wildcards are doubled because psycopg parses '%' as a placeholder marker
+# whenever a query is executed with parameters, and '%/' is not a placeholder.
+# Doubling is safe in both directions: psycopg unescapes it to '@%/%', and on
+# the paths that pass the string through verbatim, consecutive LIKE wildcards
+# collapse, so '@%%/%%' matches exactly what '@%/%' does.
+_EXCLUDE_SHARED_PATHS = "entity_path NOT LIKE '@%%/%%'"
 
 _SCHEMA_SQL = (Path(__file__).parent / "schema.sql").read_text(encoding="utf-8")
 

--- a/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
@@ -61,16 +61,19 @@ class _AsyncTenantRLSConnection:
             get_request_tenant_account_id,
             get_request_tenant_team_id,
             get_request_is_account_admin,
+            get_request_user_id,
         )
 
         conn = await self._inner_ctx.__aenter__()
         tid = get_request_tenant_account_id()
         team_id = get_request_tenant_team_id()
         is_admin = get_request_is_account_admin()
+        user_id = get_request_user_id()
 
         guc_account = tid if tid else ""
         guc_team = team_id if team_id else ""
         guc_admin = "true" if is_admin else "false"
+        guc_user = user_id if user_id else ""
 
         if not tid:
             logger.warning(
@@ -80,11 +83,15 @@ class _AsyncTenantRLSConnection:
             )
 
         async with conn.cursor() as cur:
+            # Set unconditionally, for the same reason as the other three: a
+            # pooled connection would otherwise keep the previous borrower's
+            # user, and this is the GUC that grants access across accounts.
             await cur.execute(
                 "SELECT set_config('amfs.current_account_id', %s, false),"
                 "       set_config('amfs.current_team_id', %s, false),"
-                "       set_config('amfs.is_account_admin', %s, false)",
-                (guc_account, guc_team, guc_admin),
+                "       set_config('amfs.is_account_admin', %s, false),"
+                "       set_config('amfs.current_user_id', %s, false)",
+                (guc_account, guc_team, guc_admin, guc_user),
             )
         return conn
 

--- a/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
@@ -34,7 +34,7 @@ from amfs_core.models import (
     SemanticQuery,
 )
 
-from amfs_postgres.adapter import PostgresAdapter
+from amfs_postgres.adapter import _EXCLUDE_SHARED_PATHS, PostgresAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -402,6 +402,8 @@ class AsyncPostgresAdapter:
         if entity_path is not None:
             conditions.append("entity_path = %s")
             params.append(entity_path)
+        else:
+            conditions.append(_EXCLUDE_SHARED_PATHS)
 
         if not include_superseded:
             conditions.append("superseded_at IS NULL")
@@ -438,6 +440,8 @@ class AsyncPostgresAdapter:
         if query.entity_path is not None:
             conditions.append("entity_path = %s")
             params.append(query.entity_path)
+        else:
+            conditions.append(_EXCLUDE_SHARED_PATHS)
         if query.min_confidence > 0:
             conditions.append("confidence >= %s")
             params.append(query.min_confidence)
@@ -544,6 +548,8 @@ class AsyncPostgresAdapter:
         if query.entity_path is not None:
             conditions.append("entity_path = %s")
             params.append(query.entity_path)
+        else:
+            conditions.append(_EXCLUDE_SHARED_PATHS)
         if query.min_confidence > 0:
             conditions.append("confidence >= %s")
             params.append(query.min_confidence)

--- a/packages/adapters/postgres/src/amfs_postgres/tenant_context.py
+++ b/packages/adapters/postgres/src/amfs_postgres/tenant_context.py
@@ -9,6 +9,15 @@ Stores account_id, team_id, and is_account_admin for two-layer tenancy:
   - account_id  -> amfs.current_account_id  (outer boundary)
   - team_id     -> amfs.current_team_id     (inner boundary)
   - is_admin    -> amfs.is_account_admin    (admin bypass)
+
+and the acting user:
+  - user_id     -> amfs.current_user_id     (cross-account grants)
+
+The first three narrow what a request can see. user_id is the one that can
+widen it: a user invited to a room in someone else's account reaches it
+through permissive policies keyed on this value, and on nothing else. It is
+therefore only ever set from an authenticated identity the server resolved
+itself, never from a client-supplied header taken at face value.
 """
 
 from __future__ import annotations
@@ -18,6 +27,7 @@ from contextvars import ContextVar
 _account_id_var: ContextVar[str | None] = ContextVar("amfs_account_id", default=None)
 _team_id_var: ContextVar[str | None] = ContextVar("amfs_team_id", default=None)
 _is_admin_var: ContextVar[bool] = ContextVar("amfs_is_admin", default=False)
+_user_id_var: ContextVar[str | None] = ContextVar("amfs_user_id", default=None)
 
 
 # -- account_id --
@@ -63,3 +73,23 @@ def clear_tls_is_account_admin() -> None:
 
 def get_request_is_account_admin() -> bool:
     return _is_admin_var.get()
+
+
+# -- user_id --
+
+def set_tls_user_id(user_id: str | None) -> None:
+    """Called from HTTP middleware once the acting user is authenticated.
+
+    Only from a resolved identity — an API key's owner, or a dashboard header
+    whose proxy secret validated. Unlike the account and team vars, this one
+    grants access rather than restricting it.
+    """
+    _user_id_var.set(user_id or None)
+
+
+def clear_tls_user_id() -> None:
+    _user_id_var.set(None)
+
+
+def get_request_user_id() -> str | None:
+    return _user_id_var.get()

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -147,6 +147,14 @@ async def _dashboard_tenant_middleware(request: Request, call_next):
 
 _memory: AgentMemory | None = None
 _sse_manager = SSEManager()
+
+# Routers mounted onto this app from outside the package cannot reach a
+# module-level private, so the manager is published on app.state, which a
+# route reaches through its own Request. Without this the room event stream
+# has no manager to find and answers 503 on every connection, and the
+# broadcasts aimed at it are dropped in silence — which is how it behaved.
+app.state.sse_manager = _sse_manager
+
 _bg_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="amfs-bg")
 _known_agents: set[str] = set()
 # Tracks (agent, namespace, user) triples whose owner linkage was already

--- a/tests/test_shared_path_scoping.py
+++ b/tests/test_shared_path_scoping.py
@@ -50,7 +50,25 @@ class TestTheGuardIsDefinedOnce:
         """A bare '@name' with no topic is not a shared namespace, and an
         ordinary path that merely contains an @ must not be caught."""
         src = SYNC.read_text()
-        assert "entity_path NOT LIKE '@%/%'" in src
+        assert "entity_path NOT LIKE '@%%/%%'" in src
+
+    def test_its_wildcards_are_escaped_for_psycopg(self) -> None:
+        """psycopg reads '%' as the start of a placeholder on any query run
+        with parameters, so a single '%' here raises ProgrammingError the
+        moment an unscoped query also binds a value — which every one of them
+        does. The doubling is load-bearing, not style: consecutive LIKE
+        wildcards collapse, so the escaped form means the same thing on the
+        paths where psycopg passes the string through untouched.
+        """
+        line = next(
+            ln for ln in SYNC.read_text().splitlines()
+            if ln.startswith(f"{GUARD} =")
+        )
+        assert "%" in line, "the guard no longer uses a LIKE pattern"
+        assert not re.search(r"(?<!%)%(?!%)", line), (
+            f"unescaped '%' in {line.strip()} — psycopg will reject any "
+            f"unscoped query that binds parameters"
+        )
 
     def test_the_async_adapter_shares_the_definition(self) -> None:
         """Two copies of a security rule is one copy that gets forgotten."""

--- a/tests/test_shared_path_scoping.py
+++ b/tests/test_shared_path_scoping.py
@@ -1,0 +1,118 @@
+"""Shared namespaces are returned only when they are asked for by name.
+
+An entity path of the form @<name>/<topic> is a shared namespace: its
+contents belong to a group, and people outside the account reading them can
+write to it. That is the feature. The hazard is where those writes end up.
+
+An unscoped query — search with no entity_path, list() with no argument, the
+retrieval that backs "what do I know about this" — puts its results into an
+agent's context without anyone having chosen them. If shared content can
+land there, then anyone who can write to a shared namespace can put text in
+front of an agent that is working on something else entirely. They do not
+need to breach anything; they write an ordinary memory and wait. Naming the
+path is the act of deciding to trust it, so scoped reads are untouched and
+only the ambient ones filter.
+
+These are SQL-shape tests. The behaviour they protect is invisible in normal
+use and the failure is silent, so the guard is easy to drop in a refactor
+and nothing will notice.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[1] / (
+    "packages/adapters/postgres/src/amfs_postgres"
+)
+SYNC = SRC / "adapter.py"
+ASYNC = SRC / "async_adapter.py"
+
+GUARD = "_EXCLUDE_SHARED_PATHS"
+
+
+def _method(path: Path, name: str) -> str:
+    """The source of one method, up to the next def at the same indent."""
+    src = path.read_text()
+    start = src.index(f"    def {name}(") if f"    def {name}(" in src else src.index(
+        f"    async def {name}("
+    )
+    rest = src[start + 10 :]
+    end = re.search(r"\n    (?:async )?def ", rest)
+    return src[start : start + 10 + (end.start() if end else len(rest))]
+
+
+class TestTheGuardIsDefinedOnce:
+    def test_it_matches_prefixed_paths_only(self) -> None:
+        """A bare '@name' with no topic is not a shared namespace, and an
+        ordinary path that merely contains an @ must not be caught."""
+        src = SYNC.read_text()
+        assert "entity_path NOT LIKE '@%/%'" in src
+
+    def test_the_async_adapter_shares_the_definition(self) -> None:
+        """Two copies of a security rule is one copy that gets forgotten."""
+        assert f"from amfs_postgres.adapter import {GUARD}" in ASYNC.read_text()
+        assert f'{GUARD} = ' not in ASYNC.read_text()
+
+
+class TestUnscopedReadsExcludeSharedNamespaces:
+    @pytest.mark.parametrize(
+        "path,method",
+        [
+            (SYNC, "list"),
+            (SYNC, "search"),
+            (SYNC, "semantic_search"),
+            (ASYNC, "list"),
+            (ASYNC, "search"),
+            (ASYNC, "semantic_search"),
+        ],
+    )
+    def test_the_guard_is_applied_when_no_path_is_given(self, path, method) -> None:
+        body = _method(path, method)
+        assert GUARD in body, (
+            f"{path.name}:{method} can return shared-namespace entries to a "
+            f"query that never asked for them"
+        )
+
+    @pytest.mark.parametrize(
+        "path,method",
+        [
+            (SYNC, "list"),
+            (SYNC, "search"),
+            (SYNC, "semantic_search"),
+            (ASYNC, "list"),
+            (ASYNC, "search"),
+            (ASYNC, "semantic_search"),
+        ],
+    )
+    def test_it_is_the_else_of_the_entity_path_filter(self, path, method) -> None:
+        """Applying it unconditionally would break the scoped read too, which
+        is the one case that must keep working: naming the path is how a
+        caller says they want it."""
+        body = _method(path, method)
+        assert re.search(
+            r'conditions\.append\("entity_path = %s"\)\s*\n'
+            r'\s*params\.append\([^)]+\)\s*\n'
+            r'\s*else:\s*\n'
+            r'\s*conditions\.append\(' + GUARD + r'\)',
+            body,
+        ), f"{path.name}:{method} does not gate the guard on the path being absent"
+
+    def test_entity_summaries_is_always_filtered(self) -> None:
+        """It takes no entity_path at all and groups by it, so a shared
+        namespace's topics would be listed as though they were this
+        account's own."""
+        assert GUARD in _method(SYNC, "entity_summaries")
+
+
+class TestScopedReadsAreUntouched:
+    def test_read_does_not_filter(self) -> None:
+        """read() names both the path and the key. That is as explicit as a
+        request gets, and filtering it would make shared rooms unreadable."""
+        assert GUARD not in _method(SYNC, "read")
+
+    def test_read_at_version_does_not_filter(self) -> None:
+        assert GUARD not in _method(SYNC, "read_at_version")

--- a/tests/unit/test_async_adapter.py
+++ b/tests/unit/test_async_adapter.py
@@ -40,6 +40,7 @@ class TestAsyncTenantRLSConnection:
             patch("amfs_postgres.tenant_context.get_request_tenant_account_id", return_value="acct-123"),
             patch("amfs_postgres.tenant_context.get_request_tenant_team_id", return_value="team-456"),
             patch("amfs_postgres.tenant_context.get_request_is_account_admin", return_value=True),
+            patch("amfs_postgres.tenant_context.get_request_user_id", return_value="user-789"),
         ):
             rls = _AsyncTenantRLSConnection(inner_ctx)
             conn = await rls.__aenter__()
@@ -49,7 +50,8 @@ class TestAsyncTenantRLSConnection:
         assert "set_config('amfs.current_account_id'" in sql
         assert "set_config('amfs.current_team_id'" in sql
         assert "set_config('amfs.is_account_admin'" in sql
-        assert params == ("acct-123", "team-456", "true")
+        assert "set_config('amfs.current_user_id'" in sql
+        assert params == ("acct-123", "team-456", "true", "user-789")
 
     async def test_no_tenant_sets_empty_strings(self, _make_conn):
         from amfs_postgres.async_adapter import _AsyncTenantRLSConnection
@@ -60,13 +62,14 @@ class TestAsyncTenantRLSConnection:
             patch("amfs_postgres.tenant_context.get_request_tenant_account_id", return_value=None),
             patch("amfs_postgres.tenant_context.get_request_tenant_team_id", return_value=None),
             patch("amfs_postgres.tenant_context.get_request_is_account_admin", return_value=False),
+            patch("amfs_postgres.tenant_context.get_request_user_id", return_value=None),
         ):
             rls = _AsyncTenantRLSConnection(inner_ctx)
             await rls.__aenter__()
 
         assert len(executed) == 1
         _, params = executed[0]
-        assert params == ("", "", "false")
+        assert params == ("", "", "false", "")
 
     async def test_admin_false(self, _make_conn):
         from amfs_postgres.async_adapter import _AsyncTenantRLSConnection
@@ -77,12 +80,43 @@ class TestAsyncTenantRLSConnection:
             patch("amfs_postgres.tenant_context.get_request_tenant_account_id", return_value="acct-x"),
             patch("amfs_postgres.tenant_context.get_request_tenant_team_id", return_value="team-y"),
             patch("amfs_postgres.tenant_context.get_request_is_account_admin", return_value=False),
+            patch("amfs_postgres.tenant_context.get_request_user_id", return_value=None),
         ):
             rls = _AsyncTenantRLSConnection(inner_ctx)
             await rls.__aenter__()
 
         _, params = executed[0]
-        assert params == ("acct-x", "team-y", "false")
+        assert params == ("acct-x", "team-y", "false", "")
+
+    async def test_a_pooled_connection_never_inherits_the_last_users_identity(
+        self, _make_conn
+    ):
+        """The GUC that grants cross-account access must be reset, not skipped.
+
+        Every other GUC here narrows what a request can see, so leaving a
+        stale one behind fails closed. current_user_id is the opposite: it is
+        what lets an invited user reach a room in someone else's account. A
+        connection handed on with the previous borrower's user still set
+        would grant the next request their room access.
+        """
+        from amfs_postgres.async_adapter import _AsyncTenantRLSConnection
+
+        inner_ctx, executed = _make_conn
+
+        with (
+            patch("amfs_postgres.tenant_context.get_request_tenant_account_id", return_value="acct-x"),
+            patch("amfs_postgres.tenant_context.get_request_tenant_team_id", return_value=None),
+            patch("amfs_postgres.tenant_context.get_request_is_account_admin", return_value=False),
+            patch("amfs_postgres.tenant_context.get_request_user_id", return_value=None),
+        ):
+            await _AsyncTenantRLSConnection(inner_ctx).__aenter__()
+
+        sql, params = executed[0]
+        assert "set_config('amfs.current_user_id'" in sql, (
+            "current_user_id is left untouched on checkout, so it keeps "
+            "whatever the previous borrower of this pooled connection set"
+        )
+        assert params[3] == ""
 
     async def test_aexit_delegates(self, _make_conn):
         from amfs_postgres.async_adapter import _AsyncTenantRLSConnection
@@ -93,6 +127,7 @@ class TestAsyncTenantRLSConnection:
             patch("amfs_postgres.tenant_context.get_request_tenant_account_id", return_value=None),
             patch("amfs_postgres.tenant_context.get_request_tenant_team_id", return_value=None),
             patch("amfs_postgres.tenant_context.get_request_is_account_admin", return_value=False),
+            patch("amfs_postgres.tenant_context.get_request_user_id", return_value=None),
         ):
             rls = _AsyncTenantRLSConnection(inner_ctx)
             await rls.__aenter__()

--- a/tests/unit/test_sse_manager_is_published.py
+++ b/tests/unit/test_sse_manager_is_published.py
@@ -1,0 +1,41 @@
+"""The SSE manager is reachable from routers mounted outside this package.
+
+Room routes live in a separate distribution and are mounted onto this app.
+They cannot see a module-level private, so they look for the manager on
+`request.app.state.sse_manager` — and nothing was putting it there. The room
+event stream therefore answered 503 on every connection and every broadcast
+aimed at it was dropped without a word, because a broadcast with no
+subscribers is indistinguishable from one nobody happened to be watching.
+
+A one-line omission that disables a whole feature and produces no error is
+worth a test, even a test this small.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+
+def test_the_manager_is_published_on_app_state() -> None:
+    from amfs_http.server import app
+
+    assert getattr(app.state, "sse_manager", None) is not None
+
+
+def test_it_is_the_same_object_the_write_path_broadcasts_on() -> None:
+    """Two managers would be worse than none: writes would broadcast into one
+    while subscribers waited on the other, and nothing anywhere would fail."""
+    from amfs_http import server
+
+    assert server.app.state.sse_manager is server._sse_manager
+
+
+def test_it_can_broadcast_a_room_event() -> None:
+    """Shape check on the interface the room routes actually call."""
+    from amfs_http.server import app
+
+    app.state.sse_manager.broadcast_room_event(
+        "00000000-0000-4000-8000-000000000000", "join", {"user_id": "u1"},
+    )

--- a/tests/unit/test_tenant_rls_connection.py
+++ b/tests/unit/test_tenant_rls_connection.py
@@ -1,0 +1,105 @@
+"""The sync pooled-connection RLS wrapper.
+
+Four session variables decide what a request can see. Three of them narrow:
+account, team, and the admin flag. A stale value there fails closed — the
+next borrower of the connection sees less than they should, which is a bug
+but not a leak.
+
+amfs.current_user_id is the one that widens. Permissive policies use it to
+let a user reach rooms in accounts that are not theirs, so a connection
+handed on with the previous borrower's user still set grants the next
+request that person's room access. Hence: set on every checkout, never
+conditionally.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def _make_conn():
+    executed: list = []
+
+    cur = MagicMock()
+    cur.execute = MagicMock(side_effect=lambda sql, params=None: executed.append((sql, params)))
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=None)
+
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=cur)
+
+    inner_ctx = MagicMock()
+    inner_ctx.__enter__ = MagicMock(return_value=conn)
+    inner_ctx.__exit__ = MagicMock(return_value=None)
+
+    return inner_ctx, executed
+
+
+def _checkout(inner_ctx, *, account="acct-1", team=None, admin=False, user=None):
+    from amfs_postgres.adapter import _TenantRLSConnection
+
+    with (
+        patch("amfs_postgres.tenant_context.get_request_tenant_account_id", return_value=account),
+        patch("amfs_postgres.tenant_context.get_request_tenant_team_id", return_value=team),
+        patch("amfs_postgres.tenant_context.get_request_is_account_admin", return_value=admin),
+        patch("amfs_postgres.tenant_context.get_request_user_id", return_value=user),
+    ):
+        return _TenantRLSConnection(inner_ctx).__enter__()
+
+
+class TestTheActingUserReachesTheDatabase:
+    def test_the_user_guc_is_set_from_context(self, _make_conn):
+        """Without this, the cross-account room policies match nothing and an
+        invited user sees an empty room rather than its contents."""
+        inner_ctx, executed = _make_conn
+
+        _checkout(inner_ctx, account="acct-1", user="user-42")
+
+        sql, params = executed[0]
+        assert "set_config('amfs.current_user_id'" in sql
+        assert "user-42" in params
+
+    def test_all_four_gucs_are_set_in_one_statement(self, _make_conn):
+        # One round trip per checkout; this is on every request's hot path.
+        inner_ctx, executed = _make_conn
+
+        _checkout(inner_ctx, account="a", team="t", admin=True, user="u")
+
+        assert len(executed) == 1
+        sql, params = executed[0]
+        for guc in (
+            "amfs.current_account_id",
+            "amfs.current_team_id",
+            "amfs.is_account_admin",
+            "amfs.current_user_id",
+        ):
+            assert f"set_config('{guc}'" in sql
+        assert params == ("a", "t", "true", "u")
+
+
+class TestAPooledConnectionCarriesNothingOver:
+    def test_no_user_still_writes_an_empty_string(self, _make_conn):
+        """Skipping the set when there is no user is what would make this
+        dangerous: the connection keeps the last borrower's identity, and the
+        permissive room policies would grant their access to whoever holds
+        the connection next."""
+        inner_ctx, executed = _make_conn
+
+        _checkout(inner_ctx, account="acct-2", user=None)
+
+        sql, params = executed[0]
+        assert "set_config('amfs.current_user_id'" in sql
+        assert params[3] == "", "must clear, not leave the previous value"
+
+    def test_an_unauthenticated_checkout_clears_everything(self, _make_conn):
+        inner_ctx, executed = _make_conn
+
+        _checkout(inner_ctx, account=None, team=None, admin=False, user=None)
+
+        _sql, params = executed[0]
+        # NULLIF in the policies turns each empty string into NULL, which
+        # matches no rows.
+        assert params == ("", "", "false", "")


### PR DESCRIPTION
Promotes `dev` to `main`. Two commits, both groundwork for shared room join links in amfs-internal. Merged to `dev` as #286 and #287 and deployed green there.

**Merge this before raia-live/amfs-internal's promotion** — the internal `_apply_user_tls` imports `amfs_postgres.tenant_context`, and the room SSE stream reads `app.state.sse_manager`. Both land here.

## What's in it

**Carry the acting user onto pooled connections (#286).** Adds `set_tls_user_id` / `clear_tls_user_id` to `amfs_postgres.tenant_context`, so RLS policies can see who is asking and not just which account. Cross-account room access needs the user identity on the connection; before this only the account GUC was published.

**Return shared namespaces only when they are asked for by name (#287).** A room's memories live on an entity path several accounts can reach. Unscoped reads — `list`, `search`, `semantic_search`, `entity_summaries` with no entity filter — were sweeping those into results. That is a prompt-injection surface as much as a privacy one: a broad recall would pick up text a stranger wrote in a shared room, with nothing marking it as foreign. A shared `_EXCLUDE_SHARED_PATHS` predicate now excludes those paths from unscoped queries only; naming the entity path still returns the room exactly as before.

**Publish the SSE manager so mounted routers can find it (#287).** `_sse_manager` was built but never attached to `app.state`, so `/rooms/{id}/stream` answered 503 and every `broadcast_room_event` was a silent no-op. One assignment, same singleton.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes security-sensitive retrieval scoping and cross-account RLS session variables on pooled connections; incorrect filtering or stale `current_user_id` could enable prompt-injection via ambient recall or grant another user’s room access.
> 
> **Overview**
> Groundwork for shared rooms: **unscoped memory reads no longer sweep shared namespaces** (`@name/topic` paths). A shared `_EXCLUDE_SHARED_PATHS` SQL predicate is applied when `list`, `search`, `semantic_search`, and `entity_summaries` run without an `entity_path`; **explicit path-scoped reads are unchanged**. Sync and async Postgres adapters share one definition; wildcards are doubled for psycopg parameter escaping.
> 
> **Acting user identity is carried on every pooled DB checkout** via new `set_tls_user_id` / `get_request_user_id` in `tenant_context` and `set_config('amfs.current_user_id', …)` alongside the existing account/team/admin GUCs (sync `_TenantRLSConnection` and async `_AsyncTenantRLSConnection`). The user GUC is always set—even to empty string when absent—so a previous borrower’s cross-account grants cannot leak on the next request.
> 
> **Room SSE**: `app.state.sse_manager` is assigned the process singleton so externally mounted room routes can subscribe and receive `broadcast_room_event` (previously 503 / silent drops).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2ae6caad368e0ca7804fd26e7fb2465663d94cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->