### PR TITLE
Document migrating in from Mem0 and Zep

### DIFF
--- a/docs/editions.md
+++ b/docs/editions.md
@@ -232,6 +232,7 @@ AMFS is GitHub for agent memory, split into two layers. The open-source core giv
 | Usage analytics & quota monitoring | — | Yes |
 | Snapshot capture, compare, and export | — | Yes |
 | Memory Tiers dashboard (distribution, entry browser) | — | Yes |
+| Guided migration from Mem0 and Zep (preview, resume, undo) | — | Yes |
 | Extended MCP server (Pro tools) | — | Yes |
 
 ---

--- a/docs/guides/migrate.md
+++ b/docs/guides/migrate.md
@@ -1,0 +1,103 @@
+---
+title: Migrate from Mem0 or Zep
+layout: default
+parent: Guides
+nav_order: 13
+description: "Bring your memory across from Mem0 or Zep with a guided import: preview the counts first, watch it run, and remove it again if you change your mind."
+---
+
+# Migrate from Mem0 or Zep
+{: .no_toc }
+
+Paste an API key, look at what would come over, and start it. The import runs on our side while you close the tab, and everything it wrote can be removed in one action if you change your mind.
+{: .fs-6 .fw-300 }
+
+Available on Pro, Teams and Enterprise.
+{: .fs-3 }
+
+## Table of Contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Before you start
+
+You need a read-capable API key for the account you're moving out of, and enough room on your plan for what's coming. The preview tells you both before anything is written.
+
+Nothing is removed from Mem0 or Zep. An import reads; it never deletes, and you can keep running the old system alongside AMFS for as long as you want to compare them.
+
+## Run the import
+
+Open **Migrate** in the dashboard and pick the source. It's three steps.
+
+**1. Connect.** Paste the API key. It's checked against the source immediately, so a wrong or expired key fails here rather than twenty minutes into a run. Once the key works you'll see which account it belongs to — worth a glance if you have more than one project.
+
+**2. Review.** This is the whole point of the flow. You get counts of what's there, how many memories that becomes in AMFS, roughly how long it will take, and whether your plan has room for it. Adjust the options (below), refresh, and the numbers re-price for the import you actually chose.
+
+**3. Import.** It runs on our infrastructure, not in your browser. Close the tab, come back tomorrow, reopen the page — the progress is where you left it. You can stop it at any point.
+
+### Options worth knowing about
+
+| Option | What it does |
+|:--|:--|
+| **Import a few users first** | Caps the import to N subjects. The honest way to try this: run five users, look at what landed, then run the rest. On Mem0 this makes an import smaller but not shorter — its list can't be filtered to a set of users, so the pages still have to be walked |
+| **Trial run** | Reads and maps everything and writes nothing, then tells you what it would have written. It still reads from the source, so it costs whatever that reading costs you there |
+| **Include facts that are no longer true** | Facts the source has stopped believing. Off by default. On, they come in at low confidence, so you keep the history of what changed without it outranking anything live |
+| **Include raw conversation events** | The messages the facts were derived from. On by default for Zep; off for Mem0, where reading history is metered against your **monthly** quota there rather than a rate limit |
+
+## What comes over
+
+**From Zep:** users and threads, the facts on your knowledge graph with their entities and relationships, the graph edges between them, your custom entity types, and — unless you turn it off — the episodes behind the facts.
+
+**From Mem0:** every memory in the project, the entities they belong to, and optionally each memory's version history.
+
+Both sources are read into the same shape before anything is written, so a Zep fact and a Mem0 memory are treated identically wherever they differ only in where they came from.
+
+### Confidence
+
+Neither Mem0 nor Zep has a confidence score, so AMFS assigns one by what the record is:
+
+| What it is | Confidence |
+|:--|:--|
+| Transferred verbatim — a profile, an entity, a message | 1.0 |
+| A fact the source currently believes | 0.8 |
+| A summary the source's model wrote | 0.6 |
+| A fact the source has stopped believing | 0.3 |
+
+The alternative would be 1.0 across the board, which puts another product's guess level with a pattern your agents watched succeed in production. Confidence exists to prevent exactly that, so an import is not allowed to flatten it.
+
+These are a starting point, not a verdict. Once your agents start reading these entries and committing outcomes, [confidence moves with what actually happened](/amfs/concepts/confidence/) and the imported guesses stop being guesses.
+
+### Timestamps and authorship
+
+Entries keep the timestamps they had at the source, so a fact your assistant learned in March is dated March here, not the day you migrated. Everything an import writes is attributed to a synthetic author — `imported-from-zep`, `imported-from-mem0` — which is what makes it distinguishable from your agents' own work forever after.
+
+Imported entries live under a path named for the source: `zep/subjects/alice`, `mem0/alice/facts`. Your agents can read them like anything else.
+
+## Stopping, resuming, removing
+
+**Stop** takes effect between batches. It is not a rollback — what was already written is memory you can query, and leaving it is usually what you want.
+
+**Resume** picks up from the last checkpoint rather than starting over. It asks for your API key again, because we clear it the moment a job stops. Holding a live credential for another product indefinitely, against the chance you come back, is a worse trade than one paste.
+
+**Remove imported data** deletes everything that import wrote, matched on the synthetic author and the source's path prefix. Two things survive it deliberately: entries under your own paths, and any imported entry one of your agents later corrected — that version carries the agent's id, so it is the agent's, not the import's.
+
+## Limits
+
+- **Zep counts are estimates.** Zep gives an exact user count but no way to count facts without walking them, so the preview samples and extrapolates. Anything estimated is labelled "about". Mem0 previews are exact.
+- **Very long Zep histories can't be walked to the end.** Zep's episode endpoint serves a fixed window with no cursor past it. The preview says so rather than quietly truncating.
+- **One import per source at a time**, per account.
+- **Imported memories count against your plan** like any other write, which is why the plan check runs in the preview instead of failing you four fifths of the way through.
+
+## What AMFS won't do for you
+
+Mem0 and Zep both extract memory from conversations with an LLM as they run. AMFS doesn't: an entry exists because an agent decided to write it. So an import brings across what those systems already extracted, and from then on your agents do the deciding.
+
+If continuous extraction from a raw conversation stream is the thing you rely on, read [how the two models differ](/amfs/vs-competitors/) before you migrate — that is a real difference in approach, and it is better to find it now.
+
+## Other sources
+
+LangMem, Letta and raw pgvector are the next three we're asked about. If you need one of those, or a source not listed here, [tell us](https://github.com/raia-live/amfs/issues) — a new source is one module against the same import machinery.

--- a/docs/vs-competitors.md
+++ b/docs/vs-competitors.md
@@ -51,6 +51,7 @@ Every other memory system is a smarter store. AMFS is the only one that treats a
 | Cortex drift gate | Yes | No | No | No | No | No | No |
 | MCP server | Yes | Yes | No | Yes | No | No | No |
 | Self-hosted / OSS | Apache 2.0 | OSS+Cloud | OSS+Cloud | OSS | OSS | OSS+Cloud | OSS |
+| Import from another memory system | Mem0, Zep | No | No | No | No | No | No |
 | Multi-tenant with RLS | Pro | Cloud | Cloud | No | No | Cloud | Cloud |
 | Enterprise dashboard | Pro | Cloud | Cloud | No | No | Cloud | Cloud |
 | Learned ranking from outcomes | Pro | No | No | No | No | No | No |
@@ -70,6 +71,8 @@ Every other memory system is a smarter store. AMFS is the only one that treats a
 - **Multi-agent provenance** -- AMFS tracks authorship, detects conflicts, and auto-links causality. Mem0 is single-user oriented.
 - **Four-signal decay** -- Time + type + outcomes + access frequency. Mem0 has no decay model.
 - **Tiered memory** -- Hot/Warm/Archive with progressive retrieval. Mem0 searches everything.
+
+**Already on Mem0:** Pro imports a project directly — memories, entities and optionally each memory's version history. See [Migrate from Mem0 or Zep](/amfs/guides/migrate/).
 
 ---
 
@@ -158,6 +161,16 @@ Every other memory system is a smarter store. AMFS is the only one that treats a
 - **Production feedback** -- Memvid stores and retrieves. AMFS learns from outcomes.
 
 Memvid is the right choice for single-user, offline, or edge scenarios where infrastructure is a non-starter. AMFS is for production multi-agent systems that need versioning, feedback, and collaboration.
+
+---
+
+## Coming from Mem0 or Zep
+
+A comparison is only worth reading if you can act on it, so Pro imports directly from both. Paste an API key, look at the counts and what they'd cost against your plan, and start it — or run five users first and see what lands. Nothing is removed from the system you're leaving, and everything an import wrote can be removed again in one action if you decide against it.
+
+What neither source has is a confidence score, so AMFS derives one: what a source holds verbatim comes in at 1.0, what it currently believes at 0.8, its own model's summaries at 0.6, and facts it has stopped believing at 0.3. Original timestamps are preserved. From there the [outcome loop](/amfs/concepts/confidence/) takes over and those starting numbers stop being guesses.
+
+[Migrate from Mem0 or Zep](/amfs/guides/migrate/){: .btn .btn-outline }
 
 ---
 


### PR DESCRIPTION
## Summary

Pro can now import memory directly from Mem0 and Zep ([amfs-internal#559](https://github.com/raia-live/amfs-internal/pull/559)). The published docs said nothing about it, so someone weighing AMFS against the system they are already on had no answer to "I already have two years of memory in Mem0".

- **New guide** — [`docs/guides/migrate.md`](docs/guides/migrate.md). Leads with the preview, because that is what makes a migration a decision rather than a leap: the counts, what they cost against your plan, and that everything an import wrote can be removed again. Covers the options, stop/resume/undo, and the limits (Zep counts are sampled, its episode window has no cursor past it, imports count against your plan).
- **Editions** — a Pro row for guided migration.
- **Competitor comparison** — a matrix row, a section at the foot of the page, and a line in the Mem0 section pointing at the guide.

Two things the guide states plainly rather than leaving to be discovered: confidence is *derived*, not copied, because neither source has one (verbatim 1.0, currently believed 0.8, model summaries 0.6, no longer believed 0.3); and AMFS does not do the continuous LLM extraction those systems do, so an import brings across what they already extracted and your agents decide from there.

## Test plan

- [ ] Jekyll build passes on merge (Deploy Documentation runs on push to `main` for `docs/**`)
- [ ] `/amfs/guides/migrate/` renders, appears under Guides, and its TOC builds
- [ ] The three internal links resolve: `/amfs/concepts/confidence/`, `/amfs/vs-competitors/`, `/amfs/guides/migrate/`

Merging publishes this to the live docs site.

Made with [Cursor](https://cursor.com)