### PR TITLE
REUSE_CREDIT_K no longer mirrors the Pro chat recap

### DIFF
--- a/packages/core/src/amfs_core/aggregates.py
+++ b/packages/core/src/amfs_core/aggregates.py
@@ -29,13 +29,16 @@ RECALL_TOKENS_FLOOR = 200
 RECALL_TOKENS_CEIL = 4000
 CHARS_PER_TOKEN = 4
 
-# How many hits of a query-driven lookup (retrieve/search) count as reuse.
-# One: reuse should count the memory an agent took, not the candidate list it
-# was shown. Crediting the top three inflated the number roughly threefold —
-# one real session made 4 lookups, was credited 16 reuses, and exactly 1 of
-# those memories changed what the agent did. Mirrored by the MCP server's
-# value_ledger.py (REUSE_CREDIT_K) so the chat recap and the dashboard describe
-# the same query identically.
+# How many hits of a query-driven lookup (retrieve/search) bump recall_count.
+# One: per-entry reuse should count the memory an agent took, not the candidate
+# list it was shown. Crediting the top three inflated the number roughly
+# threefold — one real session made 4 lookups, was credited 16 reuses, and
+# exactly 1 of those memories changed what the agent did.
+#
+# The Pro MCP server's chat recap (value_ledger.py) deliberately no longer
+# mirrors this: it estimates what a single CALL delivered, so it credits every
+# entry returned. The two answer different questions — this one is the
+# dashboard's per-entry source of truth — and are not expected to match.
 REUSE_CREDIT_K = 1
 
 


### PR DESCRIPTION
## Summary

Comment-only correction. `REUSE_CREDIT_K` claimed that the Pro MCP server's `value_ledger.py` mirrors it "so the chat recap and the dashboard describe the same query identically". That stopped being true in raia-live/amfs-internal#456: the Pro chat recap now estimates what a single **call** delivered and credits every entry returned, while this constant stays per-entry and remains the dashboard's source of truth.

The two answer different questions by design. Saying so beats leaving a cross-reference that quietly went stale and would mislead the next person into "fixing" the divergence.

## Test plan

- [x] No behavior change — comment only; `REUSE_CREDIT_K = 1` is unchanged.

Made with [Cursor](https://cursor.com)