### PR TITLE
Say that a source may not let us count, and that it does not block the import

### DIFF
--- a/docs/guides/migrate.md
+++ b/docs/guides/migrate.md
@@ -35,7 +35,7 @@ Open **Migrate** in the dashboard and pick the source. It's three steps.
 
 **1. Connect.** Paste the API key. It's checked against the source immediately, so a wrong or expired key fails here rather than twenty minutes into a run. Once the key works you'll see which account it belongs to — worth a glance if you have more than one project.
 
-**2. Review.** This is the whole point of the flow. You get counts of what's there, how many memories that becomes in AMFS, roughly how long it will take, and whether your plan has room for it. Adjust the options (below), refresh, and the numbers re-price for the import you actually chose.
+**2. Review.** This is the whole point of the flow. You get counts of what's there, how many memories that becomes in AMFS, roughly how long it will take, and whether your plan has room for it. Adjust the options (below), refresh, and the numbers re-price for the import you actually chose. Counting reads your source at a deliberately slow pace, so give it a few seconds; if the source is rate limiting you, the counts may be unavailable and you can still go ahead.
 
 **3. Import.** It runs on our infrastructure, not in your browser. Close the tab, come back tomorrow, reopen the page — the progress is where you left it. You can stop it at any point.
 
@@ -87,8 +87,9 @@ Imported entries live under a path named for the source: `zep/subjects/alice`, `
 
 ## Limits
 
-- **Zep counts are estimates.** Zep gives an exact user count but no way to count facts without walking them, so the preview samples and extrapolates. Anything estimated is labelled "about". Mem0 previews are exact.
+- **Zep counts are estimates.** Zep gives an exact user count but no way to count facts without walking them, so the preview samples and extrapolates. Anything estimated is labelled "about". Mem0 previews are exact when Mem0 lets us count — see below.
 - **Very long Zep histories can't be walked to the end.** Zep's episode endpoint serves a fixed window with no cursor past it. The preview says so rather than quietly truncating.
+- **Your source may not let us count.** Mem0's free plan allows about ten API requests a minute, and counting a project takes three, so a busy account can be told to wait. The preview says so and offers to try again — and you can start the import without counts. It runs in the background at a pace the source allows, and reports the real numbers as it goes.
 - **One import per source at a time**, per account.
 - **Imported memories count against your plan** like any other write, which is why the plan check runs in the preview instead of failing you four fifths of the way through.
 


### PR DESCRIPTION
## Summary

The migrate guide told readers "Mem0 previews are exact". A real import hit Mem0's free-plan limit — about ten API requests a minute, where counting a project takes three — and the preview came back with no counts at all.

That is now normal behaviour rather than a failure (see amfs-internal#563), so the guide says it: counting reads the source slowly on purpose, the counts may be unavailable, and the import can be started anyway because it paces itself in the background and reports the real numbers as it goes.

## Test plan

- [ ] Read the rendered Review step and Limits sections and check the new lines sit right

Made with [Cursor](https://cursor.com)