### PR TITLE
Capture the request that triggered a decision, and make it publishable

### DIFF
--- a/packages/adapters/http/pyproject.toml
+++ b/packages/adapters/http/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "amfs-adapter-http"
-version = "0.1.8"
+version = "0.1.9"
 description = "AMFS HTTP adapter — routes memory operations through the authenticated REST API"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 dependencies = [
-    "amfs-core",
+    # 0.3.13 adds the capture fields this adapter now sends on the outcome record.
+    "amfs-core>=0.3.13",
     "httpx>=0.27,<1",
 ]
 

--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -180,13 +180,20 @@ class HttpAdapter(AdapterABC):
         return WatchHandle(cancel_fn=lambda: None)
 
     def commit_outcome(self, record: OutcomeRecord) -> list[MemoryEntry]:
-        body = {
+        body: dict[str, Any] = {
             "outcome_ref": record.outcome_ref,
             "outcome_type": record.outcome_type.value if hasattr(record.outcome_type, "value") else str(record.outcome_type),
             "causal_entry_keys": record.causal_entry_keys,
             "causal_confidence": record.causal_confidence,
             "agent_id": record.agent_id,
         }
+        # The server seals its immutable trace from this call, so the capture has to
+        # travel with it. Sending it only on the later save_trace left the sealed
+        # copy — which is what Pro export and training read — with an empty prompt.
+        if record.task_input:
+            body["task_input"] = record.task_input
+        if record.response_text:
+            body["response_text"] = record.response_text
         data = self._post("/api/v1/outcomes", body)
         return [_parse_entry(e) for e in data.get("entries", [])]
 

--- a/packages/adapters/postgres/pyproject.toml
+++ b/packages/adapters/postgres/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "amfs-adapter-postgres"
-version = "0.1.8"
+version = "0.1.9"
 description = "AMFS Postgres adapter with back-propagation triggers"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 dependencies = [
-    "amfs-core",
+    # 0.3.13 adds the capture fields this adapter now persists and selects back.
+    "amfs-core>=0.3.13",
     "psycopg[binary]>=3.1,<4",
     "psycopg-pool>=3.1",
 ]

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -2179,7 +2179,8 @@ class PostgresAdapter(AdapterABC):
                 cur.execute(
                     """
                     SELECT id, agent_id, session_id, outcome_ref, outcome_type,
-                           decision_summary, causal_entries, external_contexts,
+                           decision_summary, task_input, response_text,
+                           causal_entries, external_contexts,
                            query_events, session_started_at, session_ended_at,
                            session_duration_ms,
                            error_events, state_diff, created_at
@@ -2263,7 +2264,8 @@ class PostgresAdapter(AdapterABC):
         where = " AND ".join(conditions)
         sql = f"""
             SELECT id, agent_id, session_id, outcome_ref, outcome_type,
-                   decision_summary, causal_entries, external_contexts,
+                   decision_summary, task_input, response_text,
+                   causal_entries, external_contexts,
                    query_events, session_started_at, session_ended_at,
                    session_duration_ms,
                    error_events, state_diff, created_at

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -317,6 +317,17 @@ class PostgresAdapter(AdapterABC):
             ALTER TABLE amfs_decision_traces
             ADD COLUMN IF NOT EXISTS session_metadata JSONB DEFAULT '{}'
         """)
+        # The request that triggered the decision, and optionally the agent's
+        # response. Supervised training needs the prompt side of the pair, and
+        # the trace previously recorded only what was decided.
+        cur.execute("""
+            ALTER TABLE amfs_decision_traces
+            ADD COLUMN IF NOT EXISTS task_input TEXT
+        """)
+        cur.execute("""
+            ALTER TABLE amfs_decision_traces
+            ADD COLUMN IF NOT EXISTS response_text TEXT
+        """)
         cur.execute("""
             ALTER TABLE amfs_digests
             ADD COLUMN IF NOT EXISTS branch TEXT NOT NULL DEFAULT 'main'
@@ -2194,9 +2205,11 @@ class PostgresAdapter(AdapterABC):
                          decision_summary, causal_entries, external_contexts,
                          query_events, session_started_at, session_ended_at,
                          session_duration_ms,
-                         error_events, state_diff, session_metadata, created_at)
+                         error_events, state_diff, session_metadata, created_at,
+                         task_input, response_text)
                     VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb,
-                            %s::jsonb, %s, %s, %s, %s::jsonb, %s::jsonb, %s::jsonb, %s)
+                            %s::jsonb, %s, %s, %s, %s::jsonb, %s::jsonb, %s::jsonb, %s,
+                            %s, %s)
                     RETURNING id, created_at
                     """,
                     (
@@ -2216,6 +2229,8 @@ class PostgresAdapter(AdapterABC):
                         json.dumps(trace.state_diff.model_dump(mode="json")) if trace.state_diff else None,
                         json.dumps(trace.session_metadata) if trace.session_metadata else "{}",
                         trace.created_at,
+                        trace.task_input,
+                        trace.response_text,
                     ),
                 )
                 row = cur.fetchone()
@@ -2302,6 +2317,8 @@ class PostgresAdapter(AdapterABC):
             outcome_ref=row.get("outcome_ref"),
             outcome_type=row.get("outcome_type"),
             decision_summary=row.get("decision_summary"),
+            task_input=row.get("task_input"),
+            response_text=row.get("response_text"),
             causal_entries=[TraceEntry(**e) for e in ce_raw],
             external_contexts=[ExternalContext(**c) for c in ec_raw],
             query_events=[QueryEvent(**q) for q in qe_raw],

--- a/packages/adapters/postgres/src/amfs_postgres/schema.sql
+++ b/packages/adapters/postgres/src/amfs_postgres/schema.sql
@@ -58,6 +58,8 @@ CREATE TABLE IF NOT EXISTS amfs_decision_traces (
     outcome_ref TEXT,
     outcome_type TEXT,
     decision_summary TEXT,
+    task_input TEXT,
+    response_text TEXT,
     causal_entries JSONB DEFAULT '[]',
     external_contexts JSONB DEFAULT '[]',
     query_events JSONB DEFAULT '[]',

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-core"
-version = "0.3.12"
+version = "0.3.13"
 description = "AMFS core models, engine, and adapter ABC"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/core/src/amfs_core/capture.py
+++ b/packages/core/src/amfs_core/capture.py
@@ -21,7 +21,8 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, MutableMapping
+from weakref import WeakKeyDictionary
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +31,40 @@ logger = logging.getLogger(__name__)
 #: latency problem, and no training example is allowed near this size anyway.
 MAX_CAPTURED_CHARS = 200_000
 
-_GATE_CACHE: dict[str, Any] = {}
+#: One gate per adapter, not one per process. ``SafetyGate`` keeps the adapter it
+#: was built with and its validator reads through it, so a single shared instance
+#: would vet every caller's capture through whichever adapter happened to arrive
+#: first — in the hosted server, that is one tenant's connection answering every
+#: other tenant's request. Keyed weakly so a gate is collected with its adapter
+#: rather than pinning it for the life of the process.
+_GATE_CACHE: MutableMapping[Any, Any] = WeakKeyDictionary()
+
+#: ``None`` cannot be a weak key, and an adapterless gate is shared by definition.
+_ADAPTERLESS_GATE: list[Any] = []
+
+
+def _gate_for(adapter: Any) -> Any:
+    """The SafetyGate bound to this adapter, built once and reused.
+
+    Raises ``ImportError`` when the Pro safety package is absent, which the
+    callers below treat as "no gate available" rather than as a failed scan.
+    """
+    from amfs_safety import SafetyGate  # Pro package, optional
+
+    if adapter is None:
+        if not _ADAPTERLESS_GATE:
+            _ADAPTERLESS_GATE.append(SafetyGate(adapter=None))
+        return _ADAPTERLESS_GATE[0]
+    try:
+        gate = _GATE_CACHE.get(adapter)
+        if gate is None:
+            gate = SafetyGate(adapter=adapter)
+            _GATE_CACHE[adapter] = gate
+        return gate
+    except TypeError:
+        # An adapter that cannot be hashed or weakly referenced still needs a
+        # correctly bound gate. It just does not get a cached one.
+        return SafetyGate(adapter=adapter)
 
 
 def scan_captured_text(
@@ -54,11 +88,7 @@ def scan_captured_text(
     try:
         from amfs_core.models import MemoryEntry, Provenance
 
-        if "gate" not in _GATE_CACHE:
-            from amfs_safety import SafetyGate  # Pro package, optional
-
-            _GATE_CACHE["gate"] = SafetyGate(adapter=adapter)
-        gate = _GATE_CACHE["gate"]
+        gate = _gate_for(adapter)
         entry = MemoryEntry(
             entity_path="_capture/task_input",
             key="scan",

--- a/packages/core/src/amfs_core/capture.py
+++ b/packages/core/src/amfs_core/capture.py
@@ -75,7 +75,17 @@ def scan_captured_text(
             logger.info("Captured text blocked by SafetyGate; dropping from trace")
             return None
         scanned = decision.entry.value
-        return scanned if isinstance(scanned, str) else text
+        if isinstance(scanned, str):
+            return scanned
+        # The gate allowed the write but handed back something that is not a
+        # string. Falling back to the caller's original text here would return the
+        # one value known *not* to be what the gate approved — if it redacted into
+        # a non-string form, the secret would go straight through. Drop instead.
+        logger.warning(
+            "SafetyGate returned a non-string value (%s); dropping capture",
+            type(scanned).__name__,
+        )
+        return None
     except ImportError:
         # OSS install without the Pro safety package. Capture is opt-in and the
         # caller asked for it, so store the text rather than silently dropping.

--- a/packages/core/src/amfs_core/capture.py
+++ b/packages/core/src/amfs_core/capture.py
@@ -1,0 +1,91 @@
+"""Sanitising captured prompt and response text before it is persisted.
+
+``DecisionTrace.task_input`` and ``DecisionTrace.response_text`` hold the request
+an agent was given and the answer it produced. That is the most useful material
+in the trace — it is the prompt half of a training example — and also the most
+dangerous, because it is raw caller text that routinely contains API keys,
+connection strings and customer data.
+
+This lives in core rather than next to any one entry point because a trace can be
+built from several: the SDK's ``commit_outcome``, the HTTP server's trace
+endpoints, and the MCP tool that wraps the SDK. When the scan lived only in the
+HTTP server, the MCP path stored raw text while its own documentation promised it
+had been redacted. One implementation, called wherever a trace is constructed, is
+the only arrangement where that cannot drift apart again.
+
+The scan itself is provided by the Pro ``amfs_safety`` package. On an OSS install
+it is absent, and capture is opt-in, so the text is stored as supplied.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Captured prompts and responses are unbounded caller-supplied text. Truncating
+#: before the safety scan keeps a runaway payload from becoming a storage or
+#: latency problem, and no training example is allowed near this size anyway.
+MAX_CAPTURED_CHARS = 200_000
+
+_GATE_CACHE: dict[str, Any] = {}
+
+
+def scan_captured_text(
+    text: str | None,
+    *,
+    adapter: Any = None,
+    agent_id: str = "",
+    session_id: str = "",
+) -> str | None:
+    """Redact secrets from captured prompt/response text before it is persisted.
+
+    Returns ``None`` when the gate blocks the text outright, and also when the
+    gate is present but errors. Losing one training example is always preferable
+    to writing a customer credential into a dataset that later leaves our
+    infrastructure for a tuning job.
+    """
+    if not text:
+        return None
+    if len(text) > MAX_CAPTURED_CHARS:
+        text = text[:MAX_CAPTURED_CHARS]
+    try:
+        from amfs_core.models import MemoryEntry, Provenance
+
+        if "gate" not in _GATE_CACHE:
+            from amfs_safety import SafetyGate  # Pro package, optional
+
+            _GATE_CACHE["gate"] = SafetyGate(adapter=adapter)
+        gate = _GATE_CACHE["gate"]
+        entry = MemoryEntry(
+            entity_path="_capture/task_input",
+            key="scan",
+            value=text,
+            provenance=Provenance(
+                agent_id=agent_id,
+                session_id=session_id,
+                written_at=datetime.now(UTC),
+            ),
+            confidence=0.5,
+        )
+        decision = gate.check_write(entry)
+        if not decision.allowed:
+            logger.info("Captured text blocked by SafetyGate; dropping from trace")
+            return None
+        scanned = decision.entry.value
+        return scanned if isinstance(scanned, str) else text
+    except ImportError:
+        # OSS install without the Pro safety package. Capture is opt-in and the
+        # caller asked for it, so store the text rather than silently dropping.
+        return text
+    except Exception:
+        # Fail closed. The gate exists here — it simply failed — so returning the
+        # text would store exactly what we could not vet, which is the one thing
+        # this function is for. Logged at warning rather than debug because a gate
+        # that errors is silently degrading every capture until someone notices.
+        logger.warning(
+            "SafetyGate scan of captured text failed; dropping capture", exc_info=True
+        )
+        return None

--- a/packages/core/src/amfs_core/models.py
+++ b/packages/core/src/amfs_core/models.py
@@ -249,6 +249,14 @@ class OutcomeRecord(BaseModel):
     committed_at: datetime
     causal_entry_keys: list[str] = Field(default_factory=list)
     agent_id: str
+    #: Captured prompt and response, carried alongside the outcome rather than
+    #: only on the trace. On the SaaS path the adapter's ``commit_outcome`` is what
+    #: reaches the server, and the server seals its immutable trace from that call
+    #: — so a capture that travelled only on the later ``save_trace`` was missing
+    #: from the sealed copy that training and export actually read. Not persisted
+    #: to the outcomes table; adapters write named columns.
+    task_input: str | None = None
+    response_text: str | None = None
 
 
 class TraceEntry(BaseModel):

--- a/packages/core/src/amfs_core/models.py
+++ b/packages/core/src/amfs_core/models.py
@@ -321,6 +321,13 @@ class DecisionTrace(BaseModel):
     outcome_ref: str | None = None
     outcome_type: str | None = None
     decision_summary: str | None = None
+    # The request that triggered the decision, and optionally the agent's
+    # answer. Without the prompt side of the pair a trace records what was
+    # decided but not what was being asked, which is exactly what supervised
+    # training needs. Both are opt-in per call and scanned for secrets before
+    # they are persisted.
+    task_input: str | None = None
+    response_text: str | None = None
     causal_entries: list[TraceEntry] = Field(default_factory=list)
     external_contexts: list[ExternalContext] = Field(default_factory=list)
     query_events: list[QueryEvent] = Field(default_factory=list)

--- a/packages/core/src/amfs_core/outcome.py
+++ b/packages/core/src/amfs_core/outcome.py
@@ -87,6 +87,8 @@ class OutcomeBackPropagator:
         *,
         causal_confidence: float = 1.0,
         committed_at: datetime | None = None,
+        task_input: str | None = None,
+        response_text: str | None = None,
     ) -> OutcomeRecord:
         """Convenience factory for creating OutcomeRecord instances."""
         return OutcomeRecord(
@@ -96,4 +98,6 @@ class OutcomeBackPropagator:
             committed_at=committed_at or datetime.now(timezone.utc),
             causal_entry_keys=causal_entry_keys,
             agent_id=agent_id,
+            task_input=task_input,
+            response_text=response_text,
         )

--- a/packages/http-server/pyproject.toml
+++ b/packages/http-server/pyproject.toml
@@ -1,12 +1,13 @@
 [project]
 name = "amfs-http-server"
-version = "0.3.12"
+version = "0.3.13"
 description = "AMFS HTTP/REST API server with SSE support"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 dependencies = [
-    "amfs",
-    "amfs-core",
+    # The trace endpoints call amfs_core.capture and read/write task_input.
+    "amfs>=0.5.6",
+    "amfs-core>=0.3.13",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.32",
     "sse-starlette>=2.0",

--- a/packages/http-server/src/amfs_http/models.py
+++ b/packages/http-server/src/amfs_http/models.py
@@ -30,6 +30,13 @@ class OutcomeRequest(BaseModel):
     causal_entry_keys: list[str] | None = None
     causal_confidence: float = 1.0
     agent_id: str | None = None
+    #: The request that triggered the decision. Supervised training needs the
+    #: prompt side of the pair and the trace otherwise records only what was
+    #: decided. Scanned for secrets before it is persisted.
+    task_input: str | None = None
+    #: The agent's answer. Opt-in separately from ``task_input`` because it is
+    #: the larger disclosure and only the assistant-model dataset needs it.
+    response_text: str | None = None
 
 
 class SearchRequest(BaseModel):

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -36,6 +36,7 @@ from amfs import AgentMemory, MemoryType, OutcomeType
 from amfs.config import load_config_or_default
 from pydantic import BaseModel, Field
 from amfs_core.aggregates import REUSE_CREDIT_K
+from amfs_core.capture import scan_captured_text
 from amfs_core.models import (
     AgentGroup,
     AMFSConfig,
@@ -1891,58 +1892,19 @@ def _get_immutable_store():
 
 _seal_sequence: dict[str, int] = {}
 
-_CAPTURE_SAFETY_GATE: dict[str, Any] = {}
-#: Captured prompts and responses are unbounded caller-supplied text. Truncating
-#: before the safety scan keeps a runaway payload from becoming a storage or
-#: latency problem, and no training example is allowed near this size anyway.
-_MAX_CAPTURED_CHARS = 200_000
-
-
 def _scan_captured_text(mem: AgentMemory, text: str | None) -> str | None:
-    """Redact secrets from captured prompt/response text before it is persisted.
+    """Redact secrets from captured text. Thin wrapper over the shared scanner.
 
-    Returns ``None`` when the gate blocks the text outright: losing one training
-    example is always preferable to writing a customer credential into a
-    dataset that later leaves our infrastructure for a tuning job.
+    The implementation lives in :mod:`amfs_core.capture` so the SDK and MCP paths
+    apply exactly the same rules; this only supplies the identity and adapter from
+    the request's memory handle.
     """
-    if not text:
-        return None
-    if len(text) > _MAX_CAPTURED_CHARS:
-        text = text[:_MAX_CAPTURED_CHARS]
-    try:
-        from amfs_core.models import Provenance
-
-        if "gate" not in _CAPTURE_SAFETY_GATE:
-            from amfs_safety import SafetyGate  # Pro package, optional
-
-            _CAPTURE_SAFETY_GATE["gate"] = SafetyGate(
-                adapter=getattr(mem, "_adapter", None)
-            )
-        gate = _CAPTURE_SAFETY_GATE["gate"]
-        entry = MemoryEntry(
-            entity_path="_capture/task_input",
-            key="scan",
-            value=text,
-            provenance=Provenance(
-                agent_id=mem.agent_id,
-                session_id=mem.session_id,
-                written_at=datetime.now(timezone.utc),
-            ),
-            confidence=0.5,
-        )
-        decision = gate.check_write(entry)
-        if not decision.allowed:
-            logger.info("Captured text blocked by SafetyGate; dropping from trace")
-            return None
-        scanned = decision.entry.value
-        return scanned if isinstance(scanned, str) else text
-    except ImportError:
-        # OSS install without the Pro safety package. Capture is opt-in and the
-        # caller asked for it, so store the text rather than silently dropping.
-        return text
-    except Exception:
-        logger.debug("SafetyGate scan of captured text failed", exc_info=True)
-        return text
+    return scan_captured_text(
+        text,
+        adapter=getattr(mem, "_adapter", None),
+        agent_id=mem.agent_id,
+        session_id=mem.session_id,
+    )
 
 
 def _auto_seal_trace(mem: AgentMemory) -> str | None:
@@ -2058,8 +2020,12 @@ async def commit_outcome(
             otype,
             causal_entry_keys=req.causal_entry_keys,
             causal_confidence=req.causal_confidence,
-            task_input=_scan_captured_text(mem, req.task_input),
-            response_text=_scan_captured_text(mem, req.response_text),
+            # Not scanned here: commit_outcome scans at trace construction, so
+            # every caller gets it. Scanning again would be harmless but would
+            # imply this endpoint is where the guarantee lives, which is the
+            # assumption that left the MCP path unscanned.
+            task_input=req.task_input,
+            response_text=req.response_text,
         )
     finally:
         if original_agent is not None:

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -2145,8 +2145,10 @@ async def save_trace(
         _link_agent_owner_once(req, trace.agent_id, mem.namespace)
     # HttpAdapter posts the whole trace here rather than through /outcomes, so
     # this is the second entry point captured text can arrive on and it needs
-    # the same scan before anything is written.
-    if trace.task_input or trace.response_text:
+    # the same scan before anything is written. Unconditionally, with no truthiness
+    # guard: an empty string skipped the scan and was stored as "" while every
+    # other path normalises absent capture to None.
+    if trace.task_input is not None or trace.response_text is not None:
         trace = trace.model_copy(update={
             "task_input": _scan_captured_text(mem, trace.task_input),
             "response_text": _scan_captured_text(mem, trace.response_text),

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -1891,6 +1891,59 @@ def _get_immutable_store():
 
 _seal_sequence: dict[str, int] = {}
 
+_CAPTURE_SAFETY_GATE: dict[str, Any] = {}
+#: Captured prompts and responses are unbounded caller-supplied text. Truncating
+#: before the safety scan keeps a runaway payload from becoming a storage or
+#: latency problem, and no training example is allowed near this size anyway.
+_MAX_CAPTURED_CHARS = 200_000
+
+
+def _scan_captured_text(mem: AgentMemory, text: str | None) -> str | None:
+    """Redact secrets from captured prompt/response text before it is persisted.
+
+    Returns ``None`` when the gate blocks the text outright: losing one training
+    example is always preferable to writing a customer credential into a
+    dataset that later leaves our infrastructure for a tuning job.
+    """
+    if not text:
+        return None
+    if len(text) > _MAX_CAPTURED_CHARS:
+        text = text[:_MAX_CAPTURED_CHARS]
+    try:
+        from amfs_core.models import Provenance
+
+        if "gate" not in _CAPTURE_SAFETY_GATE:
+            from amfs_safety import SafetyGate  # Pro package, optional
+
+            _CAPTURE_SAFETY_GATE["gate"] = SafetyGate(
+                adapter=getattr(mem, "_adapter", None)
+            )
+        gate = _CAPTURE_SAFETY_GATE["gate"]
+        entry = MemoryEntry(
+            entity_path="_capture/task_input",
+            key="scan",
+            value=text,
+            provenance=Provenance(
+                agent_id=mem.agent_id,
+                session_id=mem.session_id,
+                written_at=datetime.now(timezone.utc),
+            ),
+            confidence=0.5,
+        )
+        decision = gate.check_write(entry)
+        if not decision.allowed:
+            logger.info("Captured text blocked by SafetyGate; dropping from trace")
+            return None
+        scanned = decision.entry.value
+        return scanned if isinstance(scanned, str) else text
+    except ImportError:
+        # OSS install without the Pro safety package. Capture is opt-in and the
+        # caller asked for it, so store the text rather than silently dropping.
+        return text
+    except Exception:
+        logger.debug("SafetyGate scan of captured text failed", exc_info=True)
+        return text
+
 
 def _auto_seal_trace(mem: AgentMemory) -> str | None:
     """If Pro traces are available, auto-seal the last OSS trace as immutable."""
@@ -1953,6 +2006,8 @@ def _auto_seal_trace(mem: AgentMemory) -> str | None:
             outcome_ref=oss_trace.outcome_ref,
             outcome_type=oss_trace.outcome_type,
             decision_summary=getattr(oss_trace, "decision_summary", None),
+            task_input=getattr(oss_trace, "task_input", None),
+            response_text=getattr(oss_trace, "response_text", None),
             causal_entries=causal,
             external_contexts=contexts,
             created_at=now,
@@ -2003,6 +2058,8 @@ async def commit_outcome(
             otype,
             causal_entry_keys=req.causal_entry_keys,
             causal_confidence=req.causal_confidence,
+            task_input=_scan_captured_text(mem, req.task_input),
+            response_text=_scan_captured_text(mem, req.response_text),
         )
     finally:
         if original_agent is not None:
@@ -2120,6 +2177,14 @@ async def save_trace(
     mem = _get_memory()
     if trace.agent_id:
         _link_agent_owner_once(req, trace.agent_id, mem.namespace)
+    # HttpAdapter posts the whole trace here rather than through /outcomes, so
+    # this is the second entry point captured text can arrive on and it needs
+    # the same scan before anything is written.
+    if trace.task_input or trace.response_text:
+        trace = trace.model_copy(update={
+            "task_input": _scan_captured_text(mem, trace.task_input),
+            "response_text": _scan_captured_text(mem, trace.response_text),
+        })
     saved = mem._adapter.save_trace(trace)
     return saved.model_dump(mode="json")
 

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -1892,18 +1892,29 @@ def _get_immutable_store():
 
 _seal_sequence: dict[str, int] = {}
 
-def _scan_captured_text(mem: AgentMemory, text: str | None) -> str | None:
+def _scan_captured_text(
+    mem: AgentMemory,
+    text: str | None,
+    *,
+    agent_id: str | None = None,
+    session_id: str | None = None,
+) -> str | None:
     """Redact secrets from captured text. Thin wrapper over the shared scanner.
 
     The implementation lives in :mod:`amfs_core.capture` so the SDK and MCP paths
     apply exactly the same rules; this only supplies the identity and adapter from
     the request's memory handle.
+
+    The identity defaults to the handle's, which is the server's shared singleton
+    on this process. Callers that already know whose text this is should pass it:
+    on ``POST /api/v1/traces`` the trace carries its own agent, and the singleton's
+    is the server default rather than the client's.
     """
     return scan_captured_text(
         text,
         adapter=getattr(mem, "_adapter", None),
-        agent_id=mem.agent_id,
-        session_id=mem.session_id,
+        agent_id=agent_id if agent_id is not None else mem.agent_id,
+        session_id=session_id if session_id is not None else mem.session_id,
     )
 
 
@@ -2148,10 +2159,27 @@ async def save_trace(
     # the same scan before anything is written. Unconditionally, with no truthiness
     # guard: an empty string skipped the scan and was stored as "" while every
     # other path normalises absent capture to None.
+    #
+    # Scanned under the *trace's* identity, not the server singleton's. No rule
+    # reads it today — SafetyGate matches on content and on the fixed capture
+    # namespace — so this changes no redaction now. It is the identity the
+    # provenance should have carried all along, and getting it right here means a
+    # later per-agent policy applies to the agent that produced the text rather
+    # than to whichever identity this process happens to hold.
     if trace.task_input is not None or trace.response_text is not None:
         trace = trace.model_copy(update={
-            "task_input": _scan_captured_text(mem, trace.task_input),
-            "response_text": _scan_captured_text(mem, trace.response_text),
+            "task_input": _scan_captured_text(
+                mem,
+                trace.task_input,
+                agent_id=trace.agent_id,
+                session_id=trace.session_id,
+            ),
+            "response_text": _scan_captured_text(
+                mem,
+                trace.response_text,
+                agent_id=trace.agent_id,
+                session_id=trace.session_id,
+            ),
         })
     saved = mem._adapter.save_trace(trace)
     return saved.model_dump(mode="json")

--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -1,11 +1,15 @@
 [project]
 name = "amfs-mcp-server"
-version = "0.7.11"
+version = "0.7.12"
 description = "AMFS MCP Server — expose Agent Memory as MCP tools for Cursor and Claude Code"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 dependencies = [
-    "amfs",
+    # Floored, not bare. amfs_commit_outcome forwards task_input to the SDK as a
+    # keyword on every call, so an older amfs resolved from a cache would raise
+    # TypeError on the one call agents are told to make at the end of every task.
+    # An unbounded dependency is how the equivalent skew reached Pro users.
+    "amfs>=0.5.6",
     "amfs-adapter-http>=0.1.2",
     "fastmcp>=2.0",
 ]

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -1089,6 +1089,7 @@ def amfs_stats() -> str:
 def amfs_commit_outcome(
     outcome_ref: str,
     outcome_type: str,
+    task_input: str | None = None,
 ) -> str:
     """Record an outcome and auto-link it to everything read this session.
 
@@ -1110,9 +1111,14 @@ def amfs_commit_outcome(
         outcome_ref: Reference identifier (e.g. "INC-2047", "task-42", "PR-456")
         outcome_type: One of "success", "minor_failure", "failure", "critical_failure",
             "clean_deploy", "regression", "p2_incident", "p1_incident"
+        task_input: Optional. The request that triggered this work, in the words
+            it arrived in (e.g. the user's ask, the alert payload, the ticket
+            body). Pass it whenever you have it: it is the prompt half of the
+            trace, and without it the trace records what you decided but not
+            what you were asked. Secrets are scanned and redacted before storage.
 
     Example: amfs_commit_outcome("task-42", "success")
-    Example: amfs_commit_outcome("deploy-v2", "failure")
+    Example: amfs_commit_outcome("INC-2047", "success", task_input="API p99 latency above 2s in us-east")
     """
     mem = _get_memory()
 
@@ -1134,7 +1140,7 @@ def amfs_commit_outcome(
             "error": f"Invalid outcome_type '{outcome_type}'. Must be one of: {valid}"
         })
 
-    entries = mem.commit_outcome(outcome_ref, otype)
+    entries = mem.commit_outcome(outcome_ref, otype, task_input=task_input)
     trace = getattr(mem, "_last_trace", None)
     result: dict[str, Any] = {
         "outcome_ref": outcome_ref,

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -1,11 +1,13 @@
 [project]
 name = "amfs"
-version = "0.5.5"
+version = "0.5.6"
 description = "AMFS Python SDK — Agent Memory File System"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 dependencies = [
-    "amfs-core",
+    # 0.3.13 carries DecisionTrace.task_input and amfs_core.capture, both of which
+    # commit_outcome below uses unconditionally.
+    "amfs-core>=0.3.13",
     "amfs-adapter-filesystem",
     "pyyaml>=6.0,<7",
 ]

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -946,12 +946,36 @@ class AgentMemory:
         """
         if causal_entry_keys is None:
             causal_entry_keys = self._read_tracker.causal_keys
+
+        # Scanned here, before anything leaves the process, and reused for both the
+        # outcome record and the trace below. Scanning only at trace construction
+        # would send the raw text to the server on the SaaS path, since the record
+        # goes over the wire first.
+        task_input = scan_captured_text(
+            task_input,
+            adapter=self._adapter,
+            agent_id=self.agent_id,
+            session_id=self.session_id,
+        )
+        response_text = scan_captured_text(
+            response_text,
+            adapter=self._adapter,
+            agent_id=self.agent_id,
+            session_id=self.session_id,
+        )
+
         record = OutcomeBackPropagator.make_record(
             outcome_ref=outcome_ref,
             outcome_type=outcome_type,
             causal_entry_keys=causal_entry_keys,
             agent_id=self.agent_id,
             causal_confidence=causal_confidence,
+            # Carried on the record because the adapter's commit_outcome is what
+            # reaches the server, and the server seals its immutable trace from
+            # that call. Sending the capture only on the later save_trace left the
+            # sealed copy — the one export and training read — without it.
+            task_input=task_input,
+            response_text=response_text,
         )
         updated = self._propagator.propagate(record)
 
@@ -1033,24 +1057,12 @@ class AgentMemory:
             outcome_ref=outcome_ref,
             outcome_type=outcome_type.value,
             decision_summary=decision_summary,
-            # Scanned here, at construction, rather than by each caller. Every
-            # path that records a trace goes through this method — the SDK
-            # directly, and the MCP tool that wraps it — and the MCP tool's own
-            # documentation promises the text has been redacted. Leaving it to
-            # callers is what made that promise false for anyone not going through
-            # the HTTP server.
-            task_input=scan_captured_text(
-                task_input,
-                adapter=self._adapter,
-                agent_id=self.agent_id,
-                session_id=self.session_id,
-            ),
-            response_text=scan_captured_text(
-                response_text,
-                adapter=self._adapter,
-                agent_id=self.agent_id,
-                session_id=self.session_id,
-            ),
+            # Already scanned at the top of this method, before the record went to
+            # the adapter. Scanning is centralised here rather than left to callers
+            # because the MCP tool calls straight through and its documentation
+            # promises the text has been redacted.
+            task_input=task_input,
+            response_text=response_text,
             causal_entries=causal_trace_entries,
             external_contexts=ext_contexts,
             query_events=query_events,

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -930,11 +930,17 @@ class AgentMemory:
         *,
         causal_confidence: float = 1.0,
         decision_summary: str | None = None,
+        task_input: str | None = None,
+        response_text: str | None = None,
     ) -> list[MemoryEntry]:
         """Record an outcome and back-propagate confidence changes.
 
         If *causal_entry_keys* is ``None``, automatically uses the session's
         read log — every entry this agent read becomes a causal link.
+
+        *task_input* is the request that triggered the decision and
+        *response_text* the agent's answer. Both are optional and only stored
+        when supplied.
         """
         if causal_entry_keys is None:
             causal_entry_keys = self._read_tracker.causal_keys
@@ -1025,6 +1031,8 @@ class AgentMemory:
             outcome_ref=outcome_ref,
             outcome_type=outcome_type.value,
             decision_summary=decision_summary,
+            task_input=task_input,
+            response_text=response_text,
             causal_entries=causal_trace_entries,
             external_contexts=ext_contexts,
             query_events=query_events,

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from amfs_core.abc import AdapterABC, WatchHandle
+from amfs_core.capture import scan_captured_text
 from amfs_core.content import embedding_input
 from amfs_core.embedder import EmbedderABC
 from amfs_core.engine import CausalTagger, CoWEngine, ReadTracker
@@ -940,7 +941,8 @@ class AgentMemory:
 
         *task_input* is the request that triggered the decision and
         *response_text* the agent's answer. Both are optional and only stored
-        when supplied.
+        when supplied, and both are scanned for secrets before being persisted —
+        a value the safety gate blocks is dropped rather than stored.
         """
         if causal_entry_keys is None:
             causal_entry_keys = self._read_tracker.causal_keys
@@ -1031,8 +1033,24 @@ class AgentMemory:
             outcome_ref=outcome_ref,
             outcome_type=outcome_type.value,
             decision_summary=decision_summary,
-            task_input=task_input,
-            response_text=response_text,
+            # Scanned here, at construction, rather than by each caller. Every
+            # path that records a trace goes through this method — the SDK
+            # directly, and the MCP tool that wraps it — and the MCP tool's own
+            # documentation promises the text has been redacted. Leaving it to
+            # callers is what made that promise false for anyone not going through
+            # the HTTP server.
+            task_input=scan_captured_text(
+                task_input,
+                adapter=self._adapter,
+                agent_id=self.agent_id,
+                session_id=self.session_id,
+            ),
+            response_text=scan_captured_text(
+                response_text,
+                adapter=self._adapter,
+                agent_id=self.agent_id,
+                session_id=self.session_id,
+            ),
             causal_entries=causal_trace_entries,
             external_contexts=ext_contexts,
             query_events=query_events,

--- a/tests/integration/test_postgres_adapter.py
+++ b/tests/integration/test_postgres_adapter.py
@@ -41,3 +41,57 @@ class TestPostgresAdapter(AdapterContractTests):
     """Run all contract tests against the PostgresAdapter."""
 
     pass
+
+
+def test_captured_text_survives_a_round_trip(adapter) -> None:
+    """``task_input``/``response_text`` must come back out of the database.
+
+    The columns were written by ``save_trace`` but omitted from the SELECT lists in
+    ``get_trace`` and ``list_traces``, and ``_row_to_trace`` reads them with
+    ``row.get``, so every read returned ``None`` without raising. Behaviour cloning
+    just found nothing eligible and reported zero examples.
+
+    Asserted through both read paths, since each had its own column list and only
+    fixing one would leave half the bug in place.
+    """
+    from amfs_core.models import DecisionTrace
+
+    saved = adapter.save_trace(
+        DecisionTrace(
+            agent_id="capture-agent",
+            session_id="capture-session",
+            outcome_ref="round-trip-1",
+            outcome_type="success",
+            task_input="restart the payments worker in staging",
+            response_text="scaled the deployment to zero and back",
+        )
+    )
+
+    fetched = adapter.get_trace(saved.id)
+    assert fetched is not None
+    assert fetched.task_input == "restart the payments worker in staging"
+    assert fetched.response_text == "scaled the deployment to zero and back"
+
+    listed = [t for t in adapter.list_traces(agent_id="capture-agent")]
+    assert listed, "the trace should be listable"
+    assert listed[0].task_input == "restart the payments worker in staging"
+    assert listed[0].response_text == "scaled the deployment to zero and back"
+
+
+def test_a_trace_without_captured_text_round_trips_as_none(adapter) -> None:
+    """The columns are nullable and absence must stay absence, not empty string."""
+    from amfs_core.models import DecisionTrace
+
+    saved = adapter.save_trace(
+        DecisionTrace(
+            agent_id="capture-agent",
+            session_id="no-capture",
+            outcome_ref="round-trip-2",
+            outcome_type="success",
+        )
+    )
+
+    fetched = adapter.get_trace(saved.id)
+    assert fetched is not None
+    assert fetched.task_input is None
+    assert fetched.response_text is None

--- a/tests/unit/test_trace_capture.py
+++ b/tests/unit/test_trace_capture.py
@@ -19,6 +19,9 @@ which is why they survived to review.
 
 from __future__ import annotations
 
+import sys
+import types
+
 import pytest
 from amfs import AgentMemory
 from amfs.memory import _get_sdk_executor
@@ -29,10 +32,12 @@ from amfs_filesystem.adapter import FilesystemAdapter
 
 @pytest.fixture(autouse=True)
 def _clear_gate_cache():
-    """The gate is cached process-wide; a stub must not leak between tests."""
+    """Gates are cached across calls; a stub must not leak between tests."""
     capture._GATE_CACHE.clear()
+    capture._ADAPTERLESS_GATE.clear()
     yield
     capture._GATE_CACHE.clear()
+    capture._ADAPTERLESS_GATE.clear()
 
 
 class _Decision:
@@ -42,8 +47,13 @@ class _Decision:
 
 
 def _install_gate(monkeypatch, gate) -> None:
-    """Seed the cache so no import of the optional Pro package is attempted."""
-    capture._GATE_CACHE["gate"] = gate
+    """Stand in for the gate so no import of the optional Pro package is attempted.
+
+    Replaces the lookup rather than seeding a cache entry, because the real cache
+    is keyed by adapter and these tests reach it down several paths — some with no
+    adapter, some through an ``AgentMemory`` holding a real one.
+    """
+    monkeypatch.setattr(capture, "_gate_for", lambda adapter: gate)
 
 
 # --- The scanner itself -----------------------------------------------------
@@ -94,7 +104,8 @@ def test_an_oss_install_without_the_safety_package_stores_the_text() -> None:
     is stored rather than silently discarded. This is why the ImportError branch
     cannot simply be folded into the general failure branch.
     """
-    assert capture._GATE_CACHE == {}
+    assert len(capture._GATE_CACHE) == 0
+    assert capture._ADAPTERLESS_GATE == []
     # SafetyGate is a Pro package; in this environment the import fails and the
     # text passes through unchanged.
     pytest.importorskip
@@ -105,6 +116,55 @@ def test_an_oss_install_without_the_safety_package_stores_the_text() -> None:
         assert result == "plain prompt text"
     else:
         pytest.skip("amfs_safety installed; the ImportError branch is unreachable")
+
+
+def test_each_adapter_gets_a_gate_bound_to_itself(monkeypatch) -> None:
+    """One gate per adapter, not one per process.
+
+    ``SafetyGate`` keeps the adapter it was built with and its validator reads
+    through it, so a single shared instance would vet every caller's capture
+    through whichever adapter arrived first. In the hosted server that is one
+    tenant's connection answering every other tenant's request.
+    """
+    built = []
+
+    class Gate:
+        def __init__(self, adapter=None):
+            self.adapter = adapter
+            built.append(adapter)
+
+    module = types.ModuleType("amfs_safety")
+    module.SafetyGate = Gate
+    monkeypatch.setitem(sys.modules, "amfs_safety", module)
+
+    class Adapter:
+        pass
+
+    first, second = Adapter(), Adapter()
+    assert capture._gate_for(first).adapter is first
+    assert capture._gate_for(second).adapter is second
+    # Still cached: the same adapter reuses its gate instead of rebuilding the
+    # detectors on every captured field.
+    assert capture._gate_for(first) is capture._gate_for(first)
+    assert built == [first, second]
+
+
+def test_an_unhashable_adapter_still_gets_a_correctly_bound_gate(monkeypatch) -> None:
+    """Losing the cache is acceptable; binding the wrong adapter is not."""
+
+    class Gate:
+        def __init__(self, adapter=None):
+            self.adapter = adapter
+
+    module = types.ModuleType("amfs_safety")
+    module.SafetyGate = Gate
+    monkeypatch.setitem(sys.modules, "amfs_safety", module)
+
+    class Unhashable:
+        __hash__ = None  # type: ignore[assignment]
+
+    adapter = Unhashable()
+    assert capture._gate_for(adapter).adapter is adapter
 
 
 def test_a_non_string_from_the_gate_is_dropped_not_replaced_with_the_original(

--- a/tests/unit/test_trace_capture.py
+++ b/tests/unit/test_trace_capture.py
@@ -304,6 +304,92 @@ def test_the_http_adapter_forwards_the_capture_to_the_server() -> None:
     assert body["response_text"] == "the answer"
 
 
+def test_the_posted_traces_capture_is_scanned_as_its_own_agent() -> None:
+    """``POST /api/v1/traces`` knows whose text this is; it should say so.
+
+    The scan took its identity from the server's shared memory handle, which on
+    this entry point is the process default and not the client that posted the
+    trace. No redaction depends on it today — the gate matches on content and on
+    a fixed capture namespace — so this is provenance rather than a live bug. It
+    is asserted because the failure mode is silent: the first per-agent capture
+    rule would apply to the wrong agent, and nothing would say so.
+
+    Driven through the endpoint rather than the helper. Calling the helper with
+    the identity spelled out only proves it forwards what it is given, which was
+    never in doubt — the endpoint choosing to give it is the whole fix.
+    """
+    import asyncio
+    from datetime import UTC, datetime
+    from types import SimpleNamespace
+
+    from amfs_core.models import DecisionTrace
+    from amfs_http import server as http_server
+
+    seen: list[dict[str, str]] = []
+
+    def _record(text, *, adapter=None, agent_id="", session_id=""):
+        seen.append({"agent_id": agent_id, "session_id": session_id})
+        return text
+
+    trace = DecisionTrace(
+        session_id="posted-session",
+        agent_id="posting-agent",
+        started_at=datetime.now(UTC),
+        task_input="the ask",
+    )
+    mem = SimpleNamespace(
+        _adapter=SimpleNamespace(save_trace=lambda t: t),
+        agent_id="server-default",
+        session_id="server-session",
+        namespace="ns",
+    )
+
+    original_scan = http_server.scan_captured_text
+    original_mem = http_server._get_memory
+    original_link = http_server._link_agent_owner_once
+    http_server.scan_captured_text = _record  # type: ignore[assignment]
+    http_server._get_memory = lambda: mem  # type: ignore[assignment]
+    http_server._link_agent_owner_once = lambda *a, **k: None  # type: ignore[assignment]
+    try:
+        request = SimpleNamespace(
+            json=lambda: asyncio.sleep(0, result=trace.model_dump(mode="json"))
+        )
+        asyncio.run(http_server.save_trace(request))
+    finally:
+        http_server.scan_captured_text = original_scan  # type: ignore[assignment]
+        http_server._get_memory = original_mem  # type: ignore[assignment]
+        http_server._link_agent_owner_once = original_link  # type: ignore[assignment]
+
+    assert seen, "the endpoint must scan captured text"
+    assert all(s["agent_id"] == "posting-agent" for s in seen), seen
+    assert all(s["session_id"] == "posted-session" for s in seen), seen
+
+
+def test_the_scan_identity_still_falls_back_to_the_handle() -> None:
+    """Every other call site passes no identity and must keep the handle's."""
+    from types import SimpleNamespace
+
+    from amfs_http import server as http_server
+
+    seen: list[dict[str, str]] = []
+
+    def _record(text, *, adapter=None, agent_id="", session_id=""):
+        seen.append({"agent_id": agent_id, "session_id": session_id})
+        return text
+
+    original = http_server.scan_captured_text
+    http_server.scan_captured_text = _record  # type: ignore[assignment]
+    try:
+        http_server._scan_captured_text(
+            SimpleNamespace(_adapter=None, agent_id="handle-agent", session_id="s0"),
+            "the ask",
+        )
+    finally:
+        http_server.scan_captured_text = original  # type: ignore[assignment]
+
+    assert seen == [{"agent_id": "handle-agent", "session_id": "s0"}]
+
+
 def test_a_trace_without_capture_is_unaffected(tmp_path) -> None:
     """Committing an outcome with no captured text must not start failing."""
     adapter = FilesystemAdapter(root=tmp_path / ".amfs", namespace="test")

--- a/tests/unit/test_trace_capture.py
+++ b/tests/unit/test_trace_capture.py
@@ -1,0 +1,213 @@
+"""Captured prompt/response text: scanning, and surviving a round trip.
+
+``DecisionTrace.task_input`` and ``response_text`` hold the request an agent was
+given and the answer it produced. Three things went wrong when the feature was
+added, all of them silent, and each test here pins one of them:
+
+1. The scan lived in the HTTP server only, so an agent committing an outcome
+   through the SDK or the MCP tool stored raw text — while the MCP tool's own
+   documentation said secrets were redacted.
+2. The scan returned the *original* text when the safety gate raised, which is
+   fail-open: the one input nobody could vet was the one that got stored.
+3. The Postgres adapter wrote both columns but did not select them back, so every
+   read returned ``None``. Nothing raised, and behaviour cloning simply found no
+   eligible examples.
+
+None of the three would show up in a test that only checks a trace was saved,
+which is why they survived to review.
+"""
+
+from __future__ import annotations
+
+import pytest
+from amfs import AgentMemory
+from amfs.memory import _get_sdk_executor
+from amfs_core import capture
+from amfs_core.models import OutcomeType
+from amfs_filesystem.adapter import FilesystemAdapter
+
+
+@pytest.fixture(autouse=True)
+def _clear_gate_cache():
+    """The gate is cached process-wide; a stub must not leak between tests."""
+    capture._GATE_CACHE.clear()
+    yield
+    capture._GATE_CACHE.clear()
+
+
+class _Decision:
+    def __init__(self, allowed: bool, value: str | None = None) -> None:
+        self.allowed = allowed
+        self.entry = type("E", (), {"value": value})()
+
+
+def _install_gate(monkeypatch, gate) -> None:
+    """Seed the cache so no import of the optional Pro package is attempted."""
+    capture._GATE_CACHE["gate"] = gate
+
+
+# --- The scanner itself -----------------------------------------------------
+
+
+def test_absent_text_is_left_absent() -> None:
+    assert capture.scan_captured_text(None) is None
+    assert capture.scan_captured_text("") is None
+
+
+def test_a_redacted_value_replaces_the_original(monkeypatch) -> None:
+    class Gate:
+        def check_write(self, entry):
+            return _Decision(True, "token=[REDACTED]")
+
+    _install_gate(monkeypatch, Gate())
+    assert capture.scan_captured_text("token=sk-live-123") == "token=[REDACTED]"
+
+
+def test_blocked_text_is_dropped_not_stored(monkeypatch) -> None:
+    class Gate:
+        def check_write(self, entry):
+            return _Decision(False)
+
+    _install_gate(monkeypatch, Gate())
+    assert capture.scan_captured_text("AWS_SECRET_ACCESS_KEY=abc") is None
+
+
+def test_a_gate_that_raises_drops_the_text(monkeypatch) -> None:
+    """Fail closed. Returning the text here is what review flagged.
+
+    The gate exists and simply failed, so the text is precisely what could not be
+    vetted. Storing it is the one outcome this function is meant to prevent.
+    """
+
+    class Gate:
+        def check_write(self, entry):
+            raise RuntimeError("gate exploded")
+
+    _install_gate(monkeypatch, Gate())
+    assert capture.scan_captured_text("password=hunter2") is None
+
+
+def test_an_oss_install_without_the_safety_package_stores_the_text() -> None:
+    """No gate available is a different case from a gate that failed.
+
+    Capture is opt-in and the caller asked for it, so on an OSS install the text
+    is stored rather than silently discarded. This is why the ImportError branch
+    cannot simply be folded into the general failure branch.
+    """
+    assert capture._GATE_CACHE == {}
+    # SafetyGate is a Pro package; in this environment the import fails and the
+    # text passes through unchanged.
+    pytest.importorskip
+    result = capture.scan_captured_text("plain prompt text")
+    try:
+        import amfs_safety  # noqa: F401
+    except ImportError:
+        assert result == "plain prompt text"
+    else:
+        pytest.skip("amfs_safety installed; the ImportError branch is unreachable")
+
+
+def test_oversized_text_is_truncated_before_scanning(monkeypatch) -> None:
+    seen: list[int] = []
+
+    class Gate:
+        def check_write(self, entry):
+            seen.append(len(entry.value))
+            return _Decision(True, entry.value)
+
+    _install_gate(monkeypatch, Gate())
+    out = capture.scan_captured_text("x" * (capture.MAX_CAPTURED_CHARS + 5_000))
+    assert seen == [capture.MAX_CAPTURED_CHARS]
+    assert out is not None and len(out) == capture.MAX_CAPTURED_CHARS
+
+
+# --- The SDK applies it -----------------------------------------------------
+
+
+def _flush_bg() -> None:
+    _get_sdk_executor().submit(lambda: None).result(timeout=5)
+
+
+def test_commit_outcome_scans_captured_text(monkeypatch, tmp_path) -> None:
+    """The fix for the MCP path.
+
+    ``amfs_commit_outcome`` calls straight through to this method, so scanning at
+    trace construction is what makes the tool's documented promise true for a
+    client on a direct adapter.
+    """
+
+    class Gate:
+        def check_write(self, entry):
+            return _Decision(True, entry.value.replace("sk-live-123", "[REDACTED]"))
+
+    _install_gate(monkeypatch, Gate())
+
+    adapter = FilesystemAdapter(root=tmp_path / ".amfs", namespace="test")
+    mem = AgentMemory(agent_id="a", adapter=adapter)
+    mem.commit_outcome(
+        "task-1",
+        OutcomeType.SUCCESS,
+        task_input="deploy with key sk-live-123",
+        response_text="used sk-live-123",
+    )
+    _flush_bg()
+
+    trace = mem._last_trace
+    assert trace is not None
+    assert "sk-live-123" not in (trace.task_input or "")
+    assert "sk-live-123" not in (trace.response_text or "")
+    assert "[REDACTED]" in (trace.task_input or "")
+
+
+def test_commit_outcome_drops_text_the_gate_blocks(monkeypatch, tmp_path) -> None:
+    class Gate:
+        def check_write(self, entry):
+            return _Decision(False)
+
+    _install_gate(monkeypatch, Gate())
+
+    adapter = FilesystemAdapter(root=tmp_path / ".amfs", namespace="test")
+    mem = AgentMemory(agent_id="a", adapter=adapter)
+    mem.commit_outcome(
+        "task-2", OutcomeType.SUCCESS, task_input="secret", response_text="secret"
+    )
+    _flush_bg()
+
+    trace = mem._last_trace
+    assert trace is not None
+    assert trace.task_input is None
+    assert trace.response_text is None
+
+
+def test_a_trace_without_capture_is_unaffected(tmp_path) -> None:
+    """Committing an outcome with no captured text must not start failing."""
+    adapter = FilesystemAdapter(root=tmp_path / ".amfs", namespace="test")
+    mem = AgentMemory(agent_id="a", adapter=adapter)
+    mem.commit_outcome("task-3", OutcomeType.SUCCESS)
+    _flush_bg()
+
+    trace = mem._last_trace
+    assert trace is not None
+    assert trace.task_input is None
+    assert trace.response_text is None
+
+
+# --- The columns are read back ---------------------------------------------
+
+
+def test_the_postgres_read_queries_select_the_capture_columns() -> None:
+    """A source check, because the bug was an omission from a SELECT list.
+
+    A round trip against a live database is the real proof and lives in
+    tests/integration/test_postgres_adapter.py. This runs everywhere and names the
+    failure directly: ``_row_to_trace`` reads these with ``row.get``, so a missing
+    column yields ``None`` instead of raising, and the loss is silent.
+    """
+    import inspect
+
+    from amfs_postgres import adapter as pg
+
+    for fn in (pg.PostgresAdapter.get_trace, pg.PostgresAdapter.list_traces):
+        source = inspect.getsource(fn)
+        assert "task_input" in source, f"{fn.__name__} does not select task_input"
+        assert "response_text" in source, f"{fn.__name__} does not select response_text"

--- a/tests/unit/test_trace_capture.py
+++ b/tests/unit/test_trace_capture.py
@@ -107,6 +107,24 @@ def test_an_oss_install_without_the_safety_package_stores_the_text() -> None:
         pytest.skip("amfs_safety installed; the ImportError branch is unreachable")
 
 
+def test_a_non_string_from_the_gate_is_dropped_not_replaced_with_the_original(
+    monkeypatch,
+) -> None:
+    """Allowed-but-not-a-string is still not something we can store.
+
+    Returning the caller's original text here would return the one value known
+    *not* to be what the gate approved: if it redacted into a non-string form, the
+    unredacted secret would go straight through.
+    """
+
+    class Gate:
+        def check_write(self, entry):
+            return _Decision(True, {"redacted": True})
+
+    _install_gate(monkeypatch, Gate())
+    assert capture.scan_captured_text("token=sk-live-123") is None
+
+
 def test_oversized_text_is_truncated_before_scanning(monkeypatch) -> None:
     seen: list[int] = []
 
@@ -177,6 +195,113 @@ def test_commit_outcome_drops_text_the_gate_blocks(monkeypatch, tmp_path) -> Non
     assert trace is not None
     assert trace.task_input is None
     assert trace.response_text is None
+
+
+def test_the_capture_travels_with_the_outcome_record(monkeypatch, tmp_path) -> None:
+    """The SaaS ordering bug.
+
+    On the HTTP adapter the outcome record reaches the server first, and the server
+    seals its immutable trace from that call — the copy Pro export and training
+    actually read. A capture that travelled only on the later ``save_trace`` was
+    absent from the sealed trace, so the flywheel saw empty prompts.
+    """
+
+    class Gate:
+        def check_write(self, entry):
+            return _Decision(True, entry.value)
+
+    _install_gate(monkeypatch, Gate())
+
+    seen: list[object] = []
+
+    class _RecordingAdapter(FilesystemAdapter):
+        def commit_outcome(self, record):
+            seen.append(record)
+            return super().commit_outcome(record)
+
+    adapter = _RecordingAdapter(root=tmp_path / ".amfs", namespace="test")
+    mem = AgentMemory(agent_id="a", adapter=adapter)
+    mem.commit_outcome(
+        "task-4",
+        OutcomeType.SUCCESS,
+        task_input="restart the worker",
+        response_text="scaled to zero and back",
+    )
+    _flush_bg()
+
+    assert seen, "the adapter's commit_outcome should have been called"
+    assert seen[0].task_input == "restart the worker"
+    assert seen[0].response_text == "scaled to zero and back"
+
+
+def test_the_record_carries_scanned_text_not_raw(monkeypatch, tmp_path) -> None:
+    """Nothing raw may leave the process.
+
+    The record goes over the wire before the trace does, so scanning only at trace
+    construction would put the unredacted secret on the first request.
+    """
+
+    class Gate:
+        def check_write(self, entry):
+            return _Decision(True, entry.value.replace("sk-live-123", "[REDACTED]"))
+
+    _install_gate(monkeypatch, Gate())
+
+    seen: list[object] = []
+
+    class _RecordingAdapter(FilesystemAdapter):
+        def commit_outcome(self, record):
+            seen.append(record)
+            return super().commit_outcome(record)
+
+    adapter = _RecordingAdapter(root=tmp_path / ".amfs", namespace="test")
+    mem = AgentMemory(agent_id="a", adapter=adapter)
+    mem.commit_outcome("task-5", OutcomeType.SUCCESS, task_input="key sk-live-123")
+    _flush_bg()
+
+    assert seen
+    assert "sk-live-123" not in (seen[0].task_input or "")
+
+
+def test_the_http_adapter_forwards_the_capture_to_the_server() -> None:
+    """The adapter builds the /outcomes body by hand, so the fields are droppable.
+
+    This asserts on the request body rather than the record, because the record
+    carrying the capture is useless if the transport leaves it out — which is
+    exactly what it did.
+    """
+    from datetime import UTC, datetime
+
+    from amfs_adapter_http.adapter import HttpAdapter
+    from amfs_core.models import OutcomeRecord
+
+    sent: dict[str, object] = {}
+
+    adapter = HttpAdapter.__new__(HttpAdapter)
+
+    def _post(path, body):
+        sent["path"] = path
+        sent["body"] = body
+        return {"entries": []}
+
+    adapter._post = _post  # type: ignore[method-assign]
+
+    adapter.commit_outcome(
+        OutcomeRecord(
+            outcome_ref="task-6",
+            outcome_type=OutcomeType.SUCCESS,
+            committed_at=datetime.now(UTC),
+            agent_id="a",
+            task_input="the ask",
+            response_text="the answer",
+        )
+    )
+
+    assert sent["path"] == "/api/v1/outcomes"
+    body = sent["body"]
+    assert isinstance(body, dict)
+    assert body["task_input"] == "the ask"
+    assert body["response_text"] == "the answer"
 
 
 def test_a_trace_without_capture_is_unaffected(tmp_path) -> None:


### PR DESCRIPTION
## Why this exists

`amfs_commit_outcome` advertises `task_input` on the Pro MCP server, but nothing published can store it — not `amfs-mcp-server` 0.7.11, not the `amfs` 0.5.5 SDK. The Pro guard added in amfs-internal #487 correctly drops the value rather than crashing, so **every trace sealed today is missing the prompt half**. This is the OSS release that ends that.

The work already existed on `feat/record-action`, but that branch is fully merged into `dev` and has nothing beyond it, so a PR from it to `main` would have been a whole dev→main release carrying the managed-models API from #296 as well. This is the capture slice on its own: five commits cherry-picked onto `main`, plus the two fixes below.

Excluded deliberately: the managed-models mount and `ml-layer.md` (#296), the `tool_calls` / `record_action` feature and its Bugbot follow-up, and the `packages/.DS_Store` binary that was committed alongside them. Verified absent — no `managed_models`, `tool_calls`, `ToolCall`, `record_action` or `DS_Store` in the diff. 745 insertions here against 1761 on the full branch.

## Two fixes on top of the cherry-picks

**The safety gate was bound to one adapter for the life of the process.** It was built once and memoised, but every caller passes its own — `self._adapter` from the SDK, `mem._adapter` in the HTTP server — and `SafetyGate` keeps the adapter it was built with, running `MemorySafetyValidator(...).validate_write()` reads through it. Every caller after the first was therefore vetted through whichever adapter arrived first, which in the hosted multi-tenant server means one tenant's connection answering every other tenant's request. Now one gate per adapter, keyed weakly so a gate is collected with its adapter, with an uncached but correctly bound gate for an adapter that cannot be hashed or weakly referenced.

**Versions and floors.** The MCP tool forwards `task_input` to the SDK as a keyword on *every* call, and `amfs-mcp-server` depended on a bare `"amfs"` with no floor — so a cache holding an older SDK would raise `TypeError` on the one call agents are instructed to make at the end of every task. That is exactly the skew that took out Pro 0.1.37, one layer down and aimed at OSS users. Every package whose code changed is bumped, and each now floors the dependency whose new behaviour it relies on:

## Notes for review

Existing Postgres databases pick up `task_input` and `response_text` through `ADD COLUMN IF NOT EXISTS` in `_apply_migrations`, matching the pattern already used for `branch` and `session_metadata`, so no manual migration step.

`capture.py` fails closed: a gate that errors drops the text, because the text a gate could not vet is precisely the text that must not be stored. A missing gate is treated differently — on an OSS install without `amfs_safety` the text is stored as supplied, since capture is opt-in and the caller asked for it.