### PR TITLE
Let an entry with a slash in its key be read back

### DIFF
--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -128,7 +128,23 @@ class HttpAdapter(AdapterABC):
         params: dict[str, Any] = {}
         if branch and branch != "main":
             params["branch"] = branch
-        data = self._get(f"/api/v1/entries/{entity_path}/{key}", **params)
+        if "/" in key:
+            # The path form cannot express this. Its converter is greedy, so
+            # everything up to the final segment becomes the entity path, and a
+            # read of sweep/abc + active-negotiation/xyz asks the server for
+            # sweep/abc/active-negotiation + xyz — coordinates nothing was
+            # written at, which comes back as an ordinary "not found" rather
+            # than as an error anyone would notice.
+            #
+            # Only slashed keys take the query route, so a server too old to
+            # have it keeps serving every read it was already serving
+            # correctly. The ones it would 404 on are the ones it could never
+            # answer anyway.
+            data = self._get(
+                "/api/v1/entry", entity_path=entity_path, key=key, **params
+            )
+        else:
+            data = self._get(f"/api/v1/entries/{entity_path}/{key}", **params)
         if data.get("status") == "not_found":
             return None
         entry = _parse_entry(data)

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -683,6 +683,37 @@ async def whoami(
 # ──────────────────────────────────────────────────────────────────────
 
 
+@app.get("/api/v1/entry")
+async def read_entry_by_query(
+    request: Request,
+    entity_path: str = Query(...),
+    key: str = Query(...),
+    branch: str = Query("main"),
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    """The same read, with the coordinates where they cannot be confused.
+
+    ``/api/v1/entries/{entity_path:path}/{key}`` cannot express a key that
+    contains a slash. The path converter is greedy, so it takes everything up
+    to the final segment as the entity path, and a read of
+    ``sweep/abc`` / ``active-negotiation/xyz`` arrives as
+    ``sweep/abc/active-negotiation`` / ``xyz`` — coordinates nothing was ever
+    written at, answered with a confident "not found".
+
+    Slashed keys are not exotic here: 314 of 4,726 entries in production have
+    one, written by the negotiation engine and by anything else that namespaces
+    its keys. None of them could be read back. The OpenAI ``fetch`` tool is the
+    sharpest edge of that, because it exists to resolve an id that ``search``
+    just handed out — so search would offer an entry and fetch would deny it
+    existed.
+
+    The old route stays exactly as it was. It is unambiguous whenever the key
+    has no slash, which is most of the time, and rewriting every caller to gain
+    nothing is a worse trade than leaving them alone.
+    """
+    return await _read_entry(request, entity_path, key, branch)
+
+
 @app.get("/api/v1/entries/{entity_path:path}/{key}")
 async def read_entry(
     request: Request,
@@ -690,6 +721,15 @@ async def read_entry(
     key: str,
     branch: str = Query("main"),
     _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    return await _read_entry(request, entity_path, key, branch)
+
+
+async def _read_entry(
+    request: Request,
+    entity_path: str,
+    key: str,
+    branch: str,
 ) -> dict[str, Any]:
     mem = _get_memory()
     if _async_adapter is not None:

--- a/tests/unit/test_http_adapter.py
+++ b/tests/unit/test_http_adapter.py
@@ -701,3 +701,72 @@ class TestABatchSaysWhoWroteIt:
         body = calls[0]["body"]
         assert "agent_id" not in body
         assert "session_id" not in body
+
+
+class TestAKeyWithASlashInIt:
+    """The path route cannot express one, so read must not use it.
+
+    /api/v1/entries/{entity_path:path}/{key} is greedy: everything up to the
+    final segment becomes the entity path. Reading sweep/abc + the key
+    active-negotiation/xyz asks for sweep/abc/active-negotiation + xyz, which
+    nothing was written at, and the answer is an ordinary "not found" rather
+    than anything that looks like a bug. 314 of 4,726 entries in production
+    have such a key, and none could be read back.
+    """
+
+    def test_it_goes_by_query_rather_than_by_path(self) -> None:
+        adapter, calls = _make_adapter({
+            "/api/v1/entry": {"status": "not_found"},
+        })
+
+        adapter.read("sweep/abc", "active-negotiation/xyz")
+
+        assert calls[0]["path"] == "/api/v1/entry"
+        assert calls[0]["params"]["entity_path"] == "sweep/abc"
+        assert calls[0]["params"]["key"] == "active-negotiation/xyz"
+
+    def test_the_entry_comes_back_whole(self) -> None:
+        adapter, _calls = _make_adapter({
+            "/api/v1/entry": {
+                "entity_path": "sweep/abc",
+                "key": "active-negotiation/xyz",
+                "version": 1,
+                "value": "a proposal",
+                "provenance": {
+                    "agent_id": "a",
+                    "session_id": "s",
+                    "written_at": "2026-01-01T00:00:00Z",
+                },
+                "confidence": 0.9,
+            },
+        })
+
+        entry = adapter.read("sweep/abc", "active-negotiation/xyz")
+
+        assert entry is not None
+        assert entry.key == "active-negotiation/xyz"
+
+    def test_the_branch_still_travels(self) -> None:
+        adapter, calls = _make_adapter({"/api/v1/entry": {"status": "not_found"}})
+
+        adapter.read("sweep/abc", "active-negotiation/xyz", branch="feature")
+
+        assert calls[0]["params"]["branch"] == "feature"
+
+
+class TestAnOrdinaryKeyIsLeftAlone:
+    """Most keys have no slash, and the path route answers those correctly.
+
+    Moving them too would change every read against every deployed server to
+    gain nothing.
+    """
+
+    def test_it_still_goes_by_path(self) -> None:
+        adapter, calls = _make_adapter({
+            "/api/v1/entries/app/svc/plain-key": {"status": "not_found"},
+        })
+
+        adapter.read("app/svc", "plain-key")
+
+        assert calls[0]["path"] == "/api/v1/entries/app/svc/plain-key"
+        assert "key" not in calls[0]["params"]

--- a/tests/unit/test_slashed_key_read.py
+++ b/tests/unit/test_slashed_key_read.py
@@ -1,0 +1,123 @@
+"""An entry whose key contains a slash can be read back.
+
+``/api/v1/entries/{entity_path:path}/{key}`` cannot express one. The path
+converter is greedy, so everything up to the final segment becomes the entity
+path: a read of ``sweep/abc`` + ``active-negotiation/xyz`` arrives as
+``sweep/abc/active-negotiation`` + ``xyz``. Nothing was written there, so the
+server answers "not found" — a confident, wrong answer that looks exactly like
+an entry that never existed.
+
+314 of the 4,726 entries in production have such a key. The negotiation engine
+writes them, and so does anything else that namespaces its keys. None of them
+could be read back.
+
+The OpenAI ``fetch`` tool is the sharpest edge: it exists to resolve an id that
+``search`` has just handed out, so search would offer an entry and fetch would
+deny it existed — a contradiction between the only two tools the connector
+specification actually requires.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+from fastapi.testclient import TestClient  # noqa: E402
+
+import amfs_http.server as server  # noqa: E402
+from amfs_core.models import MemoryEntry, Provenance  # noqa: E402
+
+ENTITY = "sweep/abc"
+SLASHED_KEY = "active-negotiation/xyz"
+
+
+@pytest.fixture()
+def asked() -> list[tuple[str, str]]:
+    """The coordinates the read actually reached storage with."""
+    return []
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch, asked: list) -> TestClient:
+    stored = {
+        (ENTITY, SLASHED_KEY): MemoryEntry(
+            entity_path=ENTITY,
+            key=SLASHED_KEY,
+            value="a proposal nobody could read",
+            provenance=Provenance(
+                agent_id="builder-agent",
+                session_id="s",
+                written_at=datetime.now(timezone.utc),
+            ),
+        )
+    }
+
+    def _read(entity_path, key, branch="main", **_kw):
+        asked.append((entity_path, key))
+        return stored.get((entity_path, key))
+
+    mem = MagicMock()
+    mem.namespace = "test-ns"
+    mem._tagger = SimpleNamespace(agent_id="srv", session_id="sess")
+    mem.read.side_effect = _read
+
+    monkeypatch.setattr(server, "_memory", mem)
+    monkeypatch.setattr(server, "_get_memory", lambda: mem)
+    monkeypatch.setattr(server, "_async_adapter", None)
+    monkeypatch.setattr(server, "_get_visibility_filter", lambda _r: None)
+    return TestClient(server.app)
+
+
+class TestTheQueryRouteFindsIt:
+    def test_the_entry_comes_back(self, client) -> None:
+        resp = client.get(
+            "/api/v1/entry", params={"entity_path": ENTITY, "key": SLASHED_KEY}
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["key"] == SLASHED_KEY
+
+    def test_storage_was_asked_for_the_right_coordinates(
+        self, client, asked
+    ) -> None:
+        """The failure this fixes is a wrong question, not a missing answer."""
+        client.get(
+            "/api/v1/entry", params={"entity_path": ENTITY, "key": SLASHED_KEY}
+        )
+
+        assert asked == [(ENTITY, SLASHED_KEY)]
+
+    def test_a_key_that_is_genuinely_absent_is_still_not_found(
+        self, client
+    ) -> None:
+        resp = client.get(
+            "/api/v1/entry",
+            params={"entity_path": ENTITY, "key": "nothing/here"},
+        )
+
+        assert resp.json()["status"] == "not_found"
+
+
+class TestThePathRouteStillCannot:
+    """Kept as a record of why the other route exists.
+
+    This is not a bug left in place: the path form has no way to say where the
+    entity ends and the key begins, and both are user-supplied. The fix is to
+    ask a different question, not to guess better.
+    """
+
+    def test_it_splits_at_the_last_segment(self, client, asked) -> None:
+        client.get(f"/api/v1/entries/{ENTITY}/{SLASHED_KEY}")
+
+        assert asked == [("sweep/abc/active-negotiation", "xyz")]
+
+
+class TestOrdinaryKeysAreUnaffected:
+    def test_the_path_route_still_answers(self, client, asked) -> None:
+        client.get(f"/api/v1/entries/{ENTITY}/plain-key")
+
+        assert asked == [(ENTITY, "plain-key")]


### PR DESCRIPTION
## What is wrong

`search` returns an entry and `fetch` says it does not exist.

`/api/v1/entries/{entity_path:path}/{key}` cannot express a key containing a slash. The path converter is greedy, so everything up to the final segment becomes the entity path:

```
read("sweep/abc", "active-negotiation/xyz")
  -> GET /api/v1/entries/sweep/abc/active-negotiation/xyz
  -> entity_path="sweep/abc/active-negotiation", key="xyz"
  -> {"status": "not_found"}
```

Confirmed against production. The row is there; the read asks for coordinates nothing was ever written at, and gets a confident wrong answer:

```
$ curl .../api/v1/entries/sweep/cb5a28df/active-negotiation/sweep-negotiation-cb5a28df
{"status":"not_found","entity_path":"sweep/cb5a28df/active-negotiation","key":"sweep-negotiation-cb5a28df"}

$ curl .../api/v1/entries/sweep/cb5a28df/sweep-note
{"entity_path":"sweep/cb5a28df","key":"sweep-note","value":"..."}
```

**314 of the 4,726 entries in production have a slashed key** and none of them can be read back. The negotiation engine writes them, and so does anything that namespaces its keys.

`fetch` is the sharpest edge: it exists to resolve an id `search` just handed out, so the two tools OpenAI actually requires contradict each other. Found by the functional sweep, which searched, fetched what it found, and got a `ToolError`.
