### PR TITLE
Store commits, and ask every adapter whether it does

### DIFF
--- a/packages/adapters/filesystem/src/amfs_filesystem/adapter.py
+++ b/packages/adapters/filesystem/src/amfs_filesystem/adapter.py
@@ -193,11 +193,21 @@ class FilesystemAdapter(AdapterABC):
                 logger.warning("Skipping unreadable commit: %s", f)
 
         # Sorted by when the commit was made, not by the filename. The filename
-        # is the commit id, which is a content hash, so ordering by it returned
+        # is the commit id, a uuid4 minted per flush, so ordering by it returned
         # a history in an order nobody asked for that happened to look sorted.
         # The limit is applied after, or "newest first" would mean "whichever
         # ones were read first".
-        commits.sort(key=lambda c: c.created_at, reverse=True)
+        #
+        # The id breaks ties, because created_at alone does not. Two commits
+        # made inside the same clock tick sort equal, and a stable sort then
+        # leaves them in the order the directory happened to be walked in —
+        # which is arbitrary. flush asks for exactly one commit to use as the
+        # next parent, so an arbitrary winner there is a parent pointer that
+        # varies run to run and a chain that forks where it should not. The id
+        # is arbitrary too, but it is the same arbitrary every time, and it is
+        # what Postgres already tie-breaks on (ORDER BY created_at DESC,
+        # id DESC), so the two adapters agree.
+        commits.sort(key=lambda c: (c.created_at, c.id), reverse=True)
         return commits[:limit]
 
     # ------------------------------------------------------------------

--- a/packages/adapters/filesystem/src/amfs_filesystem/adapter.py
+++ b/packages/adapters/filesystem/src/amfs_filesystem/adapter.py
@@ -154,7 +154,12 @@ class FilesystemAdapter(AdapterABC):
     # ------------------------------------------------------------------
 
     def _commits_dir(self) -> Path:
-        d = self._layout._root / "_commits"
+        # ``root``, not ``_root``. PathLayout has never had the private name,
+        # so every one of these three raised AttributeError on first use — the
+        # filesystem adapter was the one place commits were supposed to work
+        # and it did not either. Nothing noticed because the adapter contract
+        # suite did not ask about commits until now.
+        d = self._layout.root / "_commits"
         d.mkdir(parents=True, exist_ok=True)
         return d
 
@@ -177,19 +182,23 @@ class FilesystemAdapter(AdapterABC):
         limit: int = 50,
         namespace: str = "default",
     ) -> list[Commit]:
-        commits_dir = self._commits_dir()
         commits: list[Commit] = []
-        for f in sorted(commits_dir.glob("*.json"), reverse=True):
+        for f in self._commits_dir().glob("*.json"):
             try:
                 data = json.loads(f.read_text(encoding="utf-8"))
                 c = Commit.model_validate(data)
                 if c.branch == branch and c.namespace == namespace:
                     commits.append(c)
-                    if len(commits) >= limit:
-                        break
             except Exception:
                 logger.warning("Skipping unreadable commit: %s", f)
-        return commits
+
+        # Sorted by when the commit was made, not by the filename. The filename
+        # is the commit id, which is a content hash, so ordering by it returned
+        # a history in an order nobody asked for that happened to look sorted.
+        # The limit is applied after, or "newest first" would mean "whichever
+        # ones were read first".
+        commits.sort(key=lambda c: c.created_at, reverse=True)
+        return commits[:limit]
 
     # ------------------------------------------------------------------
     # list

--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -378,20 +378,45 @@ class HttpAdapter(AdapterABC):
     # one. Both read as an honest answer about an empty repository, so nothing
     # ever complained.
     #
-    # ``save_commit`` is still the inherited no-op, and that is a known gap
-    # rather than a finished thought. ``TransactionBuffer.flush`` assembles a
-    # Commit client-side and calls ``save_commit`` to persist it, so over HTTP
-    # the object is built, its id is returned to the caller, and it is then
-    # dropped — leaving an id that ``get_commit`` cannot resolve. There is no
-    # endpoint that accepts a client-assembled commit; ``POST /api/v1/commits``
-    # runs its own transaction and mints its own id. Closing this means moving
-    # the whole transaction server-side, which needs that endpoint to carry the
-    # metadata it currently discards (confidence, memory_type, pattern_refs,
-    # shared), so it is deliberately not attempted here.
+    # ``save_commit`` remains the inherited no-op, and now deliberately rather
+    # than as an unfinished thought. It was one because a client-side
+    # transaction assembled a Commit here and had nowhere to send it: no
+    # endpoint accepted a commit somebody else had minted, so the id went back
+    # to the caller and the object was dropped, leaving an id ``get_commit``
+    # could not resolve.
+    #
+    # The way out was not to add that endpoint, which would mean trusting a
+    # client-assembled id and tree hash, but to stop assembling commits on this
+    # side at all. ``commit_batch`` posts the writes and the server runs the
+    # transaction, mints the commit and persists it. That is also what makes
+    # the group atomic: one transaction on one connection, rather than n
+    # separate requests that can half-succeed.
+    #
+    # What that leaves is a ``save_commit`` nobody should reach. It is not made
+    # to raise, because ``TransactionBuffer.flush`` still calls it on the paths
+    # that have not moved over, and turning those into errors would break
+    # working code to make a point.
     #
     # One consequence of ``list_commits`` working: ``flush`` calls it to find a
     # parent, so a transaction over HTTP now costs one more request than before
     # and its commits form a real chain instead of every one being a root.
+
+    def commit_batch(
+        self,
+        writes: list[dict[str, Any]],
+        message: str = "",
+    ) -> Commit | None:
+        """Write a group of entries as one commit, run server-side.
+
+        Returns the commit the server minted, or ``None`` from a server old
+        enough not to send one back. ``None`` means "committed, details
+        unavailable" rather than "failed": by the time the response is read the
+        transaction has already landed, and treating it as an error would have
+        a caller retry writes that are already there.
+        """
+        data = self._post("/api/v1/commits", {"writes": writes, "message": message})
+        commit = data.get("commit")
+        return Commit.model_validate(commit) if commit else None
 
     def get_commit(self, commit_id: str) -> Commit | None:
         try:

--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -413,7 +413,16 @@ class HttpAdapter(AdapterABC):
         unavailable" rather than "failed": by the time the response is read the
         transaction has already landed, and treating it as an error would have
         a caller retry writes that are already there.
+
+        That reading only holds because a 200 now means something was written.
+        An empty ``writes`` list never reached flush, so the server answered
+        200 with no commit — the same answer an old server gives — and the
+        caller could not tell "nothing happened" from "landed, silently". The
+        server refuses an empty batch instead, which leaves ``None`` with one
+        meaning rather than two.
         """
+        if not writes:
+            raise ValueError("writes is empty — nothing to commit.")
         data = self._post("/api/v1/commits", {"writes": writes, "message": message})
         commit = data.get("commit")
         return Commit.model_validate(commit) if commit else None

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -27,6 +27,8 @@ from amfs_core.models import (
     BranchAccess,
     BranchAccessPermission,
     BranchStatus,
+    Commit,
+    CommitEntry,
     DecisionTrace,
     DiffEntry,
     Digest,
@@ -2284,8 +2286,126 @@ class PostgresAdapter(AdapterABC):
         return [self._row_to_trace(row) for row in rows]
 
     # ------------------------------------------------------------------
+    # commits
+    # ------------------------------------------------------------------
+    #
+    # These three inherited the base class's placeholders — a no-op save,
+    # ``None``, and ``[]`` — for as long as this adapter has existed. The
+    # effect was silent and complete: ``TransactionBuffer.flush`` assembled a
+    # Commit, handed it to ``save_commit``, and it was dropped, so every
+    # transaction returned a real id that resolved to nothing. ``commit_log``
+    # was empty for every account and ``common_ancestor`` found no ancestor for
+    # any pair of commits, including two that obviously shared one. All three
+    # read as an honest answer about a history that had not been written yet,
+    # which is why nothing complained.
+
+    def save_commit(self, commit: Commit) -> None:
+        """Persist a commit.
+
+        Idempotent on the id. The id is a content hash the SDK mints before
+        this is called, so a retried flush produces the same commit rather than
+        a second one, and ``ON CONFLICT DO NOTHING`` is what makes replaying a
+        flush safe. Nothing about a commit is mutable, so there is no update
+        branch to reach for.
+        """
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO amfs_commits
+                        (id, namespace, branch, message, author_agent_id,
+                         session_id, entries, tree_hash, parent_ids, created_at)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s::jsonb, %s)
+                    ON CONFLICT (id) DO NOTHING
+                    """,
+                    (
+                        commit.id,
+                        self._namespace,
+                        commit.branch,
+                        commit.message,
+                        commit.author_agent_id,
+                        commit.session_id,
+                        json.dumps([e.model_dump(mode="json") for e in commit.entries]),
+                        commit.tree_hash,
+                        json.dumps(list(commit.parent_ids)),
+                        commit.created_at,
+                    ),
+                )
+
+    def get_commit(self, commit_id: str) -> Commit | None:
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT id, namespace, branch, message, author_agent_id,
+                           session_id, entries, tree_hash, parent_ids, created_at
+                    FROM amfs_commits
+                    WHERE id = %s AND namespace = %s
+                    """,
+                    (commit_id, self._namespace),
+                )
+                row = cur.fetchone()
+
+        return self._row_to_commit(row) if row is not None else None
+
+    def list_commits(
+        self,
+        *,
+        branch: str = "main",
+        limit: int = 50,
+        namespace: str = "default",
+    ) -> list[Commit]:
+        """Commits, newest first.
+
+        ``namespace`` is accepted for the interface but the adapter's own
+        namespace is what is queried, as everywhere else here: it is fixed at
+        construction and is the tenant boundary this connection was opened for.
+        """
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT id, namespace, branch, message, author_agent_id,
+                           session_id, entries, tree_hash, parent_ids, created_at
+                    FROM amfs_commits
+                    WHERE namespace = %s AND branch = %s
+                    ORDER BY created_at DESC, id DESC
+                    LIMIT %s
+                    """,
+                    (self._namespace, branch, limit),
+                )
+                rows = cur.fetchall()
+
+        return [self._row_to_commit(row) for row in rows]
+
+    # ------------------------------------------------------------------
     # helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _row_to_commit(row: dict[str, Any]) -> Commit:
+        # psycopg returns JSONB already decoded, but the same rows arrive as
+        # strings through a plain cursor, so both are handled — the trace
+        # reader above does the same for the same reason.
+        entries = row.get("entries") or []
+        parents = row.get("parent_ids") or []
+        if isinstance(entries, str):
+            entries = json.loads(entries)
+        if isinstance(parents, str):
+            parents = json.loads(parents)
+
+        return Commit(
+            id=row["id"],
+            namespace=row["namespace"],
+            branch=row["branch"],
+            message=row["message"] or "",
+            author_agent_id=row["author_agent_id"],
+            session_id=row.get("session_id"),
+            entries=[CommitEntry.model_validate(e) for e in entries],
+            tree_hash=row.get("tree_hash"),
+            parent_ids=list(parents),
+            created_at=row["created_at"],
+        )
 
     def _row_to_trace(self, row: dict[str, Any]) -> DecisionTrace:
         ce_raw = row["causal_entries"] or []

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -2302,11 +2302,19 @@ class PostgresAdapter(AdapterABC):
     def save_commit(self, commit: Commit) -> None:
         """Persist a commit.
 
-        Idempotent on the id. The id is a content hash the SDK mints before
-        this is called, so a retried flush produces the same commit rather than
-        a second one, and ``ON CONFLICT DO NOTHING`` is what makes replaying a
-        flush safe. Nothing about a commit is mutable, so there is no update
-        branch to reach for.
+        Idempotent on the id, so saving the same commit object twice is safe
+        and nothing about a commit is mutable enough to need an update branch.
+
+        That is narrower than it sounds, and worth being exact about: the id is
+        a fresh uuid4 minted per flush, not a hash of the contents. A retried
+        flush is therefore a *different* commit, and ``ON CONFLICT`` will not
+        collapse the two. It protects a replay of one commit object, not a
+        retry of the operation that produced it.
+
+        This also runs on its own connection, after ``write_batch`` has already
+        committed the entries. If this insert fails, the entries stay and the
+        commit row does not, leaving versions that name a commit nobody can
+        look up. See ``TransactionBuffer.flush``.
         """
         with self._pool.connection() as conn:
             with conn.cursor() as cur:

--- a/packages/adapters/postgres/src/amfs_postgres/schema.sql
+++ b/packages/adapters/postgres/src/amfs_postgres/schema.sql
@@ -494,3 +494,44 @@ DROP TRIGGER IF EXISTS trg_notify_digest ON amfs_digests;
 CREATE TRIGGER trg_notify_digest
     AFTER INSERT OR UPDATE ON amfs_digests
     FOR EACH ROW EXECUTE FUNCTION amfs_notify_digest();
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Commits — atomic groups of writes
+-- ──────────────────────────────────────────────────────────────────────
+--
+-- Added late. Commits have existed in the model since the beginning, and
+-- TransactionBuffer has always assembled one and handed it to save_commit —
+-- which every adapter but the filesystem one inherited as a no-op. So a
+-- transaction returned a real commit id that resolved to nothing, commit_log
+-- was empty for every account, and common_ancestor found no ancestor for any
+-- pair. All three read as an honest answer about an empty history, which is
+-- why nothing complained for so long.
+--
+-- ``id`` is TEXT rather than UUID: the id is minted by the SDK as a content
+-- hash of the commit, not by the database, and it is what a caller has already
+-- been handed by the time this row is written.
+--
+-- ``entries`` and ``parent_ids`` are JSONB rather than child tables. A commit
+-- is immutable once written and is always read whole, so there is nothing to
+-- join for and nothing to update in place. Parent ids are a list because a
+-- merge commit has two.
+
+CREATE TABLE IF NOT EXISTS amfs_commits (
+    id TEXT PRIMARY KEY,
+    namespace TEXT NOT NULL DEFAULT 'default',
+    branch TEXT NOT NULL DEFAULT 'main',
+    message TEXT NOT NULL DEFAULT '',
+    author_agent_id TEXT NOT NULL,
+    session_id TEXT,
+    entries JSONB NOT NULL DEFAULT '[]',
+    tree_hash TEXT,
+    parent_ids JSONB NOT NULL DEFAULT '[]',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- The commit log query: newest first, within one namespace and branch.
+CREATE INDEX IF NOT EXISTS idx_commits_log
+    ON amfs_commits (namespace, branch, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_commits_author
+    ON amfs_commits (namespace, author_agent_id);

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -1492,21 +1492,70 @@ async def verify_integrity(
 # ──────────────────────────────────────────────────────────────────────
 
 
+#: Per-write options this endpoint forwards to the transaction.
+#:
+#: An allow-list, so a key a caller invents cannot reach ``tx.write`` as an
+#: unexpected keyword and turn a batch into a 500.
+_COMMIT_WRITE_OPTIONS = ("confidence", "memory_type", "pattern_refs", "shared")
+
+
 @app.post("/api/v1/commits")
 async def create_commit(
     body: dict[str, Any],
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
+    """Run a transaction here, rather than assembling one on the client.
+
+    A client-side transaction over HTTP wrote each entry with its own request
+    and then called ``save_commit``, which the HTTP adapter has never
+    implemented — there is no endpoint that accepts a commit somebody else
+    minted. So the id came back to the caller and the commit itself was
+    dropped, and nothing tied the entries together afterwards.
+
+    Doing it here is what makes the group atomic in the first place: one
+    transaction, against one connection, that either lands or does not.
+
+    The per-write options are the reason this was not simply switched over
+    earlier. This endpoint used to forward only path, key and value, so moving
+    a batch here would have silently discarded confidence, memory type,
+    pattern refs and sharing on every entry — writing the right entries with
+    the wrong metadata, which is worse than not writing them.
+    """
+    from amfs_core.models import MemoryType
+
     mem = _get_memory()
     writes = body.get("writes", [])
     message = body.get("message", "")
     with mem.transaction(message) as tx:
         for w in writes:
-            tx.write(w["entity_path"], w["key"], w.get("value"))
+            options = {k: w[k] for k in _COMMIT_WRITE_OPTIONS if k in w}
+            # Arrives over the wire as a string, and the write path wants the
+            # enum. An unknown one is refused rather than dropped: writing the
+            # entry with a default type would put the wrong metadata on the
+            # right memory, and nothing later can tell that happened.
+            if "memory_type" in options:
+                raw = str(options["memory_type"])
+                try:
+                    options["memory_type"] = MemoryType(raw)
+                except ValueError as exc:
+                    raise HTTPException(
+                        status_code=422,
+                        detail=(
+                            f"Invalid memory_type {raw!r}. Valid: "
+                            + ", ".join(m.value for m in MemoryType)
+                        ),
+                    ) from exc
+            tx.write(w["entity_path"], w["key"], w.get("value"), **options)
+
+    commit = tx.commit
     return {
-        "commit_id": tx.commit.id if tx.commit else None,
+        "commit_id": commit.id if commit else None,
         "message": message,
-        "entries_written": len(writes),
+        "entries_written": len(tx.entries),
+        # The whole commit, so a caller does not have to fetch what was just
+        # created to learn the versions its entries landed on.
+        "commit": json.loads(json.dumps(commit.model_dump(mode="json"), default=str))
+        if commit else None,
     }
 
 

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -1512,8 +1512,16 @@ async def create_commit(
     minted. So the id came back to the caller and the commit itself was
     dropped, and nothing tied the entries together afterwards.
 
-    Doing it here is what makes the group atomic in the first place: one
-    transaction, against one connection, that either lands or does not.
+    Doing it here is what makes the group a single round trip that either
+    reaches the server or does not, instead of n requests from a client that
+    can half-succeed and no way for the caller to find out which half.
+
+    It is not yet one database transaction, and the difference matters. The
+    Postgres adapter does not override ``write_batch``, so it inherits the
+    default that writes each entry on its own connection, and ``save_commit``
+    runs on a further one after those have committed. A failure part-way
+    leaves the earlier entries written. What is fixed here is the client-side
+    fan-out; what remains is the storage-side one.
 
     The per-write options are the reason this was not simply switched over
     earlier. This endpoint used to forward only path, key and value, so moving
@@ -1526,6 +1534,16 @@ async def create_commit(
     mem = _get_memory()
     writes = body.get("writes", [])
     message = body.get("message", "")
+    if not writes:
+        # Refused rather than accepted as a no-op, because the two are
+        # indistinguishable to the caller otherwise. An empty batch never
+        # reaches flush, so the response carries no commit — which is the same
+        # response a server too old to mint one sends back. The client reads
+        # that as "committed, details unavailable" and moves on, when in fact
+        # nothing was written at all.
+        raise HTTPException(
+            status_code=422, detail="writes is empty — nothing to commit."
+        )
     with mem.transaction(message) as tx:
         for w in writes:
             options = {k: w[k] for k in _COMMIT_WRITE_OPTIONS if k in w}

--- a/tests/integration/adapter_contract.py
+++ b/tests/integration/adapter_contract.py
@@ -216,9 +216,14 @@ class AdapterContractTests:
     # implemented" from "nothing there". These four ask.
 
     @staticmethod
-    def _make_commit(commit_id: str, *parents: str, message: str = "batch"):
+    def _make_commit(
+        commit_id: str, *parents: str, message: str = "batch", created_at=None
+    ):
         from amfs_core.models import Commit, CommitEntry
 
+        fields = {}
+        if created_at is not None:
+            fields["created_at"] = created_at
         return Commit(
             id=commit_id,
             message=message,
@@ -230,6 +235,7 @@ class AdapterContractTests:
             ],
             tree_hash=f"tree-{commit_id}",
             parent_ids=list(parents),
+            **fields,
         )
 
     def test_a_saved_commit_can_be_read_back(self, adapter: AdapterABC) -> None:
@@ -284,6 +290,44 @@ class AdapterContractTests:
             f"list_commits returned {ids} after two saves"
         )
         assert ids.index("c-two") < ids.index("c-one"), "newest first"
+
+    def test_commits_made_in_the_same_tick_still_have_one_order(
+        self, adapter: AdapterABC
+    ) -> None:
+        """A tie on created_at must not leave the winner up to chance.
+
+        flush asks for exactly one commit to use as the next parent. If two
+        commits share a timestamp and nothing breaks the tie, which one comes
+        back depends on the order storage happened to hand them over — so the
+        parent pointer varies between runs and the chain forks where it should
+        not. The id is arbitrary but consistent, and it is what Postgres
+        already tie-breaks on, so every adapter has to agree.
+        """
+        from datetime import datetime, timezone
+
+        tick = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        # Enough of them that an implementation which leaves ties in whatever
+        # order storage produced cannot pass by coincidence. With two it can:
+        # a directory walk returning them the right way round makes a broken
+        # sort look correct, which is how this went unnoticed.
+        ids = [f"c-tie-{s}" for s in ("aaa", "bbb", "ccc", "ddd", "eee", "fff")]
+        for commit_id in ids:
+            adapter.save_commit(self._make_commit(commit_id, created_at=tick))
+
+        tied = [
+            c.id for c in adapter.list_commits(limit=50)
+            if c.id.startswith("c-tie-")
+        ]
+
+        assert tied == sorted(ids, reverse=True), (
+            f"tied commits came back as {tied}; expected the id to break the "
+            "tie, descending, as Postgres does"
+        )
+        again = [
+            c.id for c in adapter.list_commits(limit=50)
+            if c.id.startswith("c-tie-")
+        ]
+        assert again == tied, "the order changed between two identical calls"
 
     def test_an_unknown_commit_is_none_rather_than_an_error(
         self, adapter: AdapterABC

--- a/tests/integration/adapter_contract.py
+++ b/tests/integration/adapter_contract.py
@@ -197,3 +197,111 @@ class AdapterContractTests:
         # After cancel, should not receive new entries
         # (may have received 0 or some depending on timing, but handle is cancelled)
         assert handle.cancelled
+
+    # ------------------------------------------------------------------
+    # commits
+    # ------------------------------------------------------------------
+    #
+    # Added after the connector functional sweep found there was no way to
+    # obtain two commit ids to give amfs_merge_base. The cause was that
+    # save_commit, get_commit and list_commits are concrete on AdapterABC with
+    # placeholder bodies — a no-op, None, and [] — so an adapter that never
+    # implemented them still satisfied the interface. Postgres never did, which
+    # means every hosted account's commit log had been empty since the
+    # beginning while reading as an honest answer about a history nobody had
+    # written yet.
+    #
+    # Nothing in this suite asked. That is the actual defect: a contract that
+    # tests only the methods an adapter chose to write cannot tell "not
+    # implemented" from "nothing there". These four ask.
+
+    @staticmethod
+    def _make_commit(commit_id: str, *parents: str, message: str = "batch"):
+        from amfs_core.models import Commit, CommitEntry
+
+        return Commit(
+            id=commit_id,
+            message=message,
+            author_agent_id="review-agent",
+            session_id="sess-001",
+            entries=[
+                CommitEntry(entity_path="checkout-service", key="retry-pattern",
+                            version=1, content_hash="h1"),
+            ],
+            tree_hash=f"tree-{commit_id}",
+            parent_ids=list(parents),
+        )
+
+    def test_a_saved_commit_can_be_read_back(self, adapter: AdapterABC) -> None:
+        adapter.save_commit(self._make_commit("c-round-trip"))
+
+        got = adapter.get_commit("c-round-trip")
+
+        assert got is not None, (
+            "save_commit accepted the commit and get_commit cannot find it — "
+            "the placeholder no-op is still in place"
+        )
+        assert got.id == "c-round-trip"
+        assert got.author_agent_id == "review-agent"
+        assert got.tree_hash == "tree-c-round-trip"
+
+    def test_the_entries_survive_the_round_trip(self, adapter: AdapterABC) -> None:
+        """A commit whose entries are lost cannot say what it committed."""
+        adapter.save_commit(self._make_commit("c-entries"))
+
+        got = adapter.get_commit("c-entries")
+
+        assert got is not None
+        assert len(got.entries) == 1
+        assert got.entries[0].entity_path == "checkout-service"
+        assert got.entries[0].key == "retry-pattern"
+
+    def test_parents_survive_so_the_history_is_a_chain(self, adapter: AdapterABC) -> None:
+        """Without parents every commit is a root and no pair has an ancestor.
+
+        This is the property common_ancestor walks, and losing it is invisible:
+        the answer "these two share no ancestor" is a perfectly plausible thing
+        for a repository to say.
+        """
+        adapter.save_commit(self._make_commit("c-parent"))
+        adapter.save_commit(self._make_commit("c-child", "c-parent"))
+
+        got = adapter.get_commit("c-child")
+
+        assert got is not None
+        assert got.parent_ids == ["c-parent"]
+
+    def test_list_commits_returns_what_was_saved_newest_first(
+        self, adapter: AdapterABC
+    ) -> None:
+        adapter.save_commit(self._make_commit("c-one"))
+        adapter.save_commit(self._make_commit("c-two", "c-one"))
+
+        listed = adapter.list_commits(limit=10)
+
+        ids = [c.id for c in listed]
+        assert "c-one" in ids and "c-two" in ids, (
+            f"list_commits returned {ids} after two saves"
+        )
+        assert ids.index("c-two") < ids.index("c-one"), "newest first"
+
+    def test_an_unknown_commit_is_none_rather_than_an_error(
+        self, adapter: AdapterABC
+    ) -> None:
+        assert adapter.get_commit("c-never-written") is None
+
+    def test_saving_the_same_commit_twice_does_not_duplicate_it(
+        self, adapter: AdapterABC
+    ) -> None:
+        """The id is a content hash, so a retried flush is the same commit.
+
+        Without this an interrupted transaction that is retried leaves two rows
+        claiming to be one commit, and the log shows work that happened once as
+        having happened twice.
+        """
+        adapter.save_commit(self._make_commit("c-idempotent"))
+        adapter.save_commit(self._make_commit("c-idempotent"))
+
+        listed = [c for c in adapter.list_commits(limit=50) if c.id == "c-idempotent"]
+
+        assert len(listed) == 1

--- a/tests/unit/test_http_adapter.py
+++ b/tests/unit/test_http_adapter.py
@@ -532,3 +532,100 @@ class TestTheBranchFilterReachesTheServer:
         assert "branch" not in calls[0]["params"]
         assert "namespace" not in calls[0]["params"]
         assert [c.id for c in commits] == ["c-main", "c-exp"]
+
+
+class TestCommitBatchRunsServerSide:
+    """Writing a group of entries as one commit, without assembling it here.
+
+    The client used to build the Commit itself and hand it to ``save_commit``,
+    which this adapter has never implemented — there was no endpoint that
+    accepted a commit somebody else had minted. So the caller got an id back
+    for an object that was dropped, and n separate write requests that could
+    half-succeed were described to them as atomic.
+
+    ``commit_batch`` posts the writes instead and lets the server transact,
+    mint and persist. What these pin is that the metadata survives the trip,
+    because the reason this was not done sooner is that the endpoint used to
+    forward only path, key and value — moving a batch across without fixing
+    that would have written the right entries with the wrong metadata, which
+    is worse than not writing them.
+    """
+
+    def test_the_writes_are_posted_as_one_request(self) -> None:
+        adapter, calls = _make_adapter({
+            "POST /api/v1/commits": {"commit_id": "c1", "commit": _commit("c1")},
+        })
+
+        adapter.commit_batch(
+            [
+                {"entity_path": "app/a", "key": "k1", "value": "v1"},
+                {"entity_path": "app/b", "key": "k2", "value": "v2"},
+            ],
+            "two entries",
+        )
+
+        assert len(calls) == 1, "a batch must not become one request per entry"
+        assert calls[0]["path"] == "/api/v1/commits"
+        assert calls[0]["method"] == "POST"
+        assert len(calls[0]["body"]["writes"]) == 2
+        assert calls[0]["body"]["message"] == "two entries"
+
+    def test_per_write_metadata_survives_the_trip(self) -> None:
+        """The regression that kept this on the client for so long."""
+        adapter, calls = _make_adapter({
+            "POST /api/v1/commits": {"commit": _commit("c1")},
+        })
+
+        adapter.commit_batch([{
+            "entity_path": "app/a",
+            "key": "k1",
+            "value": "v1",
+            "confidence": 0.4,
+            "memory_type": "belief",
+            "pattern_refs": ["risk-x"],
+            "shared": True,
+        }])
+
+        sent = calls[0]["body"]["writes"][0]
+        assert sent["confidence"] == 0.4
+        assert sent["memory_type"] == "belief"
+        assert sent["pattern_refs"] == ["risk-x"]
+        assert sent["shared"] is True
+
+    def test_the_minted_commit_comes_back(self) -> None:
+        adapter, _ = _make_adapter({
+            "POST /api/v1/commits": {"commit": _commit("c-abc", "c-parent")},
+        })
+
+        commit = adapter.commit_batch([{"entity_path": "a/b", "key": "k"}])
+
+        assert commit is not None
+        assert commit.id == "c-abc"
+        assert commit.parent_ids == ["c-parent"]
+
+    def test_a_server_that_returns_no_commit_is_not_a_failure(self) -> None:
+        """An older server writes the entries and says nothing about a commit.
+
+        The transaction has already landed by the time the response is read, so
+        raising here would have a caller retry writes that are already there.
+        ``None`` means "committed, details unavailable".
+        """
+        adapter, _ = _make_adapter({
+            "POST /api/v1/commits": {"commit_id": "c1", "entries_written": 1},
+        })
+
+        assert adapter.commit_batch([{"entity_path": "a/b", "key": "k"}]) is None
+
+    def test_save_commit_stays_a_no_op_rather_than_raising(self) -> None:
+        """TransactionBuffer.flush still calls it on paths that have not moved.
+
+        Making it raise would break working code to make a point about an
+        arrangement this adapter has now stopped relying on.
+        """
+        from amfs_core.models import Commit
+
+        adapter, calls = _make_adapter()
+
+        adapter.save_commit(Commit(id="c1", author_agent_id="a"))
+
+        assert calls == [], "save_commit must not reach the network"

--- a/tests/unit/test_http_adapter.py
+++ b/tests/unit/test_http_adapter.py
@@ -629,3 +629,35 @@ class TestCommitBatchRunsServerSide:
         adapter.save_commit(Commit(id="c1", author_agent_id="a"))
 
         assert calls == [], "save_commit must not reach the network"
+
+
+class TestAnEmptyBatchIsNotACommit:
+    """"Nothing happened" and "landed, silently" must not look the same.
+
+    ``commit_batch`` returns None for a server too old to send a commit back,
+    and reads that as "committed, details unavailable" — which is right, since
+    by then the transaction has landed and raising would have the caller retry
+    writes that already exist.
+
+    An empty writes list broke that reading. It never reached flush, so the
+    server answered 200 with no commit: the same response, and the caller
+    concluded a commit it never made had succeeded.
+    """
+
+    def test_an_empty_batch_is_refused_before_it_is_sent(self) -> None:
+        adapter, calls = _make_adapter({})
+
+        with pytest.raises(ValueError, match="nothing to commit"):
+            adapter.commit_batch([], "empty")
+
+        assert calls == [], "a request was sent for a batch with no writes"
+
+    def test_none_still_means_an_old_server_rather_than_an_error(self) -> None:
+        """The one remaining meaning of None, which is why the above matters."""
+        adapter, _ = _make_adapter({
+            "POST /api/v1/commits": {"commit_id": "c1", "entries_written": 1},
+        })
+
+        assert adapter.commit_batch(
+            [{"entity_path": "app/a", "key": "k", "value": "v"}], "one"
+        ) is None


### PR DESCRIPTION
Carries #302, which was merged into `fix/commits-over-http` after that branch
had already gone to main with #301 — so its commits never reached main. Same
content, retargeted. #302 itself is closed as merged and cannot be reopened.

## What is in here

Commits had nowhere to live. `save_commit` was a no-op on every adapter that
mattered, so `amfs_commit_log` and `amfs_merge_base` answered from an empty
store and looked like tools that worked.

- `amfs_commits` table in the OSS Postgres schema, with `save_commit`,
  `get_commit` and `list_commits` implemented against it.
- `commit_batch` on the HTTP adapter, so a batch is one request the server
  transacts rather than n requests a client hopes about.
- The `POST /api/v1/commits` endpoint runs the transaction server-side and
  forwards the per-write options, which is what stopped it being switched over
  earlier: it used to carry only path, key and value, so moving a batch there
  would have silently dropped confidence, memory type, pattern refs and
  sharing on every entry.
- Filesystem adapter commit storage fixed. `_commits_dir` reached for
  `self._layout._root`, which does not exist, so commit storage there had never
  once worked. `list_commits` also sorted by filename, which is a content hash,
  and applied its limit before sorting.
- Contract tests for commits, so an adapter claiming to store them has to
  prove it.

## Bugbot findings addressed

- Empty batches returned 200 with no commit, indistinguishable from an old
  server that mints none. Refused now at both ends.
- The route claimed the batch was one transaction against one connection. It is
  not: Postgres does not override `write_batch`. Both docstrings say so plainly
  instead. The storage-side fan-out is deliberately deferred — see the thread on
  #302.

## Deploy ordering

Migration 062 in amfs-internal #543 creates `amfs_commits` and is already
applied to production, so the adapter has a table to write to before this
ships.

Made with [Cursor](https://cursor.com)