### PR TITLE
Document the hosted MCP endpoint, which the docs said did not exist

### DIFF
--- a/docs/editions.md
+++ b/docs/editions.md
@@ -549,7 +549,9 @@ exporter.export_trace(trace)  # sends spans to your OTel collector
 
 ### Pro MCP Server
 
-On **Sense Lab**, Cursor uses **`uvx amfs-mcp-server`** with **`AMFS_HTTP_URL`** (dashboard **Server URL**, e.g. `https://amfs-login.sense-lab.ai`) and **`AMFS_API_KEY`**—same JSON as the **Agents** MCP Connection card. Install the **[Cursor plugin](https://github.com/raia-live/cursor-plugin)** or copy that snippet; see [MCP setup — AMFS Pro and Cursor](https://raia-live.github.io/amfs/guides/mcp/#amfs-pro-saas-and-cursor). **Streamable HTTP** (`url` … `/mcp`) is a separate deployment mode for a self-hosted MCP HTTP listener, not the dashboard default.
+On **Sense Lab**, Cursor uses **`uvx amfs-mcp-server`** with **`AMFS_HTTP_URL`** (dashboard **Server URL**, e.g. `https://amfs-login.sense-lab.ai`) and **`AMFS_API_KEY`**—same JSON as the **Agents** MCP Connection card. Install the **[Cursor plugin](https://github.com/raia-live/cursor-plugin)** or copy that snippet; see [MCP setup — AMFS Pro and Cursor](https://raia-live.github.io/amfs/guides/mcp/#amfs-pro-saas-and-cursor).
+
+Hosted AMFS also serves **Streamable HTTP** directly at **`https://mcp.sense-lab.ai/mcp`** for clients that prefer a remote URL to a local process, authenticated with the same API key as a bearer token. It exposes a focused set of memory tools rather than the full stdio surface. Running your own MCP HTTP listener remains a separate, self-hosted deployment mode.
 
 Extends the OSS MCP server with additional tools:
 

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -114,7 +114,26 @@ After setup, your AI agents have tools across five categories:
 
 ## AMFS Pro (SaaS) and Cursor
 
-On **Sense Lab**, the AMFS dashboard (**Agents** page, MCP Connection card) is the source of truth. Cursor talks to hosted AMFS by running the **`amfs-mcp-server`** process locally with **stdio** (e.g. `uvx`), while the server uses **`AMFS_HTTP_URL`** (dashboard **Server URL**, e.g. `https://amfs-login.sense-lab.ai`) and **`AMFS_API_KEY`** to call the HTTP API. That URL is the **API base**, not an MCP Streamable HTTP path—there is **no `/mcp`** on it for this setup. The `/mcp` path applies only when you run the MCP server in **HTTP transport mode** as its own listening service (see [Streamable HTTP](#streamable-http-team--remote) below).
+On **Sense Lab**, the AMFS dashboard (**Agents** page, MCP Connection card) is the source of truth. There are two ways to connect, and the dashboard shows both.
+
+**Local process (stdio).** Cursor runs the **`amfs-mcp-server`** process locally, and that process uses **`AMFS_HTTP_URL`** (dashboard **Server URL**, e.g. `https://amfs-login.sense-lab.ai`) and **`AMFS_API_KEY`** to call the HTTP API. Point `AMFS_HTTP_URL` at the **API base** only — without `/mcp` — because this is the address the server calls, not an MCP endpoint a client connects to. This is the setup the snippet below describes.
+
+**Hosted endpoint (Streamable HTTP).** Hosted AMFS also serves MCP directly at **`https://mcp.sense-lab.ai/mcp`**, so a client that speaks Streamable HTTP can connect with no local process at all. Authenticate with your API key as a bearer token:
+
+```json
+{
+  "mcpServers": {
+    "senselab": {
+      "url": "https://mcp.sense-lab.ai/mcp",
+      "headers": { "Authorization": "Bearer ${env:AMFS_API_KEY}" }
+    }
+  }
+}
+```
+
+This endpoint exposes a focused set of memory tools rather than the full stdio surface. Use the local process when you want everything.
+
+To run **your own** HTTP server rather than using the hosted one, see [Streamable HTTP](#streamable-http-team--remote) below.
 
 Use the official **[Cursor plugin](https://github.com/raia-live/cursor-plugin)** (same shape as the dashboard JSON) or copy the snippet from the dashboard. Set **`AMFS_API_KEY`** in your environment and reference it with [Cursor interpolation](https://cursor.com/docs/mcp.md#config-interpolation). See also [SaaS / hosted AMFS](https://raia-live.github.io/amfs/guides/saas/).
 

--- a/docs/guides/saas.md
+++ b/docs/guides/saas.md
@@ -132,6 +132,23 @@ Or with the OSS MCP server (when `amfs-adapter-http` is installed):
 }
 ```
 
+Or without a local process at all, using the hosted Streamable HTTP endpoint:
+
+```json
+{
+  "mcpServers": {
+    "senselab": {
+      "url": "https://mcp.sense-lab.ai/mcp",
+      "headers": { "Authorization": "Bearer amfs_sk_your_key_here" }
+    }
+  }
+}
+```
+
+The hosted endpoint exposes a focused set of memory tools rather than the full
+stdio surface, and needs nothing installed. Use a local process when you want
+every tool.
+
 ### Claude Code
 
 Add to `~/.claude/claude_desktop_config.json`:


### PR DESCRIPTION
## What

`docs/guides/mcp.md` told readers there is **no `/mcp`** on hosted AMFS, and
`docs/editions.md` described Streamable HTTP as a self-hosted-only deployment
mode. Neither is true.

```
POST https://amfs-login.sense-lab.ai/mcp  -> 401  www-authenticate: Bearer realm="SenseLab MCP"
POST https://mcp.sense-lab.ai/mcp         -> 401  www-authenticate: Bearer realm="SenseLab MCP"
```

The endpoint answers and challenges for a bearer token. The practical cost of
the old wording is that someone evaluating AMFS concluded a remote URL was not
available and set up a local `uvx` process instead — or assumed remote MCP was
unsupported.

## Changes

- `docs/guides/mcp.md` — replaces the "no `/mcp`" claim with both connection
  methods, and keeps the part that was correct but easy to misread: the local
  server's `AMFS_HTTP_URL` is the **API base** and takes no `/mcp` suffix,
  which is a different thing from the endpoint a client connects to.
- `docs/guides/saas.md` — adds the hosted `url` + `Authorization` snippet
  alongside the existing stdio ones, since this is where readers go for
  connection options.
- `docs/editions.md` — same correction in the Pro MCP Server section.

Each mention notes that the hosted endpoint carries a focused set of memory
tools rather than the full stdio surface, so the trade-off between the two is
stated rather than left to be discovered after connecting.
