### PR TITLE
Size the Postgres pool from the environment, and apply the statement ceiling to the async adapter

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -23,6 +23,31 @@ AMFS supports the following environment variables. They override values set in `
 
 ---
 
+## Postgres tuning
+
+Only relevant when `AMFS_POSTGRES_DSN` is set. The defaults are fine for a single
+process; these exist for deployments that run many of them.
+
+| Variable | Description | Default |
+|:---------|:------------|:--------|
+| `AMFS_POSTGRES_POOL_MAX` | Most connections one adapter may hold | `10` |
+| `AMFS_POSTGRES_POOL_MIN` | Connections kept open when idle | `2` |
+| `AMFS_POSTGRES_STATEMENT_TIMEOUT` | Ceiling on any one statement, as Postgres accepts it (`300s`, `5min`) | none |
+
+{: .important }
+Each process holding an adapter holds its own pool, so the connections you need
+are `pool max × processes`, and Postgres has a fixed `max_connections`. If you
+run the API behind an autoscaler, budget for the maximum number of instances,
+not the usual one — exhausting `max_connections` refuses new connections for
+everything sharing that database, including your own psql session.
+
+Set `AMFS_POSTGRES_STATEMENT_TIMEOUT` on anything serving HTTP, at or near the
+request timeout in front of it. Without one, a query whose caller has already
+given up keeps running and keeps its locks, and other statements queue behind
+it — a slow read becomes an outage rather than a slow read.
+
+---
+
 ## HTTP Adapter (SaaS / Multi-Tenant)
 
 When connecting to AMFS as a hosted service (SaaS), set these variables to route all memory operations through the authenticated HTTP API instead of a direct database connection.

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -96,6 +96,79 @@ _EXCLUDE_SHARED_PATHS = "entity_path NOT LIKE '@%%/%%'"
 
 _SCHEMA_SQL = (Path(__file__).parent / "schema.sql").read_text(encoding="utf-8")
 
+_DEFAULT_POOL_MIN = 2
+_DEFAULT_POOL_MAX = 10
+
+
+def _pool_size_from_env(name: str, default: int) -> int:
+    """A pool bound read from the environment, or the default.
+
+    A bad value is a misconfiguration, not a reason to refuse to start: a typo
+    in a deployment variable would otherwise take a service down at boot, which
+    is worse than running on the default and saying so.
+    """
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        size = int(raw)
+    except ValueError:
+        logger.warning("%s=%r is not a number — using %d", name, raw, default)
+        return default
+    if size < 1:
+        logger.warning("%s=%d is below 1 — using %d", name, size, default)
+        return default
+    return size
+
+
+def pool_bounds(
+    min_pool_size: int | None = None, max_pool_size: int | None = None
+) -> tuple[int, int]:
+    """How many connections one adapter may hold.
+
+    Every process holding a pool multiplies against every instance of it, and
+    the database has a fixed ``max_connections``. That budget is a property of
+    the deployment, not of the code, so it belongs in the environment —
+    ``AMFS_POSTGRES_POOL_MIN`` and ``AMFS_POSTGRES_POOL_MAX`` — where an
+    operator scaling a service out can spend it without a release.
+
+    An explicit argument still wins, because a caller that names a size is
+    describing what that particular adapter is for: a background worker asking
+    for two connections should get two, whatever the request path is allowed.
+    """
+    low = (
+        min_pool_size
+        if min_pool_size is not None
+        else _pool_size_from_env("AMFS_POSTGRES_POOL_MIN", _DEFAULT_POOL_MIN)
+    )
+    high = (
+        max_pool_size
+        if max_pool_size is not None
+        else _pool_size_from_env("AMFS_POSTGRES_POOL_MAX", _DEFAULT_POOL_MAX)
+    )
+    # psycopg_pool refuses a minimum above the maximum. Reaching that means the
+    # two numbers came from different places — one argument, one variable — and
+    # the ceiling is the one to respect, since it is what the database can bear.
+    return min(low, high), high
+
+
+def statement_timeout_options() -> str | None:
+    """The libpq ``options`` string carrying the statement ceiling, if set.
+
+    A ceiling on how long any one statement may run. Off unless asked for,
+    because the right ceiling depends on the deployment: a request-serving
+    process wants one near its own request timeout, while a consolidation or
+    backfill job may legitimately run for much longer, and a default here would
+    abort the second kind of work in installations that never asked for it.
+
+    Worth setting on anything serving HTTP. A statement that outlives the
+    request that asked for it holds its locks with nobody left to want the
+    answer, which is how a single slow query became a production outage on
+    2026-08-12; see _apply_schema.
+    """
+    timeout = os.environ.get("AMFS_POSTGRES_STATEMENT_TIMEOUT", "").strip()
+    return f"-c statement_timeout={timeout}" if timeout else None
+
 
 def _tables_created_by(sql: str) -> frozenset[str]:
     """The tables a chunk of DDL creates.
@@ -234,8 +307,10 @@ class PostgresAdapter(AdapterABC):
         If True, create tables/triggers on init.
     min_pool_size:
         Minimum number of connections in the pool (requires ``psycopg_pool``).
+        Defaults to ``AMFS_POSTGRES_POOL_MIN``, or 2.
     max_pool_size:
         Maximum number of connections in the pool (requires ``psycopg_pool``).
+        Defaults to ``AMFS_POSTGRES_POOL_MAX``, or 10.
     """
 
     def __init__(
@@ -244,8 +319,8 @@ class PostgresAdapter(AdapterABC):
         namespace: str = "default",
         *,
         auto_schema: bool = True,
-        min_pool_size: int = 2,
-        max_pool_size: int = 10,
+        min_pool_size: int | None = None,
+        max_pool_size: int | None = None,
         embedder: EmbedderABC | None = None,
         embedding_dim: int = 384,
     ) -> None:
@@ -264,26 +339,16 @@ class PostgresAdapter(AdapterABC):
             "row_factory": dict_row,
             "autocommit": True,
         }
-        # A ceiling on how long any one statement may run, applied to every
-        # connection this adapter opens. Off unless asked for, because the right
-        # ceiling depends on the deployment: a request-serving process wants one
-        # near its own request timeout, while a consolidation or backfill job may
-        # legitimately run for much longer, and a default here would abort the
-        # second kind of work in installations that never asked for it.
-        #
-        # Worth setting on anything serving HTTP. A statement that outlives the
-        # request that asked for it holds its locks with nobody left to want the
-        # answer, which is how a single slow query became a production outage on
-        # 2026-08-12; see _apply_schema.
-        timeout = os.environ.get("AMFS_POSTGRES_STATEMENT_TIMEOUT", "").strip()
-        if timeout:
-            connect_kwargs["options"] = f"-c statement_timeout={timeout}"
+        options = statement_timeout_options()
+        if options:
+            connect_kwargs["options"] = options
         pool_kwargs: dict[str, Any] = {"kwargs": connect_kwargs}
         if _ConnectionPool is not None:
+            min_size, max_size = pool_bounds(min_pool_size, max_pool_size)
             self._pool = _ConnectionPool(
                 dsn,
-                min_size=min_pool_size,
-                max_size=max_pool_size,
+                min_size=min_size,
+                max_size=max_size,
                 **pool_kwargs,
             )
         else:

--- a/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
@@ -34,7 +34,12 @@ from amfs_core.models import (
     SemanticQuery,
 )
 
-from amfs_postgres.adapter import _EXCLUDE_SHARED_PATHS, PostgresAdapter
+from amfs_postgres.adapter import (
+    _EXCLUDE_SHARED_PATHS,
+    PostgresAdapter,
+    pool_bounds,
+    statement_timeout_options,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -136,20 +141,30 @@ class AsyncPostgresAdapter:
         dsn: str,
         namespace: str = "default",
         *,
-        min_pool_size: int = 2,
-        max_pool_size: int = 10,
+        min_pool_size: int | None = None,
+        max_pool_size: int | None = None,
     ) -> None:
         self._dsn = dsn
         self._namespace = namespace
         self._has_embedding_col = False
         self._has_search_tsv = False
         self._has_is_artifact_col = False
+        connect_kwargs: dict[str, Any] = {"row_factory": dict_row, "autocommit": True}
+        # The ceiling belongs here most of all. This adapter serves the hot-path
+        # REST endpoints, so it holds the statements a caller is actually waiting
+        # on — and until this line existed, AMFS_POSTGRES_STATEMENT_TIMEOUT
+        # reached only the sync adapter, leaving the request path it was
+        # introduced to protect without one.
+        options = statement_timeout_options()
+        if options:
+            connect_kwargs["options"] = options
+        min_size, max_size = pool_bounds(min_pool_size, max_pool_size)
         self._pool = _AsyncTenantRLSPoolWrapper(
             AsyncConnectionPool(
                 dsn,
-                min_size=min_pool_size,
-                max_size=max_pool_size,
-                kwargs={"row_factory": dict_row, "autocommit": True},
+                min_size=min_size,
+                max_size=max_size,
+                kwargs=connect_kwargs,
                 open=False,
             )
         )

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -5940,7 +5940,14 @@ def main() -> None:
                 from amfs_cortex.worker import CortexWorker
 
                 namespace = os.environ.get("AMFS_NAMESPACE", "default")
-                adapter = PostgresAdapter(dsn=dsn, namespace=namespace)
+                # One background thread compiling digests on a timer, sharing a
+                # process with the request path. Sized for that rather than left
+                # on the pool default, which would have it hold as many
+                # connections as the endpoints do while using one at a time —
+                # multiplied by every instance the service scales out to.
+                adapter = PostgresAdapter(
+                    dsn=dsn, namespace=namespace, min_pool_size=1, max_pool_size=2
+                )
 
                 strategies = []
                 try:

--- a/tests/unit/test_async_adapter_pool.py
+++ b/tests/unit/test_async_adapter_pool.py
@@ -1,0 +1,55 @@
+"""What the async adapter's pool is configured with before it opens.
+
+The async adapter serves the hot-path REST endpoints, so it holds the
+statements a caller is actually waiting on. It went without a statement
+ceiling while the sync adapter had one, which left the request path that
+motivated the ceiling as the one place it did not apply.
+
+The pool is built with open=False, so nothing here touches a database.
+"""
+
+from __future__ import annotations
+
+from amfs_postgres.adapter import _DEFAULT_POOL_MAX
+from amfs_postgres.async_adapter import AsyncPostgresAdapter
+
+DSN = "postgresql://nobody@127.0.0.1:1/nothing"
+
+
+def _pool(adapter: AsyncPostgresAdapter):
+    return adapter._pool._inner
+
+
+class TestTheStatementCeiling:
+    def test_it_reaches_the_request_path(self, monkeypatch):
+        monkeypatch.setenv("AMFS_POSTGRES_STATEMENT_TIMEOUT", "300s")
+        kwargs = _pool(AsyncPostgresAdapter(dsn=DSN)).kwargs
+        assert kwargs["options"] == "-c statement_timeout=300s"
+
+    def test_nothing_is_passed_when_none_is_configured(self, monkeypatch):
+        monkeypatch.delenv("AMFS_POSTGRES_STATEMENT_TIMEOUT", raising=False)
+        kwargs = _pool(AsyncPostgresAdapter(dsn=DSN)).kwargs
+        assert "options" not in kwargs
+
+    def test_the_row_factory_survives_the_ceiling(self, monkeypatch):
+        # The options string is added to the connect kwargs rather than
+        # replacing them; dropping the row factory would break every read.
+        monkeypatch.setenv("AMFS_POSTGRES_STATEMENT_TIMEOUT", "300s")
+        kwargs = _pool(AsyncPostgresAdapter(dsn=DSN)).kwargs
+        assert kwargs["autocommit"] is True
+        assert kwargs["row_factory"] is not None
+
+
+class TestThePoolSize:
+    def test_it_follows_the_environment(self, monkeypatch):
+        monkeypatch.setenv("AMFS_POSTGRES_POOL_MAX", "6")
+        assert _pool(AsyncPostgresAdapter(dsn=DSN)).max_size == 6
+
+    def test_an_argument_still_wins(self, monkeypatch):
+        monkeypatch.setenv("AMFS_POSTGRES_POOL_MAX", "6")
+        assert _pool(AsyncPostgresAdapter(dsn=DSN, max_pool_size=2)).max_size == 2
+
+    def test_the_default_is_unchanged(self, monkeypatch):
+        monkeypatch.delenv("AMFS_POSTGRES_POOL_MAX", raising=False)
+        monkeypatch.delenv("AMFS_POSTGRES_POOL_MIN", raising=False)
+        assert _pool(AsyncPostgresAdapter(dsn=DSN)).max_size == _DEFAULT_POOL_MAX

--- a/tests/unit/test_pool_bounds.py
+++ b/tests/unit/test_pool_bounds.py
@@ -1,0 +1,78 @@
+"""How many database connections an adapter is allowed to hold.
+
+Every pool multiplies against every instance of the process holding it, and
+the database has a fixed max_connections. These tests pin the rules that let
+an operator spend that budget from the environment, and the rule that a
+caller who names a size for a particular adapter still gets it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from amfs_postgres.adapter import (
+    _DEFAULT_POOL_MAX,
+    _DEFAULT_POOL_MIN,
+    pool_bounds,
+    statement_timeout_options,
+)
+
+
+class TestWithNothingConfigured:
+    def test_the_defaults_are_unchanged(self):
+        assert pool_bounds() == (_DEFAULT_POOL_MIN, _DEFAULT_POOL_MAX)
+
+
+class TestFromTheEnvironment:
+    def test_the_ceiling_is_taken_from_the_variable(self, monkeypatch):
+        monkeypatch.setenv("AMFS_POSTGRES_POOL_MAX", "4")
+        assert pool_bounds() == (2, 4)
+
+    def test_the_floor_is_taken_from_the_variable(self, monkeypatch):
+        monkeypatch.setenv("AMFS_POSTGRES_POOL_MIN", "1")
+        assert pool_bounds() == (1, _DEFAULT_POOL_MAX)
+
+    def test_a_ceiling_below_the_default_floor_lowers_the_floor(self, monkeypatch):
+        # psycopg_pool refuses min_size > max_size, and an operator who caps a
+        # service at one connection means one, not a crash at boot.
+        monkeypatch.setenv("AMFS_POSTGRES_POOL_MAX", "1")
+        assert pool_bounds() == (1, 1)
+
+    @pytest.mark.parametrize("junk", ["", "  ", "lots", "4.5", "0", "-3"])
+    def test_a_value_that_is_not_a_usable_size_falls_back(self, monkeypatch, junk):
+        # A typo in a deployment variable should not stop a service starting.
+        monkeypatch.setenv("AMFS_POSTGRES_POOL_MAX", junk)
+        assert pool_bounds() == (_DEFAULT_POOL_MIN, _DEFAULT_POOL_MAX)
+
+
+class TestWhenTheCallerNamesASize:
+    def test_an_explicit_ceiling_beats_the_environment(self, monkeypatch):
+        # The background worker asking for two connections is describing what it
+        # is for, and is not competing with what the request path may have.
+        monkeypatch.setenv("AMFS_POSTGRES_POOL_MAX", "20")
+        assert pool_bounds(min_pool_size=1, max_pool_size=2) == (1, 2)
+
+    def test_naming_only_one_end_leaves_the_other_to_the_environment(self, monkeypatch):
+        monkeypatch.setenv("AMFS_POSTGRES_POOL_MIN", "3")
+        assert pool_bounds(max_pool_size=6) == (3, 6)
+
+    def test_an_explicit_floor_above_an_environment_ceiling_yields_to_it(
+        self, monkeypatch
+    ):
+        # The ceiling is what the database can bear; the floor is a preference.
+        monkeypatch.setenv("AMFS_POSTGRES_POOL_MAX", "2")
+        assert pool_bounds(min_pool_size=8) == (2, 2)
+
+
+class TestTheStatementCeiling:
+    def test_it_is_off_unless_asked_for(self, monkeypatch):
+        monkeypatch.delenv("AMFS_POSTGRES_STATEMENT_TIMEOUT", raising=False)
+        assert statement_timeout_options() is None
+
+    def test_a_blank_value_is_not_a_ceiling(self, monkeypatch):
+        monkeypatch.setenv("AMFS_POSTGRES_STATEMENT_TIMEOUT", "   ")
+        assert statement_timeout_options() is None
+
+    def test_it_becomes_a_libpq_option(self, monkeypatch):
+        monkeypatch.setenv("AMFS_POSTGRES_STATEMENT_TIMEOUT", "300s")
+        assert statement_timeout_options() == "-c statement_timeout=300s"


### PR DESCRIPTION
## Summary

Two changes to how an adapter uses its database connections, both prompted by production sizing work on 2026-08-12.
