### PR TITLE
Stop the boot-time schema apply from wedging the database

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import logging
+import os
+import re
 import threading
 import uuid
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable
 
@@ -91,6 +95,23 @@ logger = logging.getLogger(__name__)
 _EXCLUDE_SHARED_PATHS = "entity_path NOT LIKE '@%%/%%'"
 
 _SCHEMA_SQL = (Path(__file__).parent / "schema.sql").read_text(encoding="utf-8")
+
+
+@lru_cache(maxsize=1)
+def _schema_tables() -> frozenset[str]:
+    """Every table schema.sql creates, read out of the file itself.
+
+    Used to confirm a database still has what the schema-state marker claims it
+    has. Derived rather than listed so a table added to schema.sql is covered
+    without anyone remembering to update a second place.
+    """
+    return frozenset(
+        re.findall(
+            r"CREATE TABLE IF NOT EXISTS\s+([A-Za-z_][A-Za-z0-9_]*)",
+            _SCHEMA_SQL,
+            re.IGNORECASE,
+        )
+    )
 
 # SQL mirror of amfs_core.aggregates.recall_tokens_saved: per reuse, credit
 # the measured content size (~CHARS_PER_TOKEN chars/token) clamped to
@@ -240,9 +261,25 @@ class PostgresAdapter(AdapterABC):
         # dimension (see ensure_embedding_column). None => write-time embedding off.
         self._embedder = embedder
         self._embedding_dim = embedding_dim
-        pool_kwargs: dict[str, Any] = {
-            "kwargs": {"row_factory": dict_row, "autocommit": True},
+        connect_kwargs: dict[str, Any] = {
+            "row_factory": dict_row,
+            "autocommit": True,
         }
+        # A ceiling on how long any one statement may run, applied to every
+        # connection this adapter opens. Off unless asked for, because the right
+        # ceiling depends on the deployment: a request-serving process wants one
+        # near its own request timeout, while a consolidation or backfill job may
+        # legitimately run for much longer, and a default here would abort the
+        # second kind of work in installations that never asked for it.
+        #
+        # Worth setting on anything serving HTTP. A statement that outlives the
+        # request that asked for it holds its locks with nobody left to want the
+        # answer, which is how a single slow query became a production outage on
+        # 2026-08-12; see _apply_schema.
+        timeout = os.environ.get("AMFS_POSTGRES_STATEMENT_TIMEOUT", "").strip()
+        if timeout:
+            connect_kwargs["options"] = f"-c statement_timeout={timeout}"
+        pool_kwargs: dict[str, Any] = {"kwargs": connect_kwargs}
         if _ConnectionPool is not None:
             self._pool = _ConnectionPool(
                 dsn,
@@ -263,15 +300,77 @@ class PostgresAdapter(AdapterABC):
         self._listen_stop = threading.Event()
         self._watchers: dict[str, list[Callable[[MemoryEntry], None]]] = {}
 
+    def _schema_fingerprint(self) -> str | None:
+        """Identity of the schema this build would apply, or None if unknowable.
+
+        Covers the migrations as well as schema.sql, because they add columns and
+        indexes of their own — fingerprinting only the file would skip a container
+        whose code carries a migration the database has not seen. Reading the
+        source is how that stays automatic; a hand-bumped revision constant is a
+        step someone eventually forgets, and forgetting it here means a column
+        silently never gets added.
+
+        None when the source cannot be read (a frozen or zipped install), which
+        the caller treats as "apply the schema", i.e. the behaviour from before
+        this existed.
+        """
+        try:
+            import inspect
+
+            migrations = inspect.getsource(type(self)._apply_migrations)
+        except Exception:  # noqa: BLE001
+            return None
+        return hashlib.sha256(
+            (_SCHEMA_SQL + migrations).encode("utf-8")
+        ).hexdigest()
+
     def _apply_schema(self, *, retries: int = 3) -> None:
+        """Bring the database up to this build's schema, at most once per build.
+
+        Every process that constructs an adapter runs this, which on a warm
+        database used to mean re-running the whole DDL on every container start.
+        That is not free even when every statement is a no-op: ALTER TABLE and
+        CREATE INDEX ask for ACCESS EXCLUSIVE, and a *waiting* exclusive lock
+        blocks every reader that arrives behind it. One long-running SELECT is
+        then enough to stall the table, and because a stalled table stalls
+        startup, the platform responds by starting more containers, each adding
+        another exclusive lock to the queue. That took production down on
+        2026-08-12: 29 queued copies of this DDL behind a single orphaned query.
+
+        So the fast path checks a fingerprint and touches nothing, and the slow
+        path refuses to queue: lock_timeout means a container that cannot get the
+        lock promptly fails this attempt instead of joining the convoy it would
+        otherwise extend.
+        """
         import time as _time
+
+        fingerprint = self._schema_fingerprint()
+        if fingerprint and self._schema_is_current(fingerprint):
+            return
 
         for attempt in range(1, retries + 1):
             try:
                 with self._pool.connection() as conn:
                     with conn.cursor() as cur:
-                        cur.execute(_SCHEMA_SQL)
-                        self._apply_migrations(cur)
+                        # Bounds the wait for a lock, not the work: a genuine
+                        # first-run CREATE INDEX on a large table is allowed to
+                        # take as long as it takes.
+                        #
+                        # Reset in the finally because the pool runs autocommit,
+                        # which makes plain SET last for the life of the session.
+                        # Left set, this connection would go back to the pool and
+                        # hand a 5s lock timeout to ordinary writes, turning
+                        # everyday contention into failed requests. SET LOCAL is
+                        # not the answer either: outside a transaction it is a
+                        # no-op, and schema.sql is not something to wrap in one.
+                        cur.execute("SET lock_timeout = '5s'")
+                        try:
+                            cur.execute(_SCHEMA_SQL)
+                            self._apply_migrations(cur)
+                            if fingerprint:
+                                self._record_schema_fingerprint(cur, fingerprint)
+                        finally:
+                            cur.execute("SET lock_timeout = DEFAULT")
                 return
             except Exception as exc:
                 is_retryable = "deadlock" in str(exc).lower() or "lock" in str(exc).lower()
@@ -284,6 +383,76 @@ class PostgresAdapter(AdapterABC):
                     _time.sleep(wait)
                 else:
                     raise
+
+    def _schema_is_current(self, fingerprint: str) -> bool:
+        """Whether this database already has the schema this build would apply.
+
+        The marker alone is not enough to answer this, and trusting it on its own
+        was a bug: it lives in a table of its own, so it survives anything that
+        removes the tables it vouches for — a dropped table, a restore from an
+        older dump, a test fixture resetting state — and the next process would
+        sail past the DDL and then fail on the first query against a table that
+        is no longer there. So the tables are checked too, against the catalog,
+        which costs one indexed lookup and takes no locks.
+
+        Deliberately silent about every failure. Anything unreadable means "not
+        current", which costs one pass of idempotent DDL — the behaviour from
+        before this check existed. Raising instead would turn a missing metadata
+        row into a process that will not boot.
+        """
+        try:
+            expected = _schema_tables()
+            with self._pool.connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT 1 FROM amfs_schema_state WHERE fingerprint = %s",
+                        (fingerprint,),
+                    )
+                    if cur.fetchone() is None:
+                        return False
+                    cur.execute(
+                        """
+                        SELECT count(*) AS present
+                        FROM pg_catalog.pg_class c
+                        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+                        WHERE c.relkind = 'r'
+                          AND n.nspname = ANY (current_schemas(false))
+                          AND c.relname = ANY (%s)
+                        """,
+                        (list(expected),),
+                    )
+                    row = cur.fetchone()
+                    return bool(expected) and row["present"] == len(expected)
+        except Exception:  # noqa: BLE001
+            return False
+
+    @staticmethod
+    def _record_schema_fingerprint(cur: psycopg.Cursor, fingerprint: str) -> None:
+        """Note which schema this database is now at.
+
+        One row, replaced rather than appended: this answers "can the next
+        container skip the DDL", not "what happened here over time", and the
+        audit log is where history belongs.
+
+        Deliberately carries no account_id and no row-level security policy,
+        unlike every table that holds tenant data. It records a hash of this
+        build's DDL, which is the same for every tenant on the deployment and is
+        not anybody's data. Nothing tenant-scoped may be added to it later
+        without giving it a policy first.
+        """
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS amfs_schema_state (
+                fingerprint TEXT NOT NULL,
+                applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """
+        )
+        cur.execute("DELETE FROM amfs_schema_state")
+        cur.execute(
+            "INSERT INTO amfs_schema_state (fingerprint) VALUES (%s)",
+            (fingerprint,),
+        )
 
     @staticmethod
     def _apply_migrations(cur: psycopg.Cursor) -> None:

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -97,18 +97,17 @@ _EXCLUDE_SHARED_PATHS = "entity_path NOT LIKE '@%%/%%'"
 _SCHEMA_SQL = (Path(__file__).parent / "schema.sql").read_text(encoding="utf-8")
 
 
-@lru_cache(maxsize=1)
-def _schema_tables() -> frozenset[str]:
-    """Every table schema.sql creates, read out of the file itself.
+def _tables_created_by(sql: str) -> frozenset[str]:
+    """The tables a chunk of DDL creates.
 
-    Used to confirm a database still has what the schema-state marker claims it
-    has. Derived rather than listed so a table added to schema.sql is covered
-    without anyone remembering to update a second place.
+    Reads the SQL rather than taking a list, so that adding a table anywhere the
+    bootstrap runs is covered without anyone remembering to update a second
+    place — which is the kind of upkeep that silently stops happening.
     """
     return frozenset(
         re.findall(
             r"CREATE TABLE IF NOT EXISTS\s+([A-Za-z_][A-Za-z0-9_]*)",
-            _SCHEMA_SQL,
+            sql,
             re.IGNORECASE,
         )
     )
@@ -300,6 +299,21 @@ class PostgresAdapter(AdapterABC):
         self._listen_stop = threading.Event()
         self._watchers: dict[str, list[Callable[[MemoryEntry], None]]] = {}
 
+    def _migrations_source(self) -> str | None:
+        """The text of _apply_migrations, or None if it cannot be read.
+
+        The migrations are Python rather than a file, so both the fingerprint and
+        the table-presence check have to reach for them through inspect. None on a
+        frozen or zipped install, where callers fall back to the behaviour from
+        before any of this existed: apply the schema.
+        """
+        try:
+            import inspect
+
+            return inspect.getsource(type(self)._apply_migrations)
+        except Exception:  # noqa: BLE001
+            return None
+
     def _schema_fingerprint(self) -> str | None:
         """Identity of the schema this build would apply, or None if unknowable.
 
@@ -309,20 +323,26 @@ class PostgresAdapter(AdapterABC):
         source is how that stays automatic; a hand-bumped revision constant is a
         step someone eventually forgets, and forgetting it here means a column
         silently never gets added.
-
-        None when the source cannot be read (a frozen or zipped install), which
-        the caller treats as "apply the schema", i.e. the behaviour from before
-        this existed.
         """
-        try:
-            import inspect
-
-            migrations = inspect.getsource(type(self)._apply_migrations)
-        except Exception:  # noqa: BLE001
+        migrations = self._migrations_source()
+        if migrations is None:
             return None
         return hashlib.sha256(
             (_SCHEMA_SQL + migrations).encode("utf-8")
         ).hexdigest()
+
+    def _expected_tables(self) -> frozenset[str]:
+        """Every table the bootstrap creates, from both places it creates them.
+
+        schema.sql is not the whole schema: _apply_migrations adds the agent-group
+        tables. Checking only the file would leave those three outside the
+        presence check, so dropping one of them while the fingerprint still
+        matched would be waved through — the exact hole the presence check was
+        added to close, just further from the eye.
+        """
+        return _tables_created_by(_SCHEMA_SQL) | _tables_created_by(
+            self._migrations_source() or ""
+        )
 
     def _apply_schema(self, *, retries: int = 3) -> None:
         """Bring the database up to this build's schema, at most once per build.
@@ -392,8 +412,8 @@ class PostgresAdapter(AdapterABC):
         removes the tables it vouches for — a dropped table, a restore from an
         older dump, a test fixture resetting state — and the next process would
         sail past the DDL and then fail on the first query against a table that
-        is no longer there. So the tables are checked too, against the catalog,
-        which costs one indexed lookup and takes no locks.
+        is no longer there. So every table the bootstrap creates is checked too,
+        against the catalog, which costs one indexed lookup and takes no locks.
 
         Deliberately silent about every failure. Anything unreadable means "not
         current", which costs one pass of idempotent DDL — the behaviour from
@@ -401,7 +421,7 @@ class PostgresAdapter(AdapterABC):
         row into a process that will not boot.
         """
         try:
-            expected = _schema_tables()
+            expected = self._expected_tables()
             with self._pool.connection() as conn:
                 with conn.cursor() as cur:
                     cur.execute(
@@ -428,11 +448,23 @@ class PostgresAdapter(AdapterABC):
 
     @staticmethod
     def _record_schema_fingerprint(cur: psycopg.Cursor, fingerprint: str) -> None:
-        """Note which schema this database is now at.
+        """Note that this database has been given this build's schema.
 
-        One row, replaced rather than appended: this answers "can the next
-        container skip the DDL", not "what happened here over time", and the
-        audit log is where history belongs.
+        A row per schema, not one row for "the current schema". Two builds are
+        alive at once during any rolling deploy, and a single row makes them
+        fight over it: the older instance finds the newer hash, decides it is out
+        of date, re-applies its DDL and overwrites the marker, at which point the
+        newer instance does the same in reverse. Every scale-up on either
+        revision would then take ACCESS EXCLUSIVE locks — the convoy this whole
+        mechanism exists to prevent, arriving exactly at deploy time, when the
+        most instances are starting at once.
+
+        Recording each schema separately means both builds see themselves as
+        applied and neither re-applies. The DDL is additive, so a database that
+        has been given two schemas satisfies both. Growth is one row per distinct
+        schema version the deployment has ever run, which is not a table anyone
+        needs to prune; it is also not a history worth reading, so a row is
+        replaced rather than duplicated when the same schema is applied again.
 
         Deliberately carries no account_id and no row-level security policy,
         unlike every table that holds tenant data. It records a hash of this
@@ -448,7 +480,14 @@ class PostgresAdapter(AdapterABC):
             )
             """
         )
-        cur.execute("DELETE FROM amfs_schema_state")
+        # Scoped to this fingerprint: an unqualified DELETE is what let one build
+        # erase another's marker. Not an upsert, to avoid depending on a unique
+        # index that databases created by the first version of this code do not
+        # have.
+        cur.execute(
+            "DELETE FROM amfs_schema_state WHERE fingerprint = %s",
+            (fingerprint,),
+        )
         cur.execute(
             "INSERT INTO amfs_schema_state (fingerprint) VALUES (%s)",
             (fingerprint,),

--- a/tests/integration/test_postgres_schema_bootstrap.py
+++ b/tests/integration/test_postgres_schema_bootstrap.py
@@ -55,18 +55,31 @@ class TestAWarmDatabaseIsLeftAlone:
 
         assert first is not None
 
-    def test_a_changed_fingerprint_makes_it_apply_again(self) -> None:
-        PostgresAdapter(DSN, namespace="bootstrap-refresh")
+    def test_a_build_the_database_has_not_seen_applies_and_records_itself(
+        self,
+    ) -> None:
+        adapter = PostgresAdapter(DSN, namespace="bootstrap-refresh")
+        mine = adapter._schema_fingerprint()
         with psycopg.connect(DSN, autocommit=True) as conn:
-            conn.execute("UPDATE amfs_schema_state SET fingerprint = 'stale'")
+            conn.execute("DELETE FROM amfs_schema_state")
+            conn.execute(
+                "INSERT INTO amfs_schema_state (fingerprint) VALUES ('stale')"
+            )
+
             PostgresAdapter(DSN, namespace="bootstrap-refresh")
-            current = conn.execute(
-                "SELECT fingerprint FROM amfs_schema_state"
-            ).fetchall()
-        # One row, and not the stale one: a build whose DDL differs from what the
-        # database was last given must not be waved through.
-        assert len(current) == 1
-        assert current[0][0] != "stale"
+
+            rows = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT fingerprint FROM amfs_schema_state"
+                ).fetchall()
+            }
+        # A build whose DDL the database has not been given must apply it and say
+        # so. The unrecognised marker is left where it is on purpose: it may
+        # belong to the other half of a rolling deploy, and deleting it is what
+        # made the two builds re-apply in turn.
+        assert mine in rows
+        assert "stale" in rows
 
 
 class TestTheConnectionGoesBackClean:
@@ -79,6 +92,69 @@ class TestTheConnectionGoesBackClean:
             with conn.cursor() as cur:
                 cur.execute("SHOW lock_timeout")
                 assert cur.fetchone()["lock_timeout"] == "0"
+
+
+class TestTwoBuildsAtOnce:
+    """A rolling deploy always has two builds alive, and they share this table."""
+
+    def test_neither_build_makes_the_other_re_apply(self) -> None:
+        adapter = PostgresAdapter(DSN, namespace="bootstrap-rolling")
+        mine = adapter._schema_fingerprint()
+        assert mine is not None
+
+        # Stands in for the other revision, whose DDL differs and which records
+        # its own marker as it starts.
+        with psycopg.connect(DSN, autocommit=True) as conn:
+            conn.execute(
+                "INSERT INTO amfs_schema_state (fingerprint) VALUES ('other-build')"
+            )
+
+            # The point: this build must still consider itself applied. When one
+            # row meant "the current schema", the other revision's marker made
+            # every instance here re-run the DDL and overwrite it, and the two
+            # took ACCESS EXCLUSIVE locks in turn for as long as the rollout
+            # lasted.
+            assert adapter._schema_is_current(mine) is True
+
+            fresh = PostgresAdapter(DSN, namespace="bootstrap-rolling")
+            assert fresh._schema_is_current(mine) is True
+
+            rows = conn.execute("SELECT fingerprint FROM amfs_schema_state").fetchall()
+            assert "other-build" in {r[0] for r in rows}
+
+    def test_applying_the_same_schema_twice_leaves_one_row(self) -> None:
+        adapter = PostgresAdapter(DSN, namespace="bootstrap-dup")
+        mine = adapter._schema_fingerprint()
+        with psycopg.connect(DSN, autocommit=True) as conn:
+            conn.execute("DELETE FROM amfs_schema_state")
+            for _ in range(2):
+                PostgresAdapter(DSN, namespace="bootstrap-dup")
+            rows = conn.execute(
+                "SELECT count(*) FROM amfs_schema_state WHERE fingerprint = %s",
+                (mine,),
+            ).fetchone()
+        assert rows[0] == 1
+
+
+class TestTablesTheMigrationsCreate:
+    """schema.sql is not the whole schema; _apply_migrations makes tables too."""
+
+    def test_they_are_covered_by_the_presence_check(self) -> None:
+        adapter = PostgresAdapter(DSN, namespace="bootstrap-migrated")
+        assert "amfs_agent_groups" in adapter._expected_tables()
+
+    def test_dropping_one_makes_the_bootstrap_run_again(self) -> None:
+        adapter = PostgresAdapter(DSN, namespace="bootstrap-migrated")
+        with psycopg.connect(DSN, autocommit=True) as conn:
+            conn.execute("DROP TABLE IF EXISTS amfs_agent_group_members CASCADE")
+            fingerprint = adapter._schema_fingerprint()
+            assert adapter._schema_is_current(fingerprint) is False
+
+            PostgresAdapter(DSN, namespace="bootstrap-migrated")
+            back = conn.execute(
+                "SELECT to_regclass('amfs_agent_group_members') IS NOT NULL"
+            ).fetchone()[0]
+        assert back is True
 
 
 class TestTheStatementCeiling:

--- a/tests/integration/test_postgres_schema_bootstrap.py
+++ b/tests/integration/test_postgres_schema_bootstrap.py
@@ -1,0 +1,126 @@
+"""The schema bootstrap every process runs when it constructs an adapter.
+
+These exist because of a production incident on 2026-08-12. The bootstrap re-ran
+the whole DDL on every container start; ALTER TABLE and CREATE INDEX ask for
+ACCESS EXCLUSIVE, a waiting exclusive lock blocks every reader queued behind it,
+and a stalled table stalls startup — so the platform started more containers,
+each adding another exclusive lock. One orphaned SELECT was enough to wedge the
+service, with 29 copies of this DDL queued behind it.
+
+So what is asserted here is not "the schema gets created" (the adapter tests
+cover that) but the two properties that stop the convoy forming: a warm database
+is not touched at all, and a cold one refuses to wait for a lock.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+psycopg = pytest.importorskip("psycopg")
+
+from amfs_postgres.adapter import PostgresAdapter  # noqa: E402
+
+DSN = os.environ.get("AMFS_TEST_PG_DSN")
+pytestmark = pytest.mark.skipif(not DSN, reason="AMFS_TEST_PG_DSN not set")
+
+
+def _tables(dsn: str) -> set[str]:
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        rows = conn.execute(
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+        ).fetchall()
+    return {r[0] for r in rows}
+
+
+class TestAWarmDatabaseIsLeftAlone:
+    def test_the_second_adapter_skips_the_ddl_entirely(self) -> None:
+        first = PostgresAdapter(DSN, namespace="bootstrap-warm")
+        assert "amfs_schema_state" in _tables(DSN)
+
+        # A statement-level counter would be ideal; the reachable equivalent is
+        # to make the DDL impossible to run and show that construction still
+        # succeeds. Revoking CREATE on the schema means any CREATE TABLE or
+        # CREATE INDEX in the bootstrap would raise, so a clean construction is
+        # proof that none of them ran.
+        with psycopg.connect(DSN, autocommit=True) as conn:
+            user = conn.execute("SELECT current_user").fetchone()[0]
+            conn.execute(f'REVOKE CREATE ON SCHEMA public FROM "{user}"')
+            try:
+                second = PostgresAdapter(DSN, namespace="bootstrap-warm")
+                assert second is not None
+            finally:
+                conn.execute(f'GRANT CREATE ON SCHEMA public TO "{user}"')
+
+        assert first is not None
+
+    def test_a_changed_fingerprint_makes_it_apply_again(self) -> None:
+        PostgresAdapter(DSN, namespace="bootstrap-refresh")
+        with psycopg.connect(DSN, autocommit=True) as conn:
+            conn.execute("UPDATE amfs_schema_state SET fingerprint = 'stale'")
+            PostgresAdapter(DSN, namespace="bootstrap-refresh")
+            current = conn.execute(
+                "SELECT fingerprint FROM amfs_schema_state"
+            ).fetchall()
+        # One row, and not the stale one: a build whose DDL differs from what the
+        # database was last given must not be waved through.
+        assert len(current) == 1
+        assert current[0][0] != "stale"
+
+
+class TestTheConnectionGoesBackClean:
+    def test_lock_timeout_does_not_leak_into_pooled_connections(self) -> None:
+        # The pool runs autocommit, so a plain SET lasts for the life of the
+        # session. Leaving lock_timeout at 5s would hand it to ordinary writes
+        # and turn everyday contention into failed requests.
+        adapter = PostgresAdapter(DSN, namespace="bootstrap-leak")
+        with adapter._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SHOW lock_timeout")
+                assert cur.fetchone()["lock_timeout"] == "0"
+
+
+class TestTheStatementCeiling:
+    def test_it_is_off_unless_asked_for(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AMFS_POSTGRES_STATEMENT_TIMEOUT", raising=False)
+        adapter = PostgresAdapter(DSN, namespace="bootstrap-timeout-off")
+        with adapter._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SHOW statement_timeout")
+                assert cur.fetchone()["statement_timeout"] == "0"
+
+    def test_it_applies_to_every_connection_when_asked_for(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AMFS_POSTGRES_STATEMENT_TIMEOUT", "7s")
+        adapter = PostgresAdapter(DSN, namespace="bootstrap-timeout-on")
+        # Twice, from separate checkouts: the point of setting it on connect
+        # rather than per query is that no code path can forget it.
+        for _ in range(2):
+            with adapter._pool.connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute("SHOW statement_timeout")
+                    assert cur.fetchone()["statement_timeout"] == "7s"
+
+
+class TestAColdDatabaseWillNotQueue:
+    def test_it_gives_up_rather_than_joining_a_lock_convoy(self) -> None:
+        # A held ACCESS EXCLUSIVE lock stands in for the orphaned query from the
+        # incident. The bootstrap must fail its attempts and raise, not sit in
+        # the lock queue in front of every reader that arrives next.
+        adapter = PostgresAdapter(DSN, namespace="bootstrap-cold")
+        with psycopg.connect(DSN, autocommit=True) as conn:
+            conn.execute("UPDATE amfs_schema_state SET fingerprint = 'stale'")
+
+        blocker = psycopg.connect(DSN)
+        try:
+            blocker.execute("BEGIN")
+            blocker.execute("LOCK TABLE amfs_memory_entries IN ACCESS EXCLUSIVE MODE")
+            with pytest.raises(Exception) as caught:
+                PostgresAdapter(DSN, namespace="bootstrap-cold")
+            assert "lock timeout" in str(caught.value).lower()
+        finally:
+            blocker.rollback()
+            blocker.close()
+        assert adapter is not None


### PR DESCRIPTION
## Why

Production slow down today (2026-08-12, ~35 minutes of 429s and 504s on the hosted
API). 

## What changed

- **The warm path takes no locks.** The apply is skipped when a fingerprint of
  this build's DDL (schema.sql plus the migration statements, hashed from source
  so a new migration is covered without anyone bumping a constant) matches what
  the database was last given.
- **The marker is not trusted on its own.** It lives in its own table, so it
  outlives anything that removes the tables it vouches for — a dropped table, a
  restore from an older dump, a test fixture resetting state. The fast path also
  confirms every table `schema.sql` creates is present, via one catalog lookup
  that takes no locks. Without this, a process would boot happily and then fail
  on its first query; it was caught by the existing adapter fixture, which drops
  two tables and expects them back.
- **The cold path refuses to queue.** `lock_timeout` is set for the apply, so a
  container that cannot get the lock promptly fails its attempt rather than
  joining the convoy. It is reset explicitly afterwards: the pool runs
  autocommit, so a plain `SET` would otherwise ride that connection back into
  the pool and hand a 5s lock timeout to ordinary writes.
- Off by default: a request-serving process wants a ceiling near its request timeout,
  while a consolidation or backfill job may legitimately run far longer, and a
  default here would abort the second kind of work for installations that never
  asked for it.

`amfs_schema_state` deliberately has no `account_id` and no RLS policy — it holds
a hash of the deployment's DDL, which is the same for every tenant and is nobody's
data. Noted in the docstring so it does not later acquire tenant data without one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes critical boot-time schema application on every adapter construct, including lock behavior and a new schema-state table; mistakes here can block startups or skip needed migrations.
> 
> **Overview**
> Stops boot-time schema apply from wedging Postgres after the 2026-08-12 outage, where every container re-ran DDL, queued `ACCESS EXCLUSIVE` locks behind one orphaned query, and amplified the stall by starting more containers.
> 
> **Warm path takes no locks.** `_apply_schema` now fingerprints `schema.sql` plus `_apply_migrations` source and skips DDL when `amfs_schema_state` already has that fingerprint *and* every expected table is still present in the catalog. Markers are kept per schema version so rolling deploys with two builds do not fight over a single “current” row.
> 
> **Cold path refuses to queue.** Schema apply sets a 5s `lock_timeout` (reset before the connection returns to the pool) so a blocked container fails instead of extending the convoy. Also adds optional `AMFS_POSTGRES_STATEMENT_TIMEOUT` on connect, off by default.
> 
> Adds integration coverage for warm skip, rolling-deploy markers, migration-created tables, lock-timeout cleanup, and cold-path lock refusal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9496b824cbba53c2e065aa742d3e2a44f13ff561. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->