### PR TITLE
Say when a committed outcome cannot be trained on

### DIFF
--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-mcp-server"
-version = "0.7.13"
+version = "0.7.14"
 description = "AMFS MCP Server — expose Agent Memory as MCP tools for Cursor and Claude Code"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -1087,6 +1087,39 @@ def amfs_stats() -> str:
     return json.dumps(stats.model_dump(mode="json"), default=str)
 
 
+def _training_note(missing: list[str]) -> str:
+    """Explain which half of the training pair the sealed trace is missing.
+
+    Worded to be actionable without inviting invention. A request exists for
+    every session, so a missing ``task_input`` is always a gap worth closing;
+    an action does not, and a session that only read and wrote memory has none
+    to record. Prompting for actions unconditionally would ask agents to make
+    them up, which costs more than the missing example.
+    """
+    if missing == ["task_input"]:
+        return (
+            "The actions on this trace are recorded but the request that "
+            "prompted them is not, so it says what was done without saying "
+            "what was asked. Pass task_input on this call, in the words the "
+            "request arrived in."
+        )
+    if missing == ["tool_calls"]:
+        return (
+            "The request on this trace is recorded but no action is, so there "
+            "is no decision in it to learn from. Call amfs_record_action as "
+            "each consequential action is taken, before committing. A session "
+            "that only read and wrote memory rightly has none, and an invented "
+            "action is worse than the gap."
+        )
+    return (
+        "This trace carries neither the request that started the work nor any "
+        "recorded action, so it is not a training example. Pass task_input on "
+        "this call, and call amfs_record_action as each consequential action "
+        "is taken. A session that only read and wrote memory rightly records "
+        "no action, and an invented one is worse than the gap."
+    )
+
+
 @mcp.tool(tags={"core"}, annotations={"readOnlyHint": False, "destructiveHint": False})
 def amfs_commit_outcome(
     outcome_ref: str,
@@ -1167,6 +1200,25 @@ def amfs_commit_outcome(
         # exactly like one that landed all ten, and the absence surfaces much
         # later as an export with nothing in it.
         result["tool_calls"] = len(getattr(trace, "tool_calls", None) or [])
+        # Supervised training pairs the request with the action taken in
+        # response, and the exporter skips a trace missing either half. Said
+        # here because this call is the last moment anyone can tell: an account
+        # finds out otherwise when readiness reports hundreds of outcomes and
+        # nothing to train on, months after the sessions that produced them.
+        # Read off the trace rather than off the arguments, so a task_input the
+        # SDK never stored or the gate redacted is reported as absent.
+        missing = [
+            half
+            for half, present in (
+                ("task_input", bool(getattr(trace, "task_input", None))),
+                ("tool_calls", bool(result["tool_calls"])),
+            )
+            if not present
+        ]
+        result["training"] = {"trainable": not missing}
+        if missing:
+            result["training"]["missing"] = missing
+            result["training"]["note"] = _training_note(missing)
         result["session_duration_ms"] = trace.session_duration_ms
         diff = getattr(trace, "state_diff", None)
         if diff is not None:

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -314,6 +314,92 @@ class TestMCPTools:
         result = json.loads(amfs_commit_outcome("task-46", "success"))
         assert result["tool_calls"] == 0
 
+    def test_a_trace_missing_both_halves_is_reported_untrainable(self) -> None:
+        """The gap has to be named at the moment it can still be closed.
+
+        An outcome sealed without the request or the action commits happily and
+        reads as a success, so an account can accumulate hundreds of them and
+        discover only at readiness that none can be trained on — by which time
+        every session that could have supplied the missing half is over.
+        """
+        from amfs_mcp.server import amfs_commit_outcome, amfs_write
+
+        amfs_write("svc", "key", "value")
+
+        result = json.loads(amfs_commit_outcome("task-47", "success"))
+        assert result["training"]["trainable"] is False
+        assert result["training"]["missing"] == ["task_input", "tool_calls"]
+
+    def test_the_note_does_not_ask_for_actions_that_were_never_taken(self) -> None:
+        """A session that only read and wrote memory has no action to record.
+
+        Prompting for one regardless would ask the agent to invent it, and a
+        fabricated action is worse than the missing example: it trains the
+        model on a decision nobody made.
+        """
+        from amfs_mcp.server import amfs_commit_outcome, amfs_write
+
+        amfs_write("svc", "key", "value")
+
+        result = json.loads(amfs_commit_outcome("task-48", "success"))
+        assert "invented" in result["training"]["note"]
+
+    def test_only_the_absent_half_is_named(self) -> None:
+        from amfs_mcp.server import (
+            amfs_commit_outcome,
+            amfs_record_action,
+            amfs_write,
+        )
+
+        amfs_write("svc", "key", "value")
+        amfs_record_action("deploy", {"target": "production"}, result="live")
+
+        result = json.loads(amfs_commit_outcome("task-49", "success"))
+        assert result["training"]["missing"] == ["task_input"]
+
+    def test_a_complete_pair_is_reported_trainable_without_a_note(self) -> None:
+        from amfs_mcp.server import (
+            amfs_commit_outcome,
+            amfs_record_action,
+            amfs_write,
+        )
+
+        amfs_write("svc", "key", "value")
+        amfs_record_action("deploy", {"target": "production"}, result="live")
+
+        result = json.loads(
+            amfs_commit_outcome("task-50", "success", task_input="ship the release")
+        )
+        assert result["training"] == {"trainable": True}
+
+    def test_a_task_input_the_trace_never_kept_is_reported_absent(self) -> None:
+        """Reported off the trace rather than off the argument.
+
+        The SDK may not accept task_input, and the safety gate can redact it,
+        so an agent that passed one can still have committed a trace without
+        it. Echoing the argument back would confirm a capture that did not
+        happen, which is the one answer worse than saying nothing.
+        """
+        import amfs_mcp.server as srv
+        from amfs_mcp.server import amfs_commit_outcome, amfs_write
+
+        amfs_write("svc", "key", "value")
+
+        original = srv._get_memory().commit_outcome
+
+        def drop_task_input(ref, otype, **kwargs):
+            kwargs.pop("task_input", None)
+            return original(ref, otype, **kwargs)
+
+        with patch.object(
+            srv._get_memory(), "commit_outcome", side_effect=drop_task_input
+        ):
+            result = json.loads(
+                amfs_commit_outcome("task-51", "success", task_input="ship it")
+            )
+
+        assert "task_input" in result["training"]["missing"]
+
     def test_the_explanation_is_absent_once_something_was_read(self) -> None:
         from amfs_mcp.server import amfs_commit_outcome, amfs_read, amfs_write
 


### PR DESCRIPTION
## Summary

`amfs_commit_outcome` returned the same `committed` response whether or not the trace it sealed could ever be used for training. A supervised example pairs the request with the action taken in answer to it, and the dataset builder skips a trace holding only one half — so an account can accumulate hundreds of outcomes and find out only at readiness that none of them are usable, long after every session that could have supplied the missing half has ended.

This is not hypothetical: a production account currently shows 301 outcomes in the last 90 days and 0 eligible for training.

The response now carries a `training` block:

```json
{"training": {"trainable": false, "missing": ["task_input", "tool_calls"], "note": "..."}}
```

The two halves are deliberately not asked for on the same terms. Every session has a request, so an absent `task_input` is always worth closing. Not every session takes an action — one that only read and wrote memory rightly has none — and prompting for one regardless would invite an invented action, which teaches the model a decision nobody made. The note says so explicitly.

`trainable` is read off the sealed trace rather than off the arguments, so a `task_input` an older SDK never stored, or one the safety gate redacted, is reported as absent rather than confirmed.