### PR TITLE
fix(postgres): escape the LIKE wildcards in the shared-path guard

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -81,7 +81,12 @@ logger = logging.getLogger(__name__)
 # Asking for the path explicitly is the act of deciding to trust it. So
 # read(), and any search scoped to the path, still return everything; it is
 # only the unscoped queries that filter it out.
-_EXCLUDE_SHARED_PATHS = "entity_path NOT LIKE '@%/%'"
+# The wildcards are doubled because psycopg parses '%' as a placeholder marker
+# whenever a query is executed with parameters, and '%/' is not a placeholder.
+# Doubling is safe in both directions: psycopg unescapes it to '@%/%', and on
+# the paths that pass the string through verbatim, consecutive LIKE wildcards
+# collapse, so '@%%/%%' matches exactly what '@%/%' does.
+_EXCLUDE_SHARED_PATHS = "entity_path NOT LIKE '@%%/%%'"
 
 _SCHEMA_SQL = (Path(__file__).parent / "schema.sql").read_text(encoding="utf-8")
 

--- a/tests/test_shared_path_scoping.py
+++ b/tests/test_shared_path_scoping.py
@@ -50,7 +50,25 @@ class TestTheGuardIsDefinedOnce:
         """A bare '@name' with no topic is not a shared namespace, and an
         ordinary path that merely contains an @ must not be caught."""
         src = SYNC.read_text()
-        assert "entity_path NOT LIKE '@%/%'" in src
+        assert "entity_path NOT LIKE '@%%/%%'" in src
+
+    def test_its_wildcards_are_escaped_for_psycopg(self) -> None:
+        """psycopg reads '%' as the start of a placeholder on any query run
+        with parameters, so a single '%' here raises ProgrammingError the
+        moment an unscoped query also binds a value — which every one of them
+        does. The doubling is load-bearing, not style: consecutive LIKE
+        wildcards collapse, so the escaped form means the same thing on the
+        paths where psycopg passes the string through untouched.
+        """
+        line = next(
+            ln for ln in SYNC.read_text().splitlines()
+            if ln.startswith(f"{GUARD} =")
+        )
+        assert "%" in line, "the guard no longer uses a LIKE pattern"
+        assert not re.search(r"(?<!%)%(?!%)", line), (
+            f"unescaped '%' in {line.strip()} — psycopg will reject any "
+            f"unscoped query that binds parameters"
+        )
 
     def test_the_async_adapter_shares_the_definition(self) -> None:
         """Two copies of a security rule is one copy that gets forgotten."""


### PR DESCRIPTION
Fixes the `test (3.11)` and `test (3.12)` failures on #288. Targets `dev` because #288 is `dev` → `main`, so the fix has to land on `dev` for that promotion to go green.

## What broke

`_EXCLUDE_SHARED_PATHS` was `"entity_path NOT LIKE '@%/%'"`. psycopg reads `%` as the start of a placeholder on any query executed with parameters, and `%/` is not one:

```
psycopg.ProgrammingError: only '%s', '%b', '%t' are allowed as placeholders, got '%/'
```

Every unscoped read binds at least one value, so `list()`, `search()`, `semantic_search()` and `entity_summaries()` all raised as soon as the guard was appended. `tests/integration/test_postgres_adapter.py::test_list_all_entities` caught it in CI.

## The fix

Double the wildcards. That is correct in both directions:

- where psycopg processes the string, it unescapes `'@%%/%%'` back to `'@%/%'`;
- where it passes it through verbatim (no parameters), consecutive LIKE wildcards collapse, so `'@%%/%%'` matches exactly what `'@%/%'` matched.

Confirmed server-side rather than assumed — the two patterns agree on prefixed paths (`@acme/notes`, `@acme/a/b`, `@/x`), bare-`@` paths (`@noslash`, `@`), and ordinary ones (`plain/path`, `myapp/auth`, `a@b/c`, empty).

## Why it reached CI

`tests/test_shared_path_scoping.py` is a set of source-shape assertions; it greps the adapter source and never executes any SQL, so it was green against a predicate the database would reject. The postgres integration tests do execute it, but they skip silently unless `AMFS_TEST_PG_DSN` is set, which it was not in my local run.

Added `test_its_wildcards_are_escaped_for_psycopg`, which fails on an unescaped `%` in the constant without needing a database, so the unit job catches this class of error where the integration job may be skipped. Verified it fails on the old form and passes on the new one, alongside the integration test.

## Validation

With `AMFS_TEST_PG_DSN` pointed at a local Postgres: `tests/integration/test_postgres_adapter.py` 12/12 pass (was 11 pass, 1 fail). Full suite is back to the 4 failures that also fail on `main` — three framework-integration tests missing optional deps, one MCP agent-id env test.

Made with [Cursor](https://cursor.com)