### PR TITLE
Stop dropping every trace that carries session metadata

### DIFF
--- a/packages/adapters/postgres/pyproject.toml
+++ b/packages/adapters/postgres/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-adapter-postgres"
-version = "0.2.1"
+version = "0.2.2"
 description = "AMFS Postgres adapter with back-propagation triggers"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -60,6 +60,7 @@ from amfs_core.models import (
     QueryEvent,
     SearchQuery,
     SemanticQuery,
+    SessionMetadata,
     Tag,
     ToolCall,
     TraceEntry,
@@ -2595,7 +2596,18 @@ class PostgresAdapter(AdapterABC):
                         trace.session_duration_ms,
                         json.dumps([e.model_dump(mode="json") for e in trace.error_events]),
                         json.dumps(trace.state_diff.model_dump(mode="json")) if trace.state_diff else None,
-                        json.dumps(trace.session_metadata) if trace.session_metadata else "{}",
+                        # Dumped like every other model field on this row. The
+                        # field is typed, so anything arriving over
+                        # ``POST /api/v1/traces`` is a ``SessionMetadata`` by the
+                        # time it reaches here and ``json.dumps`` cannot encode
+                        # it — the trace was lost with a 500. A plain dict still
+                        # gets through ``model_copy(update=...)``, which does not
+                        # validate, so both shapes are accepted.
+                        json.dumps(
+                            trace.session_metadata.model_dump(mode="json")
+                            if isinstance(trace.session_metadata, SessionMetadata)
+                            else trace.session_metadata
+                        ) if trace.session_metadata else "{}",
                         trace.created_at,
                         trace.task_input,
                         trace.response_text,

--- a/tests/integration/test_postgres_adapter.py
+++ b/tests/integration/test_postgres_adapter.py
@@ -139,3 +139,61 @@ def test_recorded_actions_survive_a_round_trip(adapter) -> None:
     listed = [t for t in adapter.list_traces(agent_id="action-agent")]
     assert listed, "the trace should be listable"
     assert [t.tool_name for t in listed[0].tool_calls] == ["deploy_rollback"]
+
+
+def test_a_trace_carrying_session_metadata_is_saved(adapter) -> None:
+    """The model, not a dict, is what actually reaches ``save_trace``.
+
+    ``DecisionTrace.session_metadata`` is typed, so ``POST /api/v1/traces``
+    validating a request body hands the adapter a ``SessionMetadata`` — which
+    ``json.dumps`` refused to encode, failing the save with a 500 and dropping
+    the trace. Every other test here left the field unset, so the whole hosted
+    write path was uncovered while the column looked exercised.
+
+    Constructed as a model on purpose: passing a dict would be validated into
+    one by ``DecisionTrace`` anyway, and asserting on the round trip is what
+    proves the value survived rather than being written as an empty object.
+    """
+    from amfs_core.models import DecisionTrace, SessionMetadata
+
+    saved = adapter.save_trace(
+        DecisionTrace(
+            agent_id="metadata-agent",
+            session_id="metadata-session",
+            outcome_ref="round-trip-4",
+            outcome_type="success",
+            session_metadata=SessionMetadata(
+                model="claude-4-opus",
+                client_name="cursor",
+                platform="cursor",
+                tools_available=["Shell", "Read"],
+            ),
+        )
+    )
+
+    fetched = adapter.get_trace(saved.id)
+    assert fetched is not None
+    assert fetched.session_metadata is not None
+    assert fetched.session_metadata.model == "claude-4-opus"
+    assert fetched.session_metadata.client_name == "cursor"
+    assert fetched.session_metadata.tools_available == ["Shell", "Read"]
+
+
+def test_a_trace_without_session_metadata_still_saves(adapter) -> None:
+    """The empty case the fix must not regress: no metadata is not an error."""
+    from amfs_core.models import DecisionTrace
+
+    saved = adapter.save_trace(
+        DecisionTrace(
+            agent_id="metadata-agent",
+            session_id="metadata-session",
+            outcome_ref="round-trip-5",
+            outcome_type="success",
+        )
+    )
+
+    fetched = adapter.get_trace(saved.id)
+    assert fetched is not None
+    assert fetched.session_metadata is None or (
+        fetched.session_metadata.model is None
+    )


### PR DESCRIPTION
## Summary

Found while reading `amfs-api` production logs during today's deploy incident: `POST /api/v1/traces` has been returning 500 with

```
TypeError: Object of type SessionMetadata is not JSON serializable
```
