### PR TITLE
Release the Postgres adapter as 0.2.0

### DIFF
--- a/packages/adapters/postgres/pyproject.toml
+++ b/packages/adapters/postgres/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-adapter-postgres"
-version = "0.1.9"
+version = "0.2.0"
 description = "AMFS Postgres adapter with back-propagation triggers"
 requires-python = ">=3.11"
 license = "Apache-2.0"


### PR DESCRIPTION
## Why

`amfs-adapter-postgres` on PyPI is **0.1.9, published 3 August**. `auto-publish.yml` only triggers on a change to `packages/**/pyproject.toml`, so every change to this package since then has been merged to main and never released. Self-hosted users are running code we replaced two weeks ago.

Four of those changes are in this release, two of which are the ones that matter:

| Commit | What a self-hosted user gets |
|:--|:--|
| `8054772` | `amfs_events` reads scoped to the caller's account. Without it, a multi-tenant database can return another account's events |
| `07a333b` | The boot-time schema apply no longer takes `ACCESS EXCLUSIVE` locks on every container start. This is what convoyed our own production database; it now fingerprints the schema and skips the apply when it is current, with a 5s `lock_timeout` so a cold path fails fast instead of blocking |
| `9496b82` | The fingerprint marker is per-schema, so two revisions deploying at once cannot flap each other back onto the cold path. Tables created by `_apply_migrations` are covered by the presence check too |
| `9843f76` | `AMFS_POSTGRES_POOL_MAX`/`MIN` for pool bounds, and the async adapter gets the `AMFS_POSTGRES_STATEMENT_TIMEOUT` ceiling the sync adapter already had |

## Minor, not patch

The environment knobs are new surface, and scoping the event reads changes what an existing caller gets back — someone relying on the unscoped behaviour would see fewer rows. That earns a minor.

## The dependency floor

`amfs-core>=0.3.13` still holds, and I checked rather than assumed: **core also has unreleased commits on main** while its version is unchanged, so a user installing this adapter gets core 0.3.13 from PyPI, not core as it stands on main. Importing this source against core 0.3.13 in a clean virtualenv resolves every symbol.

## The wider problem, for a follow-up

The gap is not confined to this package. Every published package has source on main that PyPI does not have:

| Package | main | PyPI | Unreleased commits |
|:--|:--|:--|:--|
| `amfs-http-server` | 0.3.13 | 0.3.13 | 10 |
| `amfs-adapter-http` | 0.1.9 | 0.1.9 | 7 |
| `amfs-core` | 0.3.13 | 0.3.13 | 4 |
| `amfs-adapter-filesystem` | 0.1.2 | 0.1.2 | 4 |
| `amfs` (SDK) | 0.5.6 | 0.5.6 | 2 |
| `amfs-cli` | 0.3.0 | 0.3.0 | 2 |
| `amfs-mcp-server` | 0.7.12 | 0.7.12 | 1 |
| `amfs-adapter-s3` | 0.1.2 | 0.1.2 | 1 |
| `amfs-strands` | 0.1.1 | 0.1.1 | 1 |

Tying the release to a hand-edited version field means forgetting the edit silently withholds the work, and nothing warns us. Worth a CI check that fails when a package's source changed without its version moving.

Made with [Cursor](https://cursor.com)