### PR TITLE
Say what a second import does, and what fills a plan mid-run

### DIFF
--- a/docs/guides/migrate.md
+++ b/docs/guides/migrate.md
@@ -71,6 +71,8 @@ The alternative would be 1.0 across the board, which puts another product's gues
 
 These are a starting point, not a verdict. Once your agents start reading these entries and committing outcomes, [confidence moves with what actually happened](/amfs/concepts/confidence/) and the imported guesses stop being guesses.
 
+**Importing twice is safe, and the second import can lower a score as well as raise one.** Keys are derived from the source's own record ids, so a re-run updates what it wrote the first time instead of duplicating it. That applies to graph relationships too: if a fact was true when you first imported and the source has since stopped believing it, re-importing brings that relationship down to the expired score rather than leaving it stuck at its highest historical value. What an import cannot do is talk down a relationship one of *your* agents asserted — that one keeps its own confidence, whatever the source now says.
+
 ### Timestamps and authorship
 
 Entries keep the timestamps they had at the source, so a fact your assistant learned in March is dated March here, not the day you migrated. Everything an import writes is attributed to a synthetic author — `imported-from-zep`, `imported-from-mem0` — which is what makes it distinguishable from your agents' own work forever after.
@@ -90,7 +92,9 @@ Imported entries live under a path named for the source: `zep/subjects/alice`, `
 - **Zep counts are estimates.** Zep gives an exact user count but no way to count facts without walking them, so the preview samples and extrapolates. Anything estimated is labelled "about". Mem0 previews are exact.
 - **Very long Zep histories can't be walked to the end.** Zep's episode endpoint serves a fixed window with no cursor past it. The preview says so rather than quietly truncating.
 - **One import per source at a time**, per account.
-- **Imported memories count against your plan** like any other write, which is why the plan check runs in the preview instead of failing you four fifths of the way through.
+- **Imported memories count against your plan** like any other write, which is why the plan check runs in the preview instead of failing you four fifths of the way through. If you fill your plan mid-import anyway — because your agents kept writing, or because a Zep estimate was low — the import stops cleanly and keeps everything it wrote. Move to a larger plan and resume, and it carries on from where it stopped.
+
+Every import and every removal is recorded in your account's audit log, with who started it and what it wrote, so a bulk change to your memory is never invisible after the fact.
 
 ## What AMFS won't do for you
 

--- a/docs/guides/migrate.md
+++ b/docs/guides/migrate.md
@@ -31,7 +31,7 @@ Nothing is removed from Mem0 or Zep. An import reads; it never deletes, and you 
 
 ## Run the import
 
-Open **Migrate** in the dashboard and pick the source. It's three steps.
+In the dashboard, open the account menu (your avatar, top right) and choose **Migrate**, then pick the source. It's three steps.
 
 **1. Connect.** Paste the API key. It's checked against the source immediately, so a wrong or expired key fails here rather than twenty minutes into a run. Once the key works you'll see which account it belongs to — worth a glance if you have more than one project.
 


### PR DESCRIPTION
## Summary

Follow-up to #307, correcting three things the migration guide left unanswered now that the behaviour behind them is settled:

- **Re-importing can lower a confidence, not only raise one.** A relationship whose fact has expired at the source now comes back down on re-import instead of staying pinned at its highest historical value. The guide previously implied imports only ever add.
- **An import cannot talk down an edge one of your own agents asserted.** Worth saying explicitly, because it is the reassurance that makes re-importing safe to try.
- **Filling your plan mid-import stops the job cleanly and resumably**, keeping what it wrote. The guide only mentioned the preview check.

Also notes that every import and removal is recorded in the account's audit log.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-path impact.
> 
> **Overview**
> Updates the **Migrate from Mem0 or Zep** guide with settled product behavior and clearer UI directions.
> 
> **Navigation:** Tells users to open **Migrate** from the account menu (avatar, top right) instead of a vague “open Migrate in the dashboard.”
> 
> **Re-import:** Adds that a second import is idempotent (keys from source record ids) and can **lower** confidence when the source no longer believes a fact—without duplicating data or overriding edges your own agents asserted.
> 
> **Plan limits:** Extends the plan-quota bullet: if the plan fills mid-import, the job stops cleanly, keeps what was written, and can **resume** after upgrading.
> 
> **Audit:** Notes that every import and removal is recorded in the account audit log (who started it, what was written).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6039571bf865189154c7aab85a804db6ceb6afea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->