### PR TITLE
Credit a batch commit to the caller, not to the server that runs it

### DIFF
--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -405,6 +405,8 @@ class HttpAdapter(AdapterABC):
         self,
         writes: list[dict[str, Any]],
         message: str = "",
+        agent_id: str | None = None,
+        session_id: str | None = None,
     ) -> Commit | None:
         """Write a group of entries as one commit, run server-side.
 
@@ -420,10 +422,21 @@ class HttpAdapter(AdapterABC):
         caller could not tell "nothing happened" from "landed, silently". The
         server refuses an empty batch instead, which leaves ``None`` with one
         meaning rather than two.
+
+        ``agent_id`` and ``session_id`` say who is committing, the same way
+        ``write`` does. Without them the server transacts as itself, which
+        credits the entries and the commit to the server process rather than to
+        the caller — and a commit the caller does not appear to have authored
+        is one they are not shown when they ask for their own log.
         """
         if not writes:
             raise ValueError("writes is empty — nothing to commit.")
-        data = self._post("/api/v1/commits", {"writes": writes, "message": message})
+        body: dict[str, Any] = {"writes": writes, "message": message}
+        if agent_id:
+            body["agent_id"] = agent_id
+        if session_id:
+            body["session_id"] = session_id
+        data = self._post("/api/v1/commits", body)
         commit = data.get("commit")
         return Commit.model_validate(commit) if commit else None
 

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -1502,6 +1502,7 @@ _COMMIT_WRITE_OPTIONS = ("confidence", "memory_type", "pattern_refs", "shared")
 @app.post("/api/v1/commits")
 async def create_commit(
     body: dict[str, Any],
+    request: Request,
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
     """Run a transaction here, rather than assembling one on the client.
@@ -1544,26 +1545,75 @@ async def create_commit(
         raise HTTPException(
             status_code=422, detail="writes is empty — nothing to commit."
         )
-    with mem.transaction(message) as tx:
-        for w in writes:
-            options = {k: w[k] for k in _COMMIT_WRITE_OPTIONS if k in w}
-            # Arrives over the wire as a string, and the write path wants the
-            # enum. An unknown one is refused rather than dropped: writing the
-            # entry with a default type would put the wrong metadata on the
-            # right memory, and nothing later can tell that happened.
-            if "memory_type" in options:
-                raw = str(options["memory_type"])
-                try:
-                    options["memory_type"] = MemoryType(raw)
-                except ValueError as exc:
-                    raise HTTPException(
-                        status_code=422,
-                        detail=(
-                            f"Invalid memory_type {raw!r}. Valid: "
-                            + ", ".join(m.value for m in MemoryType)
-                        ),
-                    ) from exc
-            tx.write(w["entity_path"], w["key"], w.get("value"), **options)
+
+    # Whose writes these are. Running the transaction here moved the work off
+    # the client and took the caller's name off it with it: everything went in
+    # as this process's own agent, because that is who _get_memory() is. The
+    # entries were credited to the server and so was the commit — and since
+    # GET /api/v1/commits hides commits whose author the caller cannot see, the
+    # caller could not then see the commit they had just made. amfs_commit_log
+    # answered zero for an account with commits sitting in it.
+    #
+    # Swapping the tagger is how POST /api/v1/entries has always done this.
+    # AgentMemory.agent_id reads through to the tagger, so one swap covers both
+    # the entries' provenance and the commit's author.
+    #
+    # The header is a fallback for a client that does not send the field yet:
+    # the MCP gateway has always set X-AMFS-Agent-Id on every request, so
+    # reading it means a gateway already in production is attributed correctly
+    # from the moment this deploys. The body wins when both are present.
+    agent_id = body.get("agent_id") or request.headers.get("x-amfs-agent-id")
+    session_id = body.get("session_id")
+    original_agent = mem._tagger.agent_id if agent_id else None
+    original_session = mem._tagger.session_id if session_id else None
+
+    try:
+        if agent_id:
+            mem._tagger.agent_id = agent_id
+            try:
+                # The gateway ensures its agent when the session opens, so this
+                # is normally a no-op. It is here for a client committing as an
+                # agent this server has not seen, where the entry insert would
+                # otherwise fail on a name nothing has registered.
+                mem._adapter.ensure_agent(agent_id, mem.namespace)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "ensure_agent failed for %s — committing anyway", agent_id,
+                    exc_info=True,
+                )
+            _link_agent_owner_once(request, agent_id, mem.namespace)
+        if session_id:
+            mem._tagger.session_id = session_id
+
+        with mem.transaction(message) as tx:
+            for w in writes:
+                options = {k: w[k] for k in _COMMIT_WRITE_OPTIONS if k in w}
+                # Arrives over the wire as a string, and the write path wants
+                # the enum. An unknown one is refused rather than dropped:
+                # writing the entry with a default type would put the wrong
+                # metadata on the right memory, and nothing later can tell that
+                # happened.
+                if "memory_type" in options:
+                    raw = str(options["memory_type"])
+                    try:
+                        options["memory_type"] = MemoryType(raw)
+                    except ValueError as exc:
+                        raise HTTPException(
+                            status_code=422,
+                            detail=(
+                                f"Invalid memory_type {raw!r}. Valid: "
+                                + ", ".join(m.value for m in MemoryType)
+                            ),
+                        ) from exc
+                tx.write(w["entity_path"], w["key"], w.get("value"), **options)
+    finally:
+        # Restored even when the transaction raised. This memory is a process
+        # singleton, so a tagger left holding one caller's name would sign the
+        # next caller's writes with it.
+        if original_agent is not None:
+            mem._tagger.agent_id = original_agent
+        if original_session is not None:
+            mem._tagger.session_id = original_session
 
     commit = tx.commit
     return {

--- a/tests/unit/test_commit_attribution.py
+++ b/tests/unit/test_commit_attribution.py
@@ -1,0 +1,165 @@
+"""A batch commit is credited to the caller, not to the server that runs it.
+
+The batch used to be assembled client-side: each entry went over as its own
+write carrying the caller's agent, and the caller stitched a commit together
+afterwards. Moving the transaction onto the server made the group genuinely one
+round trip, and took the caller's name off it in the process — everything now
+ran through the server's own long-lived ``AgentMemory``, so the entries were
+credited to the server process and so was the commit.
+
+The commit part is the one that shows. ``GET /api/v1/commits`` hides commits
+whose author the caller is not allowed to see, and the server's own agent is
+never one of those, so a caller could not see the commit they had just made:
+``amfs_commit_log`` answered zero for an account with commits sitting in it.
+The entries were quieter about it and no less wrong, since which agent knows
+what is the thing this system is for.
+
+These mirror ``test_write_session_provenance``, which pinned the same rule for
+``POST /api/v1/entries``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+from fastapi.testclient import TestClient  # noqa: E402
+
+import amfs_http.server as server  # noqa: E402
+
+SERVER_SESSION = "sess-server"
+SERVER_AGENT = "amfs-server"
+
+WRITES = [{"entity_path": "svc", "key": "k", "value": "v"}]
+
+
+@pytest.fixture()
+def tagger() -> SimpleNamespace:
+    return SimpleNamespace(agent_id=SERVER_AGENT, session_id=SERVER_SESSION)
+
+
+@pytest.fixture()
+def observed() -> dict:
+    """What the tagger held at the moment the transaction actually ran."""
+    return {}
+
+
+@pytest.fixture()
+def client(
+    monkeypatch: pytest.MonkeyPatch,
+    tagger: SimpleNamespace,
+    observed: dict,
+) -> TestClient:
+    mem = MagicMock()
+    mem.namespace = "test-ns"
+    mem._tagger = tagger
+
+    class _Tx:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def write(self, entity_path, key, value, **options):
+            # Read at write time, not afterwards: the point of the fix is that
+            # the tagger holds the caller's name for the duration, and a check
+            # made after the block would pass even if it were restored early.
+            observed["agent_id"] = tagger.agent_id
+            observed["session_id"] = tagger.session_id
+
+        commit = SimpleNamespace(
+            id="c-1", model_dump=lambda mode="json": {"id": "c-1"}
+        )
+        entries = ["one"]
+
+    mem.transaction.return_value = _Tx()
+    monkeypatch.setattr(server, "_memory", mem)
+    monkeypatch.setattr(server, "_get_memory", lambda: mem)
+    monkeypatch.setattr(server, "_link_agent_owner_once", lambda *a, **k: None)
+    return TestClient(server.app)
+
+
+def _post(client: TestClient, headers=None, **extra):
+    body = {"writes": WRITES, "message": "batch"}
+    body.update(extra)
+    resp = client.post("/api/v1/commits", json=body, headers=headers or {})
+    assert resp.status_code == 200, resp.text
+    return resp
+
+
+class TestTheCallerIsCredited:
+    def test_the_agent_reaches_the_transaction(self, client, observed) -> None:
+        _post(client, agent_id="builder-agent", session_id="sess-caller")
+        assert observed["agent_id"] == "builder-agent"
+
+    def test_the_session_reaches_it_too(self, client, observed) -> None:
+        _post(client, agent_id="builder-agent", session_id="sess-caller")
+        assert observed["session_id"] == "sess-caller"
+
+
+class TestTheHeaderIsTheFallback:
+    """The gateway has always sent X-AMFS-Agent-Id on every request.
+
+    Reading it means a gateway already in production is attributed correctly
+    from the moment this deploys, rather than after a client release.
+    """
+
+    def test_the_header_is_used_when_the_body_is_silent(
+        self, client, observed
+    ) -> None:
+        _post(client, headers={"X-AMFS-Agent-Id": "header-agent"})
+        assert observed["agent_id"] == "header-agent"
+
+    def test_the_body_wins_when_both_are_present(self, client, observed) -> None:
+        _post(
+            client,
+            headers={"X-AMFS-Agent-Id": "header-agent"},
+            agent_id="body-agent",
+        )
+        assert observed["agent_id"] == "body-agent"
+
+
+class TestTheServerTaggerIsLeftAsItWasFound:
+    """This memory is a process singleton, so a tagger left holding one
+    caller's name signs the next caller's writes with it."""
+
+    def test_the_agent_is_restored(self, client, tagger) -> None:
+        _post(client, agent_id="builder-agent", session_id="sess-caller")
+        assert tagger.agent_id == SERVER_AGENT
+
+    def test_the_session_is_restored(self, client, tagger) -> None:
+        _post(client, agent_id="builder-agent", session_id="sess-caller")
+        assert tagger.session_id == SERVER_SESSION
+
+    def test_it_is_restored_even_when_the_batch_is_rejected(
+        self, client, tagger
+    ) -> None:
+        resp = client.post(
+            "/api/v1/commits",
+            json={
+                "writes": [
+                    {
+                        "entity_path": "svc",
+                        "key": "k",
+                        "value": "v",
+                        "memory_type": "nonsense",
+                    }
+                ],
+                "agent_id": "builder-agent",
+            },
+        )
+
+        assert resp.status_code == 422
+        assert tagger.agent_id == SERVER_AGENT
+
+
+class TestOlderClientsStillCommit:
+    """A caller that names nobody gets the behaviour it had."""
+
+    def test_the_server_agent_is_the_fallback(self, client, observed) -> None:
+        _post(client)
+        assert observed["agent_id"] == SERVER_AGENT

--- a/tests/unit/test_http_adapter.py
+++ b/tests/unit/test_http_adapter.py
@@ -661,3 +661,43 @@ class TestAnEmptyBatchIsNotACommit:
         assert adapter.commit_batch(
             [{"entity_path": "app/a", "key": "k", "value": "v"}], "one"
         ) is None
+
+
+class TestABatchSaysWhoWroteIt:
+    """The server transacts, so it has to be told whose writes these are.
+
+    Moving the transaction server-side took the caller's name off the work:
+    everything went in as the server process's own agent. The entries were
+    credited to the server and so was the commit, and since the commit log
+    hides commits whose author the caller cannot see, the caller could not see
+    the commit they had just made — amfs_commit_log answered zero for an
+    account that had commits in it.
+    """
+
+    def test_the_agent_and_session_are_sent(self) -> None:
+        adapter, calls = _make_adapter({
+            "POST /api/v1/commits": {"commit_id": "c1", "entries_written": 1},
+        })
+
+        adapter.commit_batch(
+            [{"entity_path": "app/a", "key": "k", "value": "v"}],
+            "one",
+            agent_id="builder-agent",
+            session_id="sess-9",
+        )
+
+        body = calls[0]["body"]
+        assert body["agent_id"] == "builder-agent"
+        assert body["session_id"] == "sess-9"
+
+    def test_they_are_left_out_when_not_given(self) -> None:
+        """An absent field means "use the default", not an agent called None."""
+        adapter, calls = _make_adapter({
+            "POST /api/v1/commits": {"commit_id": "c1", "entries_written": 1},
+        })
+
+        adapter.commit_batch([{"entity_path": "app/a", "key": "k", "value": "v"}])
+
+        body = calls[0]["body"]
+        assert "agent_id" not in body
+        assert "session_id" not in body


### PR DESCRIPTION
`amfs_commit_log` returns zero for an account that has commits.

Running the batch transaction server-side (#302/#303) moved the work off the client and took the caller's name off it. Everything goes through the server process's own `AgentMemory`, so the entries are credited to the server agent and so is the commit. `GET /api/v1/commits` hides commits whose author the caller may not see, and the server's own agent is never one of those — so the caller cannot see the commit they just made, and an account with commits looks like an account that has never committed.

Confirmed against production, not inferred. `amfs_commits` has rows, chained correctly, and every one is `author_agent_id = amfs-server`:

```
      id      | author_agent_id | branch | namespace
--------------+-----------------+--------+----------
 d0ba24ade0b0 | amfs-server     | main   | default
 c71ca2f63a21 | amfs-server     | main   | default
```

The entries are quieter about it and no less wrong. Sweep runs from before the change are attributed to `builder-agent`; the run after is attributed to `amfs-server`.

## The fix

Exactly what `POST /api/v1/entries` has always done: swap the tagger for the duration of the request. `AgentMemory.agent_id` is a property reading through to the tagger, so one swap covers both the entries' provenance and the commit's author.

- `create_commit` takes `agent_id` / `session_id` from the body, and restores the tagger in a `finally` — the memory is a process singleton, so a tagger left holding one caller's name signs the next caller's writes with it.
- `X-AMFS-Agent-Id` is the fallback. The gateway has always sent it, so a gateway already deployed is attributed correctly the moment this ships, rather than after a client release. Body wins when both are present.
- `HttpAdapter.commit_batch` gained `agent_id` / `session_id`, so a client can say who it is explicitly.

