### PR TITLE
Rank who knows a topic, and tell the agent asking

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -330,6 +330,14 @@ class PostgresAdapter(AdapterABC):
             ALTER TABLE amfs_decision_traces
             ADD COLUMN IF NOT EXISTS response_text TEXT
         """)
+        # Entry-to-trace resolution for knowledge lineage. The shared session id
+        # is the only link from a written entry back to the trace that committed
+        # it, since causal_entries records reads rather than writes.
+        cur.execute("""
+            CREATE INDEX IF NOT EXISTS idx_traces_session
+            ON amfs_decision_traces (namespace, agent_id, session_id)
+            WHERE session_id IS NOT NULL
+        """)
         cur.execute("""
             ALTER TABLE amfs_digests
             ADD COLUMN IF NOT EXISTS branch TEXT NOT NULL DEFAULT 'main'
@@ -1843,6 +1851,71 @@ class PostgresAdapter(AdapterABC):
             for r in rows
         ]
 
+    def agent_entity_stats(
+        self,
+        *,
+        entity_path: str | None = None,
+        agent_ids: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Per-(agent, entity) aggregates via GROUP BY — never loads values.
+
+        The authority ranking runs over every pair on the account, so this must
+        not be a full scan pulled into Python: an account with 5k entries would
+        otherwise ship all of them over the wire to count rows.
+        """
+        conditions = ["namespace = %s", "branch = 'main'", "superseded_at IS NULL"]
+        params: list[Any] = [self._namespace]
+        if agent_ids is not None:
+            conditions.append("agent_id = ANY(%s)")
+            params.append(list(agent_ids))
+        if entity_path:
+            # Descendants included: a/b covers a/b/c but never a/bc, which is
+            # why this is an equality OR a prefix-with-separator rather than a
+            # bare LIKE 'a/b%'.
+            prefix = entity_path.rstrip("/")
+            conditions.append("(entity_path = %s OR entity_path LIKE %s)")
+            params.extend([prefix, prefix + "/%"])
+        else:
+            # Same reasoning as entity_summaries: unscoped, this groups by
+            # entity_path, so a shared namespace's topics would be listed as
+            # though they were this account's own. Naming a path is the act of
+            # opting into it.
+            conditions.append(_EXCLUDE_SHARED_PATHS)
+        where = " AND ".join(conditions)
+
+        sql = f"""
+            SELECT agent_id,
+                   entity_path,
+                   COUNT(*) AS entry_count,
+                   AVG(confidence) AS avg_confidence,
+                   MAX(written_at) AS last_written,
+                   MIN(written_at) AS first_written,
+                   COALESCE(SUM(recall_count), 0) AS total_recalls,
+                   COUNT(*) FILTER (WHERE outcome_count > 0) AS outcome_linked_count
+            FROM amfs_memory_entries
+            WHERE {where}
+            GROUP BY agent_id, entity_path
+            ORDER BY entity_path, entry_count DESC, agent_id
+        """
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+                rows = cur.fetchall()
+
+        return [
+            {
+                "agent_id": r["agent_id"],
+                "entity_path": r["entity_path"],
+                "entry_count": int(r["entry_count"]),
+                "avg_confidence": float(r["avg_confidence"] or 0),
+                "last_written": r["last_written"],
+                "first_written": r["first_written"],
+                "total_recalls": int(r["total_recalls"] or 0),
+                "outcome_linked_count": int(r["outcome_linked_count"] or 0),
+            }
+            for r in rows
+        ]
+
     def stats_extended(
         self,
         *,
@@ -2185,7 +2258,7 @@ class PostgresAdapter(AdapterABC):
                            causal_entries, external_contexts,
                            query_events, session_started_at, session_ended_at,
                            session_duration_ms,
-                           error_events, state_diff, created_at
+                           error_events, state_diff, session_metadata, created_at
                     FROM amfs_decision_traces
                     WHERE id = %s AND namespace = %s
                     """,
@@ -2270,10 +2343,59 @@ class PostgresAdapter(AdapterABC):
                    causal_entries, external_contexts,
                    query_events, session_started_at, session_ended_at,
                    session_duration_ms,
-                   error_events, state_diff, created_at
+                   error_events, state_diff, session_metadata, created_at
             FROM amfs_decision_traces
             WHERE {where}
             ORDER BY created_at DESC
+            LIMIT %s
+        """
+        params.append(limit)
+
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+                rows = cur.fetchall()
+
+        return [self._row_to_trace(row) for row in rows]
+
+    def list_traces_for_entry(
+        self,
+        *,
+        agent_id: str,
+        session_id: str | None,
+        written_at: datetime | None = None,
+        limit: int = 5,
+    ) -> list[DecisionTrace]:
+        """Traces from the session that wrote an entry, nearest write first.
+
+        Uses idx_traces_session (namespace, agent_id, session_id).
+        """
+        if not session_id:
+            return []
+
+        conditions = ["namespace = %s", "agent_id = %s", "session_id = %s"]
+        params: list[Any] = [self._namespace, agent_id, session_id]
+
+        if written_at is not None:
+            # A trace committed *before* the write cannot be the one that
+            # committed it. Ordering by distance after the write picks the
+            # right trace when a long session committed several outcomes.
+            order = "ORDER BY (created_at >= %s) DESC, ABS(EXTRACT(EPOCH FROM (created_at - %s))) ASC"
+            params.extend([written_at, written_at])
+        else:
+            order = "ORDER BY created_at DESC"
+
+        where = " AND ".join(conditions)
+        sql = f"""
+            SELECT id, agent_id, session_id, outcome_ref, outcome_type,
+                   decision_summary, task_input, response_text,
+                   causal_entries, external_contexts,
+                   query_events, session_started_at, session_ended_at,
+                   session_duration_ms,
+                   error_events, state_diff, session_metadata, created_at
+            FROM amfs_decision_traces
+            WHERE {where}
+            {order}
             LIMIT %s
         """
         params.append(limit)

--- a/packages/adapters/postgres/src/amfs_postgres/schema.sql
+++ b/packages/adapters/postgres/src/amfs_postgres/schema.sql
@@ -81,6 +81,15 @@ CREATE INDEX IF NOT EXISTS idx_traces_outcome
     ON amfs_decision_traces (namespace, outcome_type)
     WHERE outcome_type IS NOT NULL;
 
+-- Resolves an entry back to the trace that committed it. An entry carries the
+-- session that wrote it (provenance.session_id) and so does a trace, which is
+-- the only link between the two — causal_entries records reads, not writes.
+-- Without this, knowledge lineage would filter traces by an unindexed JSONB
+-- scan over every trace on the account.
+CREATE INDEX IF NOT EXISTS idx_traces_session
+    ON amfs_decision_traces (namespace, agent_id, session_id)
+    WHERE session_id IS NOT NULL;
+
 CREATE TABLE IF NOT EXISTS amfs_api_keys (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     namespace TEXT NOT NULL DEFAULT 'default',

--- a/packages/core/src/amfs_core/abc.py
+++ b/packages/core/src/amfs_core/abc.py
@@ -171,6 +171,30 @@ class AdapterABC(ABC):
         """Return persisted decision traces. Default returns an empty list."""
         return []
 
+    def list_traces_for_entry(
+        self,
+        *,
+        agent_id: str,
+        session_id: str | None,
+        written_at: datetime | None = None,
+        limit: int = 5,
+    ) -> list[DecisionTrace]:
+        """Traces plausibly responsible for writing an entry, best match first.
+
+        An entry records the session that wrote it and a trace records the
+        session it was committed from, and that shared id is the only link
+        between the two — ``causal_entries`` holds the reads a session made,
+        never its writes. So resolution is: same agent, same session, and among
+        those the trace committed soonest *after* the write.
+
+        The match is exact when a session committed one outcome and a heuristic
+        when it committed several, so callers must present the result as the
+        likely committing trace rather than a certainty.
+
+        Default returns an empty list; adapters with persisted traces override.
+        """
+        return []
+
     def search(self, query: SearchQuery) -> list[MemoryEntry]:
         """Search entries with rich filters. Default: filter over list().
 
@@ -289,6 +313,40 @@ class AdapterABC(ABC):
             allowed = set(agent_ids)
             entries = [e for e in entries if e.provenance.agent_id in allowed]
         return entity_summaries_from_entries(entries)
+
+    def agent_entity_stats(
+        self,
+        *,
+        entity_path: str | None = None,
+        agent_ids: list[str] | None = None,
+    ) -> list[dict]:
+        """Per-(agent, entity) aggregates — who has written where, and how much.
+
+        Returns ``{agent_id, entity_path, entry_count, avg_confidence,
+        last_written, first_written, total_recalls, outcome_linked_count}``,
+        sorted by entity path then descending entry count.
+
+        *entity_path*, when given, restricts to that entity and its descendants
+        (``a/b`` matches ``a/b`` and ``a/b/c``, never ``a/bc``). *agent_ids*
+        restricts to those writers, for per-user visibility layers.
+
+        Default implementation groups over ``list()``; adapters with SQL
+        storage should override with GROUP BY aggregates.
+        """
+        from amfs_core.aggregates import agent_entity_stats_from_entries
+
+        entries = self.list()
+        if agent_ids is not None:
+            allowed = set(agent_ids)
+            entries = [e for e in entries if e.provenance.agent_id in allowed]
+        if entity_path:
+            prefix = entity_path.rstrip("/")
+            entries = [
+                e
+                for e in entries
+                if e.entity_path == prefix or e.entity_path.startswith(prefix + "/")
+            ]
+        return agent_entity_stats_from_entries(entries)
 
     def stats_extended(
         self,

--- a/packages/core/src/amfs_core/aggregates.py
+++ b/packages/core/src/amfs_core/aggregates.py
@@ -83,6 +83,39 @@ def entity_summaries_from_entries(entries: "list[MemoryEntry]") -> list[dict]:
     return summaries
 
 
+def agent_entity_stats_from_entries(entries: "list[MemoryEntry]") -> list[dict]:
+    """Group entries per (agent, entity) pair — who has written where.
+
+    One row per pair, carrying the evidence an authority ranking needs:
+    volume (``entry_count``), reuse (``total_recalls``), validation
+    (``outcome_linked_count``), recency (``last_written``) and stated certainty
+    (``avg_confidence``). Scoring lives in ``authority.py``; this only counts.
+    """
+    grouped: dict[tuple[str, str], list] = {}
+    for entry in entries:
+        key = (entry.provenance.agent_id, entry.entity_path)
+        grouped.setdefault(key, []).append(entry)
+
+    rows: list[dict] = []
+    for (agent_id, entity_path), group in grouped.items():
+        rows.append(
+            {
+                "agent_id": agent_id,
+                "entity_path": entity_path,
+                "entry_count": len(group),
+                "avg_confidence": sum(e.confidence for e in group) / len(group),
+                "last_written": max(e.provenance.written_at for e in group),
+                "first_written": min(e.provenance.written_at for e in group),
+                "total_recalls": sum(e.recall_count or 0 for e in group),
+                "outcome_linked_count": sum(
+                    1 for e in group if (e.outcome_count or 0) > 0
+                ),
+            }
+        )
+    rows.sort(key=lambda r: (r["entity_path"], -r["entry_count"], r["agent_id"]))
+    return rows
+
+
 def extended_stats_from_entries(entries: "list[MemoryEntry]") -> dict:
     """MemoryStats fields plus recall totals, weekly deltas, and type counts."""
     now = datetime.now(timezone.utc)

--- a/packages/core/src/amfs_core/authority.py
+++ b/packages/core/src/amfs_core/authority.py
@@ -1,0 +1,240 @@
+"""Who is the authority on a topic, and why — one scorer, four consumers.
+
+The dashboard's "Who Knows What" page, the briefing's ``who_to_ask`` block,
+retrieval's author weighting, and agent discovery all need to answer the same
+question: of the agents that have written here, whose memory should be trusted
+first? Answering it in four places guarantees four different answers, and the
+one users notice is the explanation — a dashboard that says an agent is the
+primary author while the briefing recommends someone else reads as a bug.
+
+So the score and the human sentence explaining it are produced together, here,
+and every surface reuses both verbatim.
+
+This lives in ``amfs_core`` rather than in Cortex because ``amfs-pro-api``
+depends on core but not on cortex, and the Pro expertise endpoint is one of the
+four consumers. Nothing here touches storage: it is a pure function of the rows
+``AdapterABC.agent_entity_stats()`` returns.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+# How the four signals trade off. Validated outcomes lead deliberately: an
+# agent whose memories demonstrably shaped a successful outcome is a better
+# person to ask than one who simply wrote more, and volume alone is the signal
+# most easily gamed by a chatty agent.
+_W_SHARE = 0.30
+_W_VALIDATED = 0.30
+_W_REUSE = 0.20
+_W_VOLUME = 0.20
+
+# Recency scales the blend rather than adding to it, because staleness
+# discounts every other signal at once: an agent that was authoritative a year
+# ago and has not written since is less useful on all four counts, not just on
+# recency. Floored so a dormant author is demoted, never erased — on a quiet
+# topic the only author may not have written in months and is still the answer.
+_RECENCY_HALF_LIFE_DAYS = 30.0
+_RECENCY_FLOOR = 0.5
+
+# Share thresholds for the coarse label the UI colours cells by.
+_PRIMARY_SHARE = 0.6
+_CONTRIBUTOR_SHARE = 0.2
+
+
+@dataclass
+class AuthorRank:
+    """One agent's standing on one entity, with the sentence that explains it."""
+
+    agent_id: str
+    entity_path: str
+    entry_count: int
+    share: float
+    validated_outcomes: int
+    total_recalls: int
+    last_written: datetime | None
+    score: float
+    strength: str
+    reason: str
+    top_keys: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "agent_id": self.agent_id,
+            "entity_path": self.entity_path,
+            "entry_count": self.entry_count,
+            "share": round(self.share, 4),
+            "validated_outcomes": self.validated_outcomes,
+            "total_recalls": self.total_recalls,
+            "last_written": self.last_written,
+            "score": round(self.score, 4),
+            "strength": self.strength,
+            "reason": self.reason,
+            "top_keys": list(self.top_keys),
+        }
+
+
+def _as_aware(value: Any) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+
+
+def _recency_multiplier(last_written: datetime | None, now: datetime) -> float:
+    if last_written is None:
+        return _RECENCY_FLOOR
+    days = max((now - last_written).total_seconds() / 86400.0, 0.0)
+    decayed = 0.5 ** (days / _RECENCY_HALF_LIFE_DAYS)
+    return _RECENCY_FLOOR + (1.0 - _RECENCY_FLOOR) * decayed
+
+
+def _normalise(value: float, peak: float) -> float:
+    """Scale against the strongest author on this topic, not a global maximum.
+
+    Authority is a comparison between the agents that wrote here. Normalising
+    against an account-wide maximum would make every author on a quiet topic
+    look weak, which is the flaw in the old page's global-max colour scale.
+    """
+    if peak <= 0:
+        return 0.0
+    return min(value / peak, 1.0)
+
+
+def humanise_age(last_written: datetime | None, now: datetime | None = None) -> str:
+    """"2 days ago" — the recency half of an authority explanation."""
+    if last_written is None:
+        return "at an unknown time"
+    now = now or datetime.now(timezone.utc)
+    seconds = max((now - last_written).total_seconds(), 0.0)
+    if seconds < 3600:
+        return "in the last hour"
+    if seconds < 86400:
+        hours = int(seconds // 3600)
+        return f"{hours} hour{'s' if hours != 1 else ''} ago"
+    days = int(seconds // 86400)
+    if days < 30:
+        return f"{days} day{'s' if days != 1 else ''} ago"
+    months = days // 30
+    if months < 12:
+        return f"{months} month{'s' if months != 1 else ''} ago"
+    years = days // 365
+    return f"{years} year{'s' if years != 1 else ''} ago"
+
+
+def _build_reason(
+    *,
+    entry_count: int,
+    validated: int,
+    recalls: int,
+    last_written: datetime | None,
+    now: datetime,
+) -> str:
+    """The one sentence every surface shows. Only claims what was measured."""
+    parts = [f"wrote {entry_count} memor{'ies' if entry_count != 1 else 'y'} here"]
+    if validated:
+        parts.append(
+            f"{validated} with validated outcome{'s' if validated != 1 else ''}"
+        )
+    if recalls:
+        parts.append(
+            f"recalled {recalls} time{'s' if recalls != 1 else ''} by other sessions"
+        )
+    parts.append(f"active {humanise_age(last_written, now)}")
+    return ", ".join(parts)
+
+
+def rank_authors(
+    entity_path: str,
+    *,
+    stats: list[dict[str, Any]],
+    limit: int | None = 3,
+    now: datetime | None = None,
+    top_keys: dict[str, list[str]] | None = None,
+) -> list[AuthorRank]:
+    """Rank the agents that have written to *entity_path*, strongest first.
+
+    *stats* are rows from ``AdapterABC.agent_entity_stats()``; rows for other
+    entities are ignored, so the caller can pass the whole account's stats once
+    and rank many topics from it without a query per topic.
+
+    *top_keys* optionally maps an agent id to its most relevant keys on this
+    entity, so a recommendation can name what to read rather than only whom to
+    ask. *limit* of ``None`` returns every author.
+    """
+    now = now or datetime.now(timezone.utc)
+    rows = [r for r in stats if r.get("entity_path") == entity_path]
+    if not rows:
+        return []
+
+    total_entries = sum(int(r.get("entry_count") or 0) for r in rows)
+    peak_validated = max(float(r.get("outcome_linked_count") or 0) for r in rows)
+    peak_recalls = max(float(r.get("total_recalls") or 0) for r in rows)
+    peak_volume = max(float(r.get("entry_count") or 0) for r in rows)
+
+    ranked: list[AuthorRank] = []
+    for row in rows:
+        entry_count = int(row.get("entry_count") or 0)
+        validated = int(row.get("outcome_linked_count") or 0)
+        recalls = int(row.get("total_recalls") or 0)
+        last_written = _as_aware(row.get("last_written"))
+
+        share = entry_count / total_entries if total_entries else 0.0
+        # Log-scaled so the gap between 1 and 10 memories counts for more than
+        # the gap between 100 and 110 — past a point, more of the same tells
+        # you nothing new about who to ask.
+        volume = math.log1p(entry_count) / math.log1p(peak_volume) if peak_volume else 0.0
+
+        blended = (
+            _W_SHARE * share
+            + _W_VALIDATED * _normalise(validated, peak_validated)
+            + _W_REUSE * _normalise(recalls, peak_recalls)
+            + _W_VOLUME * min(volume, 1.0)
+        )
+        score = blended * _recency_multiplier(last_written, now)
+
+        if share >= _PRIMARY_SHARE:
+            strength = "primary"
+        elif share >= _CONTRIBUTOR_SHARE:
+            strength = "contributor"
+        else:
+            strength = "touched"
+
+        ranked.append(
+            AuthorRank(
+                agent_id=str(row.get("agent_id") or ""),
+                entity_path=entity_path,
+                entry_count=entry_count,
+                share=share,
+                validated_outcomes=validated,
+                total_recalls=recalls,
+                last_written=last_written,
+                score=score,
+                strength=strength,
+                reason=_build_reason(
+                    entry_count=entry_count,
+                    validated=validated,
+                    recalls=recalls,
+                    last_written=last_written,
+                    now=now,
+                ),
+                top_keys=list((top_keys or {}).get(str(row.get("agent_id") or ""), [])),
+            )
+        )
+
+    # Ties broken by entry count then agent id so the order is stable across
+    # calls — an ordering that reshuffles between renders reads as churn.
+    ranked.sort(key=lambda a: (-a.score, -a.entry_count, a.agent_id))
+    return ranked if limit is None else ranked[:limit]
+
+
+def is_siloed(ranked: list[AuthorRank]) -> bool:
+    """True when exactly one agent has written here.
+
+    Callers showing this to a user whose view is filtered must word it as "one
+    of your agents" — the caller cannot see agents it has no access to, so an
+    account-wide claim would be one it cannot support.
+    """
+    return len(ranked) == 1

--- a/packages/core/src/amfs_core/authority.py
+++ b/packages/core/src/amfs_core/authority.py
@@ -146,6 +146,36 @@ def _build_reason(
     return ", ".join(parts)
 
 
+def _merge_by_agent(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse an agent's rows into one, summing its evidence.
+
+    Rolling a subtree up gives one row per (agent, child path); left as they
+    are, an agent that wrote across three child paths would be ranked three
+    times and its evidence split between the copies.
+    """
+    merged: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        agent_id = str(row.get("agent_id") or "")
+        acc = merged.get(agent_id)
+        if acc is None:
+            merged[agent_id] = {
+                "agent_id": agent_id,
+                "entry_count": int(row.get("entry_count") or 0),
+                "outcome_linked_count": int(row.get("outcome_linked_count") or 0),
+                "total_recalls": int(row.get("total_recalls") or 0),
+                "last_written": row.get("last_written"),
+            }
+            continue
+        acc["entry_count"] += int(row.get("entry_count") or 0)
+        acc["outcome_linked_count"] += int(row.get("outcome_linked_count") or 0)
+        acc["total_recalls"] += int(row.get("total_recalls") or 0)
+        newer = _as_aware(row.get("last_written"))
+        current = _as_aware(acc.get("last_written"))
+        if newer and (current is None or newer > current):
+            acc["last_written"] = row.get("last_written")
+    return list(merged.values())
+
+
 def rank_authors(
     entity_path: str,
     *,
@@ -153,6 +183,7 @@ def rank_authors(
     limit: int | None = 3,
     now: datetime | None = None,
     top_keys: dict[str, list[str]] | None = None,
+    include_descendants: bool = False,
 ) -> list[AuthorRank]:
     """Rank the agents that have written to *entity_path*, strongest first.
 
@@ -160,14 +191,32 @@ def rank_authors(
     entities are ignored, so the caller can pass the whole account's stats once
     and rank many topics from it without a query per topic.
 
+    *include_descendants* folds rows beneath *entity_path* into it, so an agent
+    that has only written to ``a/b/tokens`` still ranks as an authority on
+    ``a/b``. Callers that treat each path as its own column — the expertise
+    grid — want the default, where a child path is a topic in its own right.
+    Callers asking "who should I ask about this area" want it on, and it
+    matches the prefix scoping ``agent_entity_stats`` already applies to the
+    query, so subtree rows are ranked rather than fetched and thrown away.
+
     *top_keys* optionally maps an agent id to its most relevant keys on this
     entity, so a recommendation can name what to read rather than only whom to
     ask. *limit* of ``None`` returns every author.
     """
     now = now or datetime.now(timezone.utc)
-    rows = [r for r in stats if r.get("entity_path") == entity_path]
-    if not rows:
+    prefix = entity_path.rstrip("/") + "/"
+    matched = [
+        r for r in stats
+        if r.get("entity_path") == entity_path
+        or (
+            include_descendants
+            and str(r.get("entity_path") or "").startswith(prefix)
+        )
+    ]
+    if not matched:
         return []
+
+    rows = _merge_by_agent(matched)
 
     total_entries = sum(int(r.get("entry_count") or 0) for r in rows)
     peak_validated = max(float(r.get("outcome_linked_count") or 0) for r in rows)

--- a/packages/cortex/src/amfs_cortex/briefing.py
+++ b/packages/cortex/src/amfs_cortex/briefing.py
@@ -28,6 +28,34 @@ _WHO_TO_ASK_LIMIT = 3
 _WHO_TO_ASK_KEYS = 3
 
 
+def _busiest_path_by_agent(
+    stats: list[dict[str, Any]],
+    entity_path: str,
+    agent_ids: set[str],
+) -> dict[str, str]:
+    """The path in this subtree each agent has written to most.
+
+    Ranking spans descendants, so a recommended author may have written
+    nothing at the path that was asked about. The keys to offer them, and the
+    path to address a read to, both have to come from where their work
+    actually is. Ties go to the shallower path, so an agent that spread its
+    work evenly is pointed at the more general topic.
+    """
+    prefix = entity_path.rstrip("/") + "/"
+    best: dict[str, tuple[int, int, str]] = {}
+    for row in stats:
+        agent = str(row.get("agent_id") or "")
+        if agent not in agent_ids:
+            continue
+        path = str(row.get("entity_path") or "")
+        if path != entity_path and not path.startswith(prefix):
+            continue
+        rank = (int(row.get("entry_count") or 0), -path.count("/"), path)
+        if agent not in best or rank > best[agent]:
+            best[agent] = rank
+    return {agent: rank[2] for agent, rank in best.items()}
+
+
 class BriefingService:
     """Serves pre-compiled digests ranked by relevance for a given context."""
 
@@ -118,12 +146,16 @@ class BriefingService:
         if not ranked:
             return
 
-        top_keys = self._top_keys_by_agent(
-            entity_path, [a.agent_id for a in ranked], branch
+        # Where each author's keys actually live, which is not necessarily the
+        # path that was asked about now that the ranking spans the subtree.
+        source_paths = _busiest_path_by_agent(
+            stats, entity_path, {a.agent_id for a in ranked}
         )
+        top_keys = self._top_keys_by_agent(source_paths, branch)
 
         block = []
         for author in ranked:
+            source = source_paths.get(author.agent_id, entity_path)
             keys = top_keys.get(author.agent_id, [])
             item: dict[str, Any] = {
                 "agent_id": author.agent_id,
@@ -131,13 +163,19 @@ class BriefingService:
                 "entry_count": author.entry_count,
                 "share": round(author.share, 3),
                 "validated_outcomes": author.validated_outcomes,
+                # Named because it can sit below the path asked about, and a
+                # reader wanting a key other than the first one needs to know
+                # where to look for it.
+                "entity_path": source,
                 "top_keys": keys,
             }
             # The literal call closes the "I know who, but not what to read"
-            # gap that makes a bare recommendation useless.
+            # gap that makes a bare recommendation useless. It has to name the
+            # path the key is stored under: addressed to the parent, the read
+            # finds nothing and the recommendation is worse than none.
             if keys:
                 item["call"] = (
-                    f'amfs_read_from("{author.agent_id}", "{entity_path}", "{keys[0]}")'
+                    f'amfs_read_from("{author.agent_id}", "{source}", "{keys[0]}")'
                 )
             block.append(item)
 
@@ -167,17 +205,21 @@ class BriefingService:
 
     def _top_keys_by_agent(
         self,
-        entity_path: str,
-        agent_ids: list[str],
+        source_paths: dict[str, str],
         branch: str,
     ) -> dict[str, list[str]]:
-        """Highest-priority keys each named agent wrote on this entity."""
+        """Highest-priority keys each named agent wrote, on its own path.
+
+        One search per agent, as before. The path varies per agent because
+        ``search`` matches ``entity_path`` exactly, so asking about the parent
+        returns nothing for an author whose work sits in a child of it.
+        """
         result: dict[str, list[str]] = {}
-        for aid in agent_ids:
+        for aid, path in source_paths.items():
             try:
                 entries = self._adapter.search(
                     SearchQuery(
-                        entity_path=entity_path,
+                        entity_path=path,
                         agent_id=aid,
                         sort_by="priority",
                         limit=_WHO_TO_ASK_KEYS,

--- a/packages/cortex/src/amfs_cortex/briefing.py
+++ b/packages/cortex/src/amfs_cortex/briefing.py
@@ -71,7 +71,7 @@ class BriefingService:
                 self._inject_consolidation_notice(digests, entity_path, branch)
             else:
                 self._inject_standalone_hot_context(digests, entity_path, branch)
-            self._inject_who_to_ask(digests, entity_path, agent_id)
+            self._inject_who_to_ask(digests, entity_path, agent_id, branch)
 
         return digests
 
@@ -80,6 +80,7 @@ class BriefingService:
         digests: list[Digest],
         entity_path: str,
         agent_id: str | None,
+        branch: str,
     ) -> None:
         """Name the agents worth asking about this entity, and what to read.
 
@@ -99,7 +100,15 @@ class BriefingService:
             logger.debug("who_to_ask injection failed for %s", entity_path, exc_info=True)
             return
 
-        ranked = rank_authors(entity_path, stats=stats, limit=_WHO_TO_ASK_LIMIT)
+        # Descendants are rolled up because the query already scopes by prefix,
+        # and because an agent that owns `<path>/tokens` is exactly who you
+        # want named when you ask about `<path>`.
+        ranked = rank_authors(
+            entity_path,
+            stats=stats,
+            limit=_WHO_TO_ASK_LIMIT,
+            include_descendants=True,
+        )
 
         # Asking an agent to read from itself is noise, not routing. Drop the
         # caller only after ranking, so its own writes still set the share
@@ -109,7 +118,9 @@ class BriefingService:
         if not ranked:
             return
 
-        top_keys = self._top_keys_by_agent(entity_path, [a.agent_id for a in ranked])
+        top_keys = self._top_keys_by_agent(
+            entity_path, [a.agent_id for a in ranked], branch
+        )
 
         block = []
         for author in ranked:
@@ -135,10 +146,30 @@ class BriefingService:
                 d.summary["who_to_ask"] = block
                 return
 
+        # Nothing compiled for this path to hang the block on — the briefing
+        # came back with digests scoped elsewhere, or with agent briefs only.
+        # Carry the recommendations on a digest of our own instead of dropping
+        # them, the same way standalone hot context does when the compiled
+        # digest is missing entirely.
+        digests.append(Digest(
+            digest_type=DigestType.ENTITY,
+            scope=entity_path,
+            summary={
+                "narrative": f"No compiled digest yet for {entity_path}.",
+                "who_to_ask": block,
+            },
+            entry_count=0,
+            source_agents=[],
+            compiled_at=datetime.now(timezone.utc),
+            namespace=self._namespace,
+            branch=branch,
+        ))
+
     def _top_keys_by_agent(
         self,
         entity_path: str,
         agent_ids: list[str],
+        branch: str,
     ) -> dict[str, list[str]]:
         """Highest-priority keys each named agent wrote on this entity."""
         result: dict[str, list[str]] = {}
@@ -152,6 +183,10 @@ class BriefingService:
                         limit=_WHO_TO_ASK_KEYS,
                         include_artifacts=False,
                     ),
+                    # Without this the lookup silently reads main while the
+                    # rest of the briefing is on the caller's branch, and the
+                    # recommendation names an author but no key to read.
+                    branch=branch,
                 )
             except Exception:
                 logger.debug("who_to_ask key lookup failed for %s", aid, exc_info=True)

--- a/packages/cortex/src/amfs_cortex/briefing.py
+++ b/packages/cortex/src/amfs_cortex/briefing.py
@@ -11,6 +11,7 @@ import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
+from amfs_core.authority import rank_authors
 from amfs_core.models import Digest, DigestType, MemoryEntry, SearchQuery
 
 if TYPE_CHECKING:
@@ -19,6 +20,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _HOT_CONTEXT_LIMIT = 3
+
+# Three authors, three keys each. This rides along on the one call every agent
+# is told to make first, so it is paying for itself in context window on every
+# task — enough to route, not enough to be worth skimming past.
+_WHO_TO_ASK_LIMIT = 3
+_WHO_TO_ASK_KEYS = 3
 
 
 class BriefingService:
@@ -64,8 +71,93 @@ class BriefingService:
                 self._inject_consolidation_notice(digests, entity_path, branch)
             else:
                 self._inject_standalone_hot_context(digests, entity_path, branch)
+            self._inject_who_to_ask(digests, entity_path, agent_id)
 
         return digests
+
+    def _inject_who_to_ask(
+        self,
+        digests: list[Digest],
+        entity_path: str,
+        agent_id: str | None,
+    ) -> None:
+        """Name the agents worth asking about this entity, and what to read.
+
+        Injected at serve time rather than compiled into the digest, for two
+        reasons that both rule compilation out. Authority depends on recency,
+        and the worker recompiles on a debounce, so a compiled ranking is stale
+        by construction. And this names *other* agents, so it has to be
+        filtered per caller — a compiled digest is shared by everyone who asks
+        for it, which is the wrong granularity for a disclosure surface.
+
+        The caller-side visibility filter is the control that enforces the
+        second point; see the http-server's briefing handler.
+        """
+        try:
+            stats = self._adapter.agent_entity_stats(entity_path=entity_path)
+        except Exception:
+            logger.debug("who_to_ask injection failed for %s", entity_path, exc_info=True)
+            return
+
+        ranked = rank_authors(entity_path, stats=stats, limit=_WHO_TO_ASK_LIMIT)
+
+        # Asking an agent to read from itself is noise, not routing. Drop the
+        # caller only after ranking, so its own writes still set the share
+        # denominator and a colleague's contribution is not overstated.
+        if agent_id:
+            ranked = [a for a in ranked if a.agent_id != agent_id]
+        if not ranked:
+            return
+
+        top_keys = self._top_keys_by_agent(entity_path, [a.agent_id for a in ranked])
+
+        block = []
+        for author in ranked:
+            keys = top_keys.get(author.agent_id, [])
+            item: dict[str, Any] = {
+                "agent_id": author.agent_id,
+                "reason": author.reason,
+                "entry_count": author.entry_count,
+                "share": round(author.share, 3),
+                "validated_outcomes": author.validated_outcomes,
+                "top_keys": keys,
+            }
+            # The literal call closes the "I know who, but not what to read"
+            # gap that makes a bare recommendation useless.
+            if keys:
+                item["call"] = (
+                    f'amfs_read_from("{author.agent_id}", "{entity_path}", "{keys[0]}")'
+                )
+            block.append(item)
+
+        for d in digests:
+            if d.digest_type == DigestType.ENTITY and d.scope == entity_path:
+                d.summary["who_to_ask"] = block
+                return
+
+    def _top_keys_by_agent(
+        self,
+        entity_path: str,
+        agent_ids: list[str],
+    ) -> dict[str, list[str]]:
+        """Highest-priority keys each named agent wrote on this entity."""
+        result: dict[str, list[str]] = {}
+        for aid in agent_ids:
+            try:
+                entries = self._adapter.search(
+                    SearchQuery(
+                        entity_path=entity_path,
+                        agent_id=aid,
+                        sort_by="priority",
+                        limit=_WHO_TO_ASK_KEYS,
+                        include_artifacts=False,
+                    ),
+                )
+            except Exception:
+                logger.debug("who_to_ask key lookup failed for %s", aid, exc_info=True)
+                continue
+            result[aid] = [e.key for e in entries]
+        return result
 
     def _inject_hot_context(
         self,

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -3028,12 +3028,28 @@ async def agent_read_from(
                 "entityPath": entity_path, "key": key}
 
     mem = _get_memory()
-    entries = mem.search(entity_path=entity_path, agent_id=source_agent_id)
-    matching = [e for e in entries if e.key == key]
-    if not matching:
+    # Route through read_from rather than repeating its search inline. The
+    # difference is everything this endpoint exists to record: the two
+    # CROSS_AGENT_READ events, the read tracker entry that puts the read in the
+    # session's causal chain, and the learned_from edge. Doing the search here
+    # returned the same entry while leaving no trace that one agent had learned
+    # from another — and that edge is what the authority ranking is built on,
+    # so a cross-agent read over HTTP never counted for anything.
+    #
+    # Swapping the tagger is how the rest of this file attributes work to the
+    # caller (see agent_recall above): the memory is a process singleton, so a
+    # tagger left holding one caller's name would sign the next caller's reads.
+    original_agent = mem._tagger.agent_id
+    mem._tagger.agent_id = agent_id
+    try:
+        entry = mem.read_from(source_agent_id, entity_path, key)
+    finally:
+        mem._tagger.agent_id = original_agent
+
+    if entry is None:
         return {"status": "not_found", "sourceAgentId": source_agent_id,
                 "entityPath": entity_path, "key": key}
-    return _entry_to_response(matching[0])
+    return _entry_to_response(entry)
 
 
 @app.get("/api/v1/agents/{agent_id:path}/activity")
@@ -5298,6 +5314,22 @@ def _filter_briefing_digests(vis: Any, digests: list) -> list:
                     h.get("agent", ""), scope, user_agents, room_map,
                 )
             ]
+
+        # who_to_ask names agents by id and tells the caller to read from them.
+        # Unfiltered, it would both recommend a read that read_from then denies
+        # and disclose that an agent the caller cannot see exists — so this is
+        # a tenant-isolation control, not presentation.
+        if "who_to_ask" in digest.summary:
+            visible_authors = [
+                w for w in digest.summary["who_to_ask"]
+                if _is_agent_visible_for_entity(
+                    w.get("agent_id", ""), scope, user_agents, room_map,
+                )
+            ]
+            if visible_authors:
+                digest.summary["who_to_ask"] = visible_authors
+            else:
+                digest.summary.pop("who_to_ask")
 
         if source_agents:
             has_visible = any(

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -5378,7 +5378,12 @@ def _filter_briefing_digests(vis: Any, digests: list) -> list:
         else:
             has_room_access = scope in room_map
             has_visible_hot = bool(digest.summary.get("hot_context"))
-            if not has_room_access and not has_visible_hot:
+            # A surviving who_to_ask names only agents already cleared above,
+            # so keeping the digest for its sake discloses nothing further —
+            # and dropping it would throw away the routing this caller is
+            # allowed to act on, which is the whole point of the block.
+            has_visible_ask = bool(digest.summary.get("who_to_ask"))
+            if not has_room_access and not has_visible_hot and not has_visible_ask:
                 continue
 
         filtered.append(digest)

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -2014,14 +2014,12 @@ async def create_patch(
 # ──────────────────────────────────────────────────────────────────────
 
 
-@app.get("/api/v1/history/{entity_path:path}/{key}")
-async def get_history(
+async def _history_payload(
     request: Request,
     entity_path: str,
     key: str,
-    since: str | None = Query(None),
-    until: str | None = Query(None),
-    _auth: str | None = Depends(verify_api_key),
+    since: str | None,
+    until: str | None,
 ) -> dict[str, Any]:
     mem = _get_memory()
     since_dt = datetime.fromisoformat(since) if since else None
@@ -2037,6 +2035,45 @@ async def get_history(
         "version_count": len(versions),
         "versions": [_entry_to_response(e) for e in versions],
     }
+
+
+@app.get("/api/v1/history")
+async def get_history_by_query(
+    request: Request,
+    entity_path: str = Query(...),
+    key: str = Query(...),
+    since: str | None = Query(None),
+    until: str | None = Query(None),
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    """History with the coordinates where they cannot be confused.
+
+    The same greedy-path problem ``/api/v1/entry`` was added for: a key
+    containing a slash cannot be expressed as a path segment, so a history
+    lookup for one silently reported no versions. Reading an entry back was
+    fixed first because it was the louder failure; this is the same defect on
+    the same coordinates, and the version chain is what the lineage panel is
+    built on.
+    """
+    return await _history_payload(request, entity_path, key, since, until)
+
+
+@app.get("/api/v1/history/{entity_path:path}/{key}")
+async def get_history(
+    request: Request,
+    entity_path: str,
+    key: str,
+    since: str | None = Query(None),
+    until: str | None = Query(None),
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    """Unchanged, and unambiguous whenever the key has no slash.
+
+    Kept as it is for the callers already on it, exactly as the entries route
+    was: rewriting every one of them to gain nothing on the common case is the
+    worse trade.
+    """
+    return await _history_payload(request, entity_path, key, since, until)
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/unit/test_agent_entity_stats.py
+++ b/tests/unit/test_agent_entity_stats.py
@@ -1,0 +1,162 @@
+"""Unit tests for the per-(agent, entity) aggregate behind authority ranking.
+
+The Postgres adapter overrides this with a GROUP BY, so the contract pinned
+here is the one both implementations have to satisfy — most importantly the
+prefix scoping, where 'a/b' must cover 'a/b/c' without ever matching 'a/bc'.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+pytest.importorskip("amfs_core", reason="amfs_core not installed")
+
+from amfs_core.abc import AdapterABC
+from amfs_core.aggregates import agent_entity_stats_from_entries
+from amfs_core.models import MemoryEntry, Provenance
+
+NOW = datetime(2026, 8, 10, 12, 0, tzinfo=timezone.utc)
+
+
+def _entry(
+    agent_id: str,
+    entity_path: str,
+    key: str,
+    *,
+    confidence: float = 0.8,
+    recalls: int = 0,
+    outcomes: int = 0,
+    days_ago: float = 1.0,
+) -> MemoryEntry:
+    return MemoryEntry(
+        entity_path=entity_path,
+        key=key,
+        value="v",
+        confidence=confidence,
+        recall_count=recalls,
+        outcome_count=outcomes,
+        provenance=Provenance(
+            agent_id=agent_id,
+            session_id=f"session-{agent_id}",
+            written_at=NOW - timedelta(days=days_ago),
+        ),
+    )
+
+
+class _ListAdapter(AdapterABC):
+    """Minimal adapter exercising the ABC's list()-based default."""
+
+    def __init__(self, entries: list[MemoryEntry]) -> None:
+        self._entries = entries
+
+    def list(self, entity_path=None, *, include_superseded=False, branch="main"):
+        if entity_path is None:
+            return list(self._entries)
+        return [e for e in self._entries if e.entity_path == entity_path]
+
+    # Unused abstract surface.
+    def write(self, *a, **k): raise NotImplementedError
+    def read(self, *a, **k): raise NotImplementedError
+    def delete(self, *a, **k): raise NotImplementedError
+    def history(self, *a, **k): raise NotImplementedError
+    def commit_outcome(self, *a, **k): raise NotImplementedError
+    def watch(self, *a, **k): raise NotImplementedError
+
+
+class TestGrouping:
+
+    def test_one_row_per_agent_entity_pair(self):
+        rows = agent_entity_stats_from_entries([
+            _entry("a", "myapp/auth", "k1"),
+            _entry("a", "myapp/auth", "k2"),
+            _entry("b", "myapp/auth", "k3"),
+            _entry("a", "myapp/billing", "k4"),
+        ])
+        pairs = {(r["agent_id"], r["entity_path"]): r for r in rows}
+        assert len(pairs) == 3
+        assert pairs[("a", "myapp/auth")]["entry_count"] == 2
+        assert pairs[("b", "myapp/auth")]["entry_count"] == 1
+
+    def test_counts_recalls_and_validated_outcomes(self):
+        rows = agent_entity_stats_from_entries([
+            _entry("a", "myapp/auth", "k1", recalls=3, outcomes=1),
+            _entry("a", "myapp/auth", "k2", recalls=4, outcomes=0),
+        ])
+        assert rows[0]["total_recalls"] == 7
+        # Entries *with* an outcome, not the sum of outcome counts: the
+        # question is how many memories were validated, not how often.
+        assert rows[0]["outcome_linked_count"] == 1
+
+    def test_tracks_first_and_last_write(self):
+        rows = agent_entity_stats_from_entries([
+            _entry("a", "myapp/auth", "k1", days_ago=10),
+            _entry("a", "myapp/auth", "k2", days_ago=2),
+        ])
+        assert rows[0]["last_written"] == NOW - timedelta(days=2)
+        assert rows[0]["first_written"] == NOW - timedelta(days=10)
+
+    def test_averages_confidence(self):
+        rows = agent_entity_stats_from_entries([
+            _entry("a", "myapp/auth", "k1", confidence=0.6),
+            _entry("a", "myapp/auth", "k2", confidence=1.0),
+        ])
+        assert rows[0]["avg_confidence"] == pytest.approx(0.8)
+
+    def test_empty_input_yields_no_rows(self):
+        assert agent_entity_stats_from_entries([]) == []
+
+
+class TestPrefixScoping:
+
+    def _adapter(self) -> _ListAdapter:
+        return _ListAdapter([
+            _entry("a", "myapp/auth", "k1"),
+            _entry("a", "myapp/auth/tokens", "k2"),
+            _entry("a", "myapp/authorisation", "k3"),
+            _entry("a", "other/thing", "k4"),
+        ])
+
+    def test_scope_includes_descendants(self):
+        rows = self._adapter().agent_entity_stats(entity_path="myapp/auth")
+        assert {r["entity_path"] for r in rows} == {"myapp/auth", "myapp/auth/tokens"}
+
+    def test_scope_excludes_sibling_with_shared_prefix(self):
+        """'myapp/auth' must not swallow 'myapp/authorisation'."""
+        rows = self._adapter().agent_entity_stats(entity_path="myapp/auth")
+        assert "myapp/authorisation" not in {r["entity_path"] for r in rows}
+
+    def test_trailing_slash_is_tolerated(self):
+        rows = self._adapter().agent_entity_stats(entity_path="myapp/auth/")
+        assert {r["entity_path"] for r in rows} == {"myapp/auth", "myapp/auth/tokens"}
+
+    def test_unscoped_returns_every_pair(self):
+        rows = self._adapter().agent_entity_stats()
+        assert len(rows) == 4
+
+
+class TestAgentFiltering:
+
+    def test_restricts_to_named_writers(self):
+        adapter = _ListAdapter([
+            _entry("mine", "myapp/auth", "k1"),
+            _entry("theirs", "myapp/auth", "k2"),
+        ])
+        rows = adapter.agent_entity_stats(agent_ids=["mine"])
+        assert [r["agent_id"] for r in rows] == ["mine"]
+
+    def test_empty_allow_list_hides_everything(self):
+        """A user who owns no agents must not see an unfiltered account."""
+        adapter = _ListAdapter([_entry("theirs", "myapp/auth", "k1")])
+        assert adapter.agent_entity_stats(agent_ids=[]) == []
+
+
+class TestSlashedKeys:
+
+    def test_a_key_containing_a_slash_does_not_move_the_entity(self):
+        """6.6% of production keys contain a slash; grouping is by column."""
+        rows = agent_entity_stats_from_entries([
+            _entry("a", "sweep/abc", "active-negotiation/xyz"),
+        ])
+        assert rows[0]["entity_path"] == "sweep/abc"

--- a/tests/unit/test_authority.py
+++ b/tests/unit/test_authority.py
@@ -1,0 +1,207 @@
+"""Unit tests for the shared authority ranking.
+
+One scorer feeds the Who Knows What page, the briefing's who_to_ask block,
+retrieval and discovery, so what is pinned here is the behaviour every surface
+inherits: that validated outcomes beat raw volume, that a dormant author is
+demoted rather than erased, and that the explanation only claims what was
+actually measured.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+pytest.importorskip("amfs_core", reason="amfs_core not installed")
+
+from amfs_core.authority import (
+    AuthorRank,
+    humanise_age,
+    is_siloed,
+    rank_authors,
+)
+
+NOW = datetime(2026, 8, 10, 12, 0, tzinfo=timezone.utc)
+ENTITY = "myapp/auth"
+
+
+def _row(
+    agent_id: str,
+    *,
+    entity_path: str = ENTITY,
+    entry_count: int = 1,
+    recalls: int = 0,
+    validated: int = 0,
+    days_ago: float = 1.0,
+    confidence: float = 0.8,
+) -> dict:
+    return {
+        "agent_id": agent_id,
+        "entity_path": entity_path,
+        "entry_count": entry_count,
+        "avg_confidence": confidence,
+        "last_written": NOW - timedelta(days=days_ago),
+        "first_written": NOW - timedelta(days=days_ago + 10),
+        "total_recalls": recalls,
+        "outcome_linked_count": validated,
+    }
+
+
+class TestRanking:
+
+    def test_no_authors_for_unknown_entity(self):
+        assert rank_authors("myapp/nothing", stats=[_row("a")], now=NOW) == []
+
+    def test_ignores_rows_for_other_entities(self):
+        stats = [_row("a"), _row("b", entity_path="other/thing", entry_count=99)]
+        ranked = rank_authors(ENTITY, stats=stats, now=NOW)
+        assert [r.agent_id for r in ranked] == ["a"]
+
+    def test_validated_outcomes_beat_raw_volume(self):
+        """The whole point of outcome-weighting: a chatty agent is not the authority."""
+        stats = [
+            _row("chatty", entry_count=40),
+            _row("proven", entry_count=12, validated=8, recalls=20),
+        ]
+        ranked = rank_authors(ENTITY, stats=stats, now=NOW)
+        assert ranked[0].agent_id == "proven"
+
+    def test_recency_demotes_but_does_not_erase(self):
+        stats = [
+            _row("dormant", entry_count=30, days_ago=800),
+            _row("active", entry_count=30, days_ago=1),
+        ]
+        ranked = rank_authors(ENTITY, stats=stats, now=NOW)
+        assert [r.agent_id for r in ranked] == ["active", "dormant"]
+        # Demoted, still present and still scoring — on a quiet topic the only
+        # author may be dormant and is still the right person to ask.
+        assert ranked[1].score > 0
+
+    def test_sole_author_of_a_quiet_topic_still_ranks(self):
+        ranked = rank_authors(ENTITY, stats=[_row("solo", days_ago=400)], now=NOW)
+        assert len(ranked) == 1
+        assert ranked[0].score > 0
+        assert ranked[0].strength == "primary"
+
+    def test_limit_applies_and_none_returns_all(self):
+        stats = [_row(f"a{i}", entry_count=10 - i) for i in range(5)]
+        assert len(rank_authors(ENTITY, stats=stats, now=NOW)) == 3
+        assert len(rank_authors(ENTITY, stats=stats, limit=None, now=NOW)) == 5
+
+    def test_order_is_stable_for_identical_authors(self):
+        stats = [_row("b-agent"), _row("a-agent")]
+        first = [r.agent_id for r in rank_authors(ENTITY, stats=stats, now=NOW)]
+        second = [r.agent_id for r in rank_authors(ENTITY, stats=stats, now=NOW)]
+        assert first == second == ["a-agent", "b-agent"]
+
+
+class TestShareAndStrength:
+
+    def test_share_sums_to_one_across_authors(self):
+        stats = [_row("a", entry_count=3), _row("b", entry_count=1)]
+        ranked = rank_authors(ENTITY, stats=stats, limit=None, now=NOW)
+        assert sum(r.share for r in ranked) == pytest.approx(1.0)
+
+    def test_strength_labels_follow_share(self):
+        # Shares of 0.67 / 0.28 / 0.06 straddle the 0.6 and 0.2 thresholds.
+        stats = [
+            _row("dominant", entry_count=60),
+            _row("helper", entry_count=25),
+            _row("passer-by", entry_count=5),
+        ]
+        by_id = {
+            r.agent_id: r
+            for r in rank_authors(ENTITY, stats=stats, limit=None, now=NOW)
+        }
+        assert by_id["dominant"].strength == "primary"
+        assert by_id["helper"].strength == "contributor"
+        assert by_id["passer-by"].strength == "touched"
+
+    def test_share_is_relative_to_the_topic_not_the_account(self):
+        """A quiet topic's only author is primary, however small the counts."""
+        ranked = rank_authors(ENTITY, stats=[_row("solo", entry_count=2)], now=NOW)
+        assert ranked[0].share == pytest.approx(1.0)
+        assert ranked[0].strength == "primary"
+
+
+class TestReason:
+
+    def test_reason_states_volume_validation_and_recency(self):
+        stats = [_row("api-agent", entry_count=34, validated=3, days_ago=2)]
+        reason = rank_authors(ENTITY, stats=stats, now=NOW)[0].reason
+        assert "34 memories" in reason
+        assert "3 with validated outcomes" in reason
+        assert "2 days ago" in reason
+
+    def test_reason_omits_claims_it_cannot_make(self):
+        """No validated outcomes and no recalls means the sentence says neither."""
+        reason = rank_authors(ENTITY, stats=[_row("a", entry_count=1)], now=NOW)[0].reason
+        assert "validated" not in reason
+        assert "recalled" not in reason
+        assert "1 memory" in reason
+
+    def test_singular_and_plural_agree(self):
+        one = rank_authors(ENTITY, stats=[_row("a", entry_count=1, validated=1, recalls=1)], now=NOW)[0]
+        assert "1 memory here" in one.reason
+        assert "1 with validated outcome," in one.reason
+        assert "recalled 1 time by" in one.reason
+
+
+class TestHumaniseAge:
+
+    @pytest.mark.parametrize(
+        "delta,expected",
+        [
+            (timedelta(minutes=5), "in the last hour"),
+            (timedelta(hours=3), "3 hours ago"),
+            (timedelta(days=1), "1 day ago"),
+            (timedelta(days=2), "2 days ago"),
+            (timedelta(days=90), "3 months ago"),
+            (timedelta(days=800), "2 years ago"),
+        ],
+    )
+    def test_phrasing(self, delta, expected):
+        assert humanise_age(NOW - delta, NOW) == expected
+
+    def test_unknown_time_is_stated_not_guessed(self):
+        assert humanise_age(None, NOW) == "at an unknown time"
+
+    def test_naive_timestamps_are_treated_as_utc(self):
+        """Postgres can hand back naive datetimes; subtracting one would raise."""
+        stats = [_row("a")]
+        stats[0]["last_written"] = datetime(2026, 8, 9, 12, 0)
+        ranked = rank_authors(ENTITY, stats=stats, now=NOW)
+        assert ranked[0].last_written is not None
+        assert "1 day ago" in ranked[0].reason
+
+
+class TestSiloDetection:
+
+    def test_single_author_is_siloed(self):
+        assert is_siloed(rank_authors(ENTITY, stats=[_row("a")], now=NOW))
+
+    def test_two_authors_are_not(self):
+        stats = [_row("a"), _row("b")]
+        assert not is_siloed(rank_authors(ENTITY, stats=stats, now=NOW))
+
+
+class TestSerialisation:
+
+    def test_to_dict_carries_the_explanation(self):
+        ranked = rank_authors(ENTITY, stats=[_row("a", entry_count=4)], now=NOW)
+        payload = ranked[0].to_dict()
+        assert payload["agent_id"] == "a"
+        assert payload["entity_path"] == ENTITY
+        assert payload["strength"] == "primary"
+        assert payload["reason"]
+        assert isinstance(ranked[0], AuthorRank)
+
+    def test_top_keys_are_attached_when_supplied(self):
+        ranked = rank_authors(
+            ENTITY,
+            stats=[_row("a")],
+            now=NOW,
+            top_keys={"a": ["decision-token-rotation"]},
+        )
+        assert ranked[0].top_keys == ["decision-token-rotation"]

--- a/tests/unit/test_authority.py
+++ b/tests/unit/test_authority.py
@@ -205,3 +205,78 @@ class TestSerialisation:
             top_keys={"a": ["decision-token-rotation"]},
         )
         assert ranked[0].top_keys == ["decision-token-rotation"]
+
+class TestDescendantRollup:
+    """``agent_entity_stats`` scopes by prefix, so the ranker has to decide what
+    to do with the child rows it gets back. Off, each path is its own topic —
+    what the expertise grid wants, since it draws them as separate columns. On,
+    the subtree is one area of ownership — what "who should I ask about this"
+    wants, and the reason the query fetched the children at all."""
+
+    def test_child_only_authors_are_ignored_by_default(self):
+        ranked = rank_authors(
+            ENTITY,
+            stats=[_row("child-only", entity_path=f"{ENTITY}/tokens")],
+            now=NOW,
+        )
+        assert ranked == []
+
+    def test_child_only_authors_rank_when_rolled_up(self):
+        ranked = rank_authors(
+            ENTITY,
+            stats=[_row("child-only", entity_path=f"{ENTITY}/tokens")],
+            now=NOW,
+            include_descendants=True,
+        )
+        assert [a.agent_id for a in ranked] == ["child-only"]
+
+    def test_an_agents_child_rows_are_summed_not_ranked_separately(self):
+        """Three child paths must not become three copies of one agent, each
+        holding a third of the evidence it actually has."""
+        ranked = rank_authors(
+            ENTITY,
+            stats=[
+                _row("spread", entity_path=f"{ENTITY}/tokens", entry_count=2,
+                     validated=1, recalls=3, days_ago=9),
+                _row("spread", entity_path=f"{ENTITY}/sessions", entry_count=3,
+                     validated=2, recalls=1, days_ago=2),
+                _row("spread", entity_path=f"{ENTITY}/mfa", entry_count=1,
+                     days_ago=40),
+            ],
+            now=NOW,
+            include_descendants=True,
+        )
+        assert len(ranked) == 1
+        author = ranked[0]
+        assert author.entry_count == 6
+        assert author.validated_outcomes == 3
+        assert author.total_recalls == 4
+        # The most recent of its rows, so a live author is not aged out by an
+        # old memory it happens to also own.
+        assert author.last_written == NOW - timedelta(days=2)
+
+    def test_share_is_computed_over_the_whole_subtree(self):
+        ranked = rank_authors(
+            ENTITY,
+            stats=[
+                _row("owner", entity_path=f"{ENTITY}/tokens", entry_count=3),
+                _row("owner", entity_path=ENTITY, entry_count=6),
+                _row("other", entity_path=f"{ENTITY}/mfa", entry_count=1),
+            ],
+            now=NOW,
+            include_descendants=True,
+        )
+        by_id = {a.agent_id: a for a in ranked}
+        assert by_id["owner"].share == pytest.approx(0.9)
+        assert by_id["other"].share == pytest.approx(0.1)
+
+    def test_a_sibling_prefix_is_not_a_descendant(self):
+        """`myapp/authz` starts with `myapp/auth` as a string but is a
+        different topic; only a `/` boundary counts."""
+        ranked = rank_authors(
+            ENTITY,
+            stats=[_row("sibling", entity_path="myapp/authz")],
+            now=NOW,
+            include_descendants=True,
+        )
+        assert ranked == []

--- a/tests/unit/test_briefing_and_priority.py
+++ b/tests/unit/test_briefing_and_priority.py
@@ -450,3 +450,82 @@ class TestWhoToAskInjection:
         # would be filtering out the thing under test.
         branches = [call.kwargs.get("branch") for call in adapter.search.call_args_list]
         assert branches and all(b == "feature-x" for b in branches)
+
+class TestWhoToAskAddressesTheRightPath:
+    """Ranking spans the subtree, so a recommended author may have written
+    nothing at the path that was asked about. Both the keys offered and the
+    path the call names have to come from where their work actually is."""
+
+    def test_a_child_path_author_still_gets_keys(self) -> None:
+        adapter = _mock_adapter(
+            digests=[_entity_digest("svc")], search_results=[_entry("k1")]
+        )
+        adapter.agent_entity_stats.return_value = [
+            _stats_row("owner", entity_path="svc/tokens")
+        ]
+
+        result = BriefingService(adapter).briefing(entity_path="svc", agent_id="me")
+
+        rec = result[0].summary["who_to_ask"][0]
+        assert rec["top_keys"] == ["k1"]
+        assert rec["entity_path"] == "svc/tokens"
+
+    def test_the_key_lookup_is_addressed_to_the_child_path(self) -> None:
+        """search matches entity_path exactly, so asking about the parent
+        returns nothing for an author whose work sits underneath it."""
+        adapter = _mock_adapter(
+            digests=[_entity_digest("svc")], search_results=[_entry("k1")]
+        )
+        adapter.agent_entity_stats.return_value = [
+            _stats_row("owner", entity_path="svc/tokens")
+        ]
+
+        BriefingService(adapter).briefing(entity_path="svc", agent_id="me")
+
+        searched = {
+            call.args[0].entity_path
+            for call in adapter.search.call_args_list
+            if call.args and getattr(call.args[0], "agent_id", None) == "owner"
+        }
+        assert searched == {"svc/tokens"}
+
+    def test_the_call_names_the_path_the_key_is_stored_under(self) -> None:
+        """Addressed to the parent the read finds nothing, which makes the
+        recommendation worse than not making one."""
+        adapter = _mock_adapter(
+            digests=[_entity_digest("svc")], search_results=[_entry("k1")]
+        )
+        adapter.agent_entity_stats.return_value = [
+            _stats_row("owner", entity_path="svc/tokens")
+        ]
+
+        result = BriefingService(adapter).briefing(entity_path="svc", agent_id="me")
+
+        assert result[0].summary["who_to_ask"][0]["call"] == (
+            'amfs_read_from("owner", "svc/tokens", "k1")'
+        )
+
+    def test_the_busiest_child_wins_when_an_agent_spans_several(self) -> None:
+        adapter = _mock_adapter(
+            digests=[_entity_digest("svc")], search_results=[_entry("k1")]
+        )
+        adapter.agent_entity_stats.return_value = [
+            _stats_row("owner", entity_path="svc/tokens", entry_count=2),
+            _stats_row("owner", entity_path="svc/sessions", entry_count=9),
+        ]
+
+        result = BriefingService(adapter).briefing(entity_path="svc", agent_id="me")
+
+        assert result[0].summary["who_to_ask"][0]["entity_path"] == "svc/sessions"
+
+    def test_an_author_on_the_asked_path_is_unaffected(self) -> None:
+        adapter = _mock_adapter(
+            digests=[_entity_digest("svc")], search_results=[_entry("k1")]
+        )
+        adapter.agent_entity_stats.return_value = [_stats_row("owner")]
+
+        result = BriefingService(adapter).briefing(entity_path="svc", agent_id="me")
+
+        rec = result[0].summary["who_to_ask"][0]
+        assert rec["entity_path"] == "svc"
+        assert rec["call"] == 'amfs_read_from("owner", "svc", "k1")'

--- a/tests/unit/test_briefing_and_priority.py
+++ b/tests/unit/test_briefing_and_priority.py
@@ -361,3 +361,92 @@ class TestPrioritySort:
 
         results = mem.search(entity_path="svc", sort_by="confidence")
         assert results[0].key == "high"
+
+
+# ──────────────────────────────────────────────────────────────
+# who_to_ask injection
+# ──────────────────────────────────────────────────────────────
+
+
+def _agent_brief_digest(agent: str) -> Digest:
+    return Digest(
+        digest_type=DigestType.AGENT_BRIEF,
+        scope=agent,
+        summary={"narrative": f"What {agent} knows"},
+        entry_count=3,
+        source_agents=[agent],
+        compiled_at=_now(),
+        namespace="default",
+        branch="main",
+    )
+
+
+def _stats_row(agent_id: str, *, entity_path: str = "svc", entry_count: int = 4):
+    return {
+        "agent_id": agent_id,
+        "entity_path": entity_path,
+        "entry_count": entry_count,
+        "avg_confidence": 0.9,
+        "last_written": _now() - timedelta(days=1),
+        "first_written": _now() - timedelta(days=20),
+        "total_recalls": 2,
+        "outcome_linked_count": 1,
+    }
+
+
+class TestWhoToAskInjection:
+    def test_it_attaches_to_the_matching_entity_digest(self) -> None:
+        adapter = _mock_adapter(
+            digests=[_entity_digest("svc")], search_results=[_entry("k1")]
+        )
+        adapter.agent_entity_stats.return_value = [_stats_row("owner")]
+
+        result = BriefingService(adapter).briefing(entity_path="svc", agent_id="me")
+
+        assert [w["agent_id"] for w in result[0].summary["who_to_ask"]] == ["owner"]
+
+    def test_it_is_carried_on_its_own_digest_when_none_matches(self) -> None:
+        """Digests came back for this agent but none is the entity's own, so
+        there is nothing compiled to hang the block on. Dropping it there would
+        lose the routing precisely when the caller has least other context."""
+        adapter = _mock_adapter(
+            digests=[_agent_brief_digest("me")], search_results=[_entry("k1")]
+        )
+        adapter.agent_entity_stats.return_value = [_stats_row("owner")]
+
+        result = BriefingService(adapter).briefing(entity_path="svc", agent_id="me")
+
+        carriers = [
+            d for d in result
+            if d.digest_type == DigestType.ENTITY and d.scope == "svc"
+        ]
+        assert len(carriers) == 1
+        assert [w["agent_id"] for w in carriers[0].summary["who_to_ask"]] == ["owner"]
+
+    def test_the_caller_is_not_told_to_ask_itself(self) -> None:
+        adapter = _mock_adapter(
+            digests=[_entity_digest("svc")], search_results=[_entry("k1")]
+        )
+        adapter.agent_entity_stats.return_value = [_stats_row("me")]
+
+        result = BriefingService(adapter).briefing(entity_path="svc", agent_id="me")
+
+        assert "who_to_ask" not in result[0].summary
+
+    def test_top_keys_are_looked_up_on_the_callers_branch(self) -> None:
+        """Defaulting to main here names an author but no key to read, on every
+        branch that is not main — the recommendation arrives half-useless."""
+        adapter = _mock_adapter(
+            digests=[_entity_digest("svc")], search_results=[_entry("k1")]
+        )
+        adapter.agent_entity_stats.return_value = [_stats_row("owner")]
+
+        BriefingService(adapter).briefing(
+            entity_path="svc", agent_id="me", branch="feature-x"
+        )
+
+        # Every search the briefing issues, not just the ones that already
+        # pass a branch — an omitted kwarg is the bug, and filtering those out
+        # would be filtering out the thing under test.
+        branches = [call.kwargs.get("branch") for call in adapter.search.call_args_list]
+        assert branches and all(b == "feature-x" for b in branches)

--- a/tests/unit/test_briefing_visibility.py
+++ b/tests/unit/test_briefing_visibility.py
@@ -24,10 +24,13 @@ def _digest(
     source_agents: list[str] | None = None,
     hot_context: list[dict] | None = None,
     digest_type: DigestType = DigestType.ENTITY,
+    who_to_ask: list[dict] | None = None,
 ) -> Digest:
     summary: dict = {"narrative": "test digest"}
     if hot_context is not None:
         summary["hot_context"] = hot_context
+    if who_to_ask is not None:
+        summary["who_to_ask"] = who_to_ask
     return Digest(
         digest_type=digest_type,
         scope=scope,
@@ -48,6 +51,18 @@ def _hot(agent: str, key: str = "some-key") -> dict:
         "agent": agent,
         "outcome_count": 1,
         "recall_count": 2,
+    }
+
+
+def _who(agent_id: str, key: str = "decision-token-rotation") -> dict:
+    return {
+        "agent_id": agent_id,
+        "reason": "wrote 4 memories here, active 2 days ago",
+        "entry_count": 4,
+        "share": 0.8,
+        "validated_outcomes": 1,
+        "top_keys": [key],
+        "call": f'amfs_read_from("{agent_id}", "myapp/auth", "{key}")',
     }
 
 
@@ -174,6 +189,57 @@ class TestFilterBriefingDigests:
     def test_empty_digests_returns_empty(self):
         vis = _mock_vis({"my-agent"})
         assert _filter_briefing_digests(vis, []) == []
+
+
+class TestWhoToAskVisibility:
+    """who_to_ask names other agents and tells the caller to read from them.
+
+    Unfiltered it would recommend a read that read_from then refuses, and
+    disclose that an agent the caller has no access to exists at all — so these
+    are tenant-isolation assertions, not presentation ones.
+    """
+
+    def test_own_agent_recommendation_kept(self):
+        vis = _mock_vis({"my-agent"})
+        d = _digest(source_agents=["my-agent"], who_to_ask=[_who("my-agent")])
+        result = _filter_briefing_digests(vis, [d])
+        assert len(result[0].summary["who_to_ask"]) == 1
+
+    def test_foreign_agent_recommendation_removed(self):
+        vis = _mock_vis({"my-agent"})
+        d = _digest(
+            source_agents=["my-agent"],
+            who_to_ask=[_who("my-agent"), _who("foreign-agent")],
+        )
+        result = _filter_briefing_digests(vis, [d])
+        remaining = result[0].summary["who_to_ask"]
+        assert [w["agent_id"] for w in remaining] == ["my-agent"]
+
+    def test_room_co_member_recommendation_kept(self):
+        """A teammate in the same room is exactly who this should surface."""
+        vis = _mock_vis(
+            {"my-agent"},
+            room_map={"myapp/auth": {"my-agent", "teammate"}},
+        )
+        d = _digest(
+            scope="myapp/auth",
+            source_agents=["my-agent"],
+            who_to_ask=[_who("teammate")],
+        )
+        result = _filter_briefing_digests(vis, [d])
+        assert [w["agent_id"] for w in result[0].summary["who_to_ask"]] == ["teammate"]
+
+    def test_block_dropped_entirely_when_nothing_is_visible(self):
+        """An empty who_to_ask would still say "someone knows this" — omit it."""
+        vis = _mock_vis({"my-agent"})
+        d = _digest(source_agents=["my-agent"], who_to_ask=[_who("foreign-agent")])
+        result = _filter_briefing_digests(vis, [d])
+        assert "who_to_ask" not in result[0].summary
+
+    def test_hidden_digest_takes_its_recommendations_with_it(self):
+        vis = _mock_vis({"my-agent"})
+        d = _digest(source_agents=["foreign-agent"], who_to_ask=[_who("foreign-agent")])
+        assert _filter_briefing_digests(vis, [d]) == []
 
 
 class TestAdminBypass:

--- a/tests/unit/test_briefing_visibility.py
+++ b/tests/unit/test_briefing_visibility.py
@@ -256,3 +256,35 @@ class TestOSSNoFilter:
     def test_no_visibility_filter_on_request(self):
         """When _get_visibility_filter returns None (OSS), no filtering occurs."""
         pass
+
+class TestAskOnlyDigestsSurvive:
+    """A serve-time who_to_ask can be the only thing on a digest.
+
+    The block is injected onto a synthesised digest when nothing has been
+    compiled for the path yet, and that digest has no source agents and no hot
+    context. Retention keyed on those two alone throws the routing away right
+    after deciding the caller was allowed to see it.
+    """
+
+    def test_a_visible_ask_keeps_a_digest_with_nothing_else_on_it(self):
+        vis = _mock_vis({"my-agent"})
+        d = _digest(source_agents=[], who_to_ask=[_who("my-agent")])
+
+        result = _filter_briefing_digests(vis, [d])
+
+        assert len(result) == 1
+        assert [w["agent_id"] for w in result[0].summary["who_to_ask"]] == ["my-agent"]
+
+    def test_an_invisible_ask_does_not_keep_it(self):
+        """The block is emptied by the filter above, which leaves the digest
+        with nothing the caller may see — so it goes."""
+        vis = _mock_vis({"my-agent"})
+        d = _digest(source_agents=[], who_to_ask=[_who("foreign-agent")])
+
+        assert _filter_briefing_digests(vis, [d]) == []
+
+    def test_a_bare_digest_is_still_dropped(self):
+        vis = _mock_vis({"my-agent"})
+        d = _digest(source_agents=[])
+
+        assert _filter_briefing_digests(vis, [d]) == []

--- a/tests/unit/test_slashed_key_read.py
+++ b/tests/unit/test_slashed_key_read.py
@@ -42,7 +42,15 @@ def asked() -> list[tuple[str, str]]:
 
 
 @pytest.fixture()
-def client(monkeypatch: pytest.MonkeyPatch, asked: list) -> TestClient:
+def asked_history() -> list[tuple[str, str]]:
+    """The coordinates the history lookup reached storage with."""
+    return []
+
+
+@pytest.fixture()
+def client(
+    monkeypatch: pytest.MonkeyPatch, asked: list, asked_history: list
+) -> TestClient:
     stored = {
         (ENTITY, SLASHED_KEY): MemoryEntry(
             entity_path=ENTITY,
@@ -60,10 +68,16 @@ def client(monkeypatch: pytest.MonkeyPatch, asked: list) -> TestClient:
         asked.append((entity_path, key))
         return stored.get((entity_path, key))
 
+    def _history(entity_path, key, **_kw):
+        asked_history.append((entity_path, key))
+        entry = stored.get((entity_path, key))
+        return [entry] if entry else []
+
     mem = MagicMock()
     mem.namespace = "test-ns"
     mem._tagger = SimpleNamespace(agent_id="srv", session_id="sess")
     mem.read.side_effect = _read
+    mem.history.side_effect = _history
 
     monkeypatch.setattr(server, "_memory", mem)
     monkeypatch.setattr(server, "_get_memory", lambda: mem)
@@ -121,3 +135,38 @@ class TestOrdinaryKeysAreUnaffected:
         client.get(f"/api/v1/entries/{ENTITY}/plain-key")
 
         assert asked == [(ENTITY, "plain-key")]
+
+
+class TestHistoryHasTheSameProblem:
+    """The version chain is reached by the same coordinates, and was as wrong.
+
+    Reading an entry back was fixed first because it was the louder failure,
+    but a slashed key's history was equally unreachable — and the version chain
+    is the one lineage layer that is always present, so a knowledge-lineage
+    panel would have shown nothing at all for those entries.
+    """
+
+    def test_the_query_route_asks_for_the_right_coordinates(
+        self, client, asked_history
+    ) -> None:
+        resp = client.get(
+            "/api/v1/history", params={"entity_path": ENTITY, "key": SLASHED_KEY}
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert asked_history == [(ENTITY, SLASHED_KEY)]
+
+    def test_the_path_route_still_splits_at_the_last_segment(
+        self, client, asked_history
+    ) -> None:
+        client.get(f"/api/v1/history/{ENTITY}/{SLASHED_KEY}")
+
+        assert asked_history == [("sweep/abc/active-negotiation", "xyz")]
+
+    def test_an_ordinary_key_is_unaffected_on_both_routes(
+        self, client, asked_history
+    ) -> None:
+        client.get(f"/api/v1/history/{ENTITY}/plain-key")
+        client.get("/api/v1/history", params={"entity_path": ENTITY, "key": "plain-key"})
+
+        assert asked_history == [(ENTITY, "plain-key"), (ENTITY, "plain-key")]


### PR DESCRIPTION
## Three silent bugs this depended on

| Bug | Effect |
|---|---|
| `read-from` over HTTP ran its own search instead of calling `mem.read_from` | Returned the right entry while skipping both `CROSS_AGENT_READ` events and the `learned_from` edge — the edge this ranking is built on, so every cross-agent read made over HTTP counted for nothing |
| `session_metadata` written to the traces table, never SELECTed back | The model behind a decision was stored and discarded. Its two sibling columns had the same bug, fixed in `00165d3`; this one was left behind, and `_row_to_trace` reads it with `row.get`, so it failed to `{}` without raising |
| No indexed route from an entry to the trace that wrote it | `causal_entries` holds reads, not writes, so the shared session id is the only link — and following it meant a JSONB scan over every trace on the account |

Also adds `GET /api/v1/history` with the coordinates as query parameters, completing what `3f91fb7` started for `/api/v1/entry`. A key containing a slash could not be expressed as a path segment, so history for the 6.6% of entries that have one silently reported no versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cross-agent read semantics and briefing disclosure (tenant isolation on who_to_ask); authority ranking affects multiple product surfaces but is additive with extensive unit tests.
> 
> **Overview**
> Introduces a **single authority scorer** in `amfs_core.authority` (`rank_authors`) so dashboard, briefing, retrieval, and discovery share the same score and human-readable **reason** (validated outcomes weighted against volume, reuse, share, and recency).
> 
> **Adapter layer:** `agent_entity_stats()` aggregates per-(agent, entity) in SQL (or via `list()`), with prefix scoping that includes descendants without matching sibling prefixes. **`list_traces_for_entry()`** resolves traces by session id, backed by **`idx_traces_session`**. Trace reads now return **`session_metadata`**.
> 
> **Briefing:** When an `entity_path` is requested, **`who_to_ask`** is injected at serve time (not compiled): top authorities, subtree-aware paths, top keys on the caller’s branch, and optional `amfs_read_from(...)` calls; the caller is excluded from recommendations but still affects share denominators.
> 
> **HTTP fixes:** Cross-agent read routes through **`mem.read_from`** so cross-agent reads record causal/`learned_from` edges for authority. **`GET /api/v1/history`** accepts `entity_path` and `key` as query params for keys containing slashes (mirroring the entry route fix).
> 
> Briefing visibility filtering applies to **`who_to_ask`** and keeps digests that only carry visible routing recommendations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a69590a8851593c7c1ab2095b5061aa6a645667c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->