### PR TITLE
Let the installer connect without an API key, and take a room invite

### DIFF
--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -34,7 +34,25 @@ This will:
 
 ### Connecting to AMFS SaaS
 
-Pass your API key to connect to hosted AMFS:
+The shortest route needs no API key. `--remote` points your clients at the hosted
+MCP endpoint, and they sign you in through a browser the first time they connect:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/raia-live/amfs/main/install-mcp.sh | bash -s -- --remote
+```
+
+Nothing is installed locally in this mode — no `uv`, no Python — because the
+client talks to the endpoint over HTTP.
+
+If you were sent a room invite link, `--join` takes it and tells you the one
+remaining step once your client has signed in:
+
+```bash
+curl -sSL ... | bash -s -- --join https://amfs.sense-lab.ai/join/<token>
+```
+
+To run a local server against the SaaS API instead, pass an API key. This is the
+right choice if you want the process on your own machine:
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/raia-live/amfs/main/install-mcp.sh | bash -s -- --api-key <your-key>

--- a/install-mcp.sh
+++ b/install-mcp.sh
@@ -330,9 +330,13 @@ with open(config_path, 'w') as f:
 " "$config_file" "$amfs_block"
 }
 
+# The three answers has_stdio_senselab gives, named so callers cannot mix up
+# "gone" with "we could not tell" — which is the whole reason it has three.
+readonly SENSELAB_PRESENT=0
+readonly SENSELAB_ABSENT=1
+readonly SENSELAB_UNREADABLE=2
+
 # Whether a config file currently holds a local stdio `senselab` entry.
-#
-# 0 = yes, 1 = no, 2 = the file could not be read as JSON.
 #
 # The third answer is the reason this parses instead of grepping. `grep -q
 # '"senselab"'` finds the string in a path, a comment, or another server's
@@ -554,18 +558,26 @@ connector_instructions() {
     # way, so "we tried" is not evidence and the one case worth catching is
     # precisely the one where the old server is still there.
     if [[ -n "$config_file" ]]; then
-        local before=0
-        has_stdio_senselab "$config_file" || before=$?
-        if [[ $before -eq 0 ]]; then
+        local state=$SENSELAB_PRESENT
+        has_stdio_senselab "$config_file" || state=$?
+
+        if [[ $state -eq $SENSELAB_PRESENT ]]; then
             remove_mcp_config "$config_file"
-            if has_stdio_senselab "$config_file"; then
-                warn "Could not remove the old local $label entry."
-                echo "    Delete the \"senselab\" block from $config_file by hand —"
-                echo "    until then $label keeps starting the old local server."
-            else
+
+            # Asked again, because the answer is the only evidence. ABSENT is the
+            # one state that is a removal; the other two both mean the old server
+            # may still start, and they share a message because they share a
+            # recovery — open the file and look.
+            state=$SENSELAB_PRESENT
+            has_stdio_senselab "$config_file" || state=$?
+            if [[ $state -eq $SENSELAB_ABSENT ]]; then
                 success "Removed the old local $label entry ($config_file)"
+            else
+                warn "Could not confirm the old local $label entry is gone."
+                echo "    Check $config_file for a \"senselab\" block and remove it —"
+                echo "    until then $label may keep starting the old local server."
             fi
-        elif [[ $before -eq 2 ]]; then
+        elif [[ $state -eq $SENSELAB_UNREADABLE ]]; then
             warn "$config_file is not readable as JSON, so it was left alone."
             echo "    If it has a \"senselab\" block, remove it by hand: otherwise"
             echo "    $label keeps starting the old local server."

--- a/install-mcp.sh
+++ b/install-mcp.sh
@@ -507,12 +507,67 @@ configured() {
 }
 
 connector_instructions() {
-    local label="$1" where="$2"
+    local label="$1" where="$2" config_file="${3:-}"
     MANUAL_COUNT=$((MANUAL_COUNT + 1))
+
+    # Take the old stdio entry out on the way past.
+    #
+    # Not writing was only half of it. Someone switching an existing install to
+    # --remote has a `senselab` block already in this file, and leaving it there
+    # means the client keeps launching the local server: the script says to add a
+    # connector, they add one, and now there are two — or, if they do not, the
+    # migration silently did nothing and they are still on the old server. Both
+    # are worse than either half alone, because the summary says the hosted
+    # endpoint is what they are on.
+    if [[ -n "$config_file" && -f "$config_file" ]] \
+        && grep -q '"senselab"' "$config_file" 2>/dev/null; then
+        remove_mcp_config "$config_file"
+        success "Removed the old local $label entry ($config_file)"
+    fi
+
     warn "$label cannot be configured from here in remote mode."
     echo "    Add it once, by hand: $where"
     echo "    Endpoint: $(mcp_url)"
     echo "    It signs in through a browser; there is no key to paste."
+}
+
+# What is left to do about the invite, if one was passed.
+#
+# The invite is not redeemed here, and that is not a shortcoming to fix later:
+# accepting one needs a signed-in user, and the sign-in happens inside the client
+# after this script has exited. Doing it here would mean minting a credential of
+# our own first, which is the copy-and-paste step --remote exists to remove.
+#
+# What to say differs by mode, which is why this is a function rather than a block
+# in main — the two branches are the thing worth testing, and main cannot be
+# called without configuring real clients.
+join_next_steps() {
+    [[ -n "$JOIN_TOKEN" ]] || return 0
+
+    info "One step left: accept the room invitation."
+    if $REMOTE; then
+        echo "  Once your client has signed in, ask your agent:"
+    else
+        # The key path has no sign-in to wait for: the key already names its
+        # owner, and that owner is who the invite admits. Telling this person to
+        # wait for a browser they will never see reads as a stuck install.
+        echo "  Ask your agent:"
+    fi
+    echo ""
+    echo "    Join my SenseLab room with amfs_room_redeem, invite ${JOIN_TOKEN}"
+    echo ""
+    if $REMOTE; then
+        echo "  Or open the invite link in a browser, which does the same thing."
+    else
+        # Not the same thing on this path. A browser admits whoever is logged
+        # into it, which need not be the account the key belongs to — so
+        # following it can join the room as one account while the agent that is
+        # connected belongs to another, and nothing reports the mismatch.
+        echo "  Opening the link in a browser also works, but it admits"
+        echo "  whoever is signed in there — which may not be the account"
+        echo "  this API key belongs to. Asking the agent avoids the question."
+    fi
+    echo ""
 }
 
 configure_client() {
@@ -527,7 +582,7 @@ configure_client() {
                 success "Removed AMFS from Claude Desktop config"
             elif $REMOTE; then
                 connector_instructions "Claude Desktop" \
-                    "Settings → Connectors → Add custom connector"
+                    "Settings → Connectors → Add custom connector" "$path"
             else
                 inject_mcp_config "$path"
                 configured "Configured Claude Desktop ($path)"
@@ -629,7 +684,7 @@ configure_client() {
                 success "Removed AMFS from Windsurf config"
             elif $REMOTE; then
                 connector_instructions "Windsurf" \
-                    "Settings → Cascade → MCP servers → Add server"
+                    "Settings → Cascade → MCP servers → Add server" "$path"
             else
                 inject_mcp_config "$path"
                 configured "Configured Windsurf ($path)"
@@ -814,20 +869,7 @@ main() {
     fi
     echo ""
 
-    if [[ -n "$JOIN_TOKEN" ]]; then
-        # Not redeemed here, and this is not a shortcoming to fix later. Accepting
-        # an invite needs a signed-in user, and the sign-in has not happened yet
-        # — it happens inside the client, after this script has exited. Doing it
-        # here would mean minting a credential of our own first, which is the
-        # copy-and-paste step --remote exists to remove.
-        info "One step left: accept the room invitation."
-        echo "  Once your client has signed in, ask your agent:"
-        echo ""
-        echo "    Join my SenseLab room with amfs_room_redeem, invite ${JOIN_TOKEN}"
-        echo ""
-        echo "  Or open the invite link in a browser, which does the same thing."
-        echo ""
-    fi
+    join_next_steps
 
     # Claude Desktop has no writable instructions file — surface the one manual
     # step so it recalls proactively like the file-based clients now do.

--- a/install-mcp.sh
+++ b/install-mcp.sh
@@ -8,10 +8,18 @@ set -euo pipefail
 #   --client <name|all>   Skip auto-detect; configure a specific client (or "all")
 #   --api-key <key>       Use AMFS SaaS with this API key
 #   --api-url <url>       SaaS API URL (default: https://amfs-login.sense-lab.ai)
+#   --remote              Connect to the hosted MCP endpoint; sign in in a browser
+#   --join <link|token>   Room invite to accept once connected (implies --remote)
 #   --uninstall           Remove AMFS config from detected/specified clients
 #   -y, --yes             Skip confirmation prompts
 
 AMFS_DEFAULT_API_URL="https://amfs-login.sense-lab.ai"
+
+# The hosted MCP endpoint. A different host from the API URL above on purpose:
+# it is the identity this resource advertises in its OAuth discovery documents,
+# and a client that discovers one issuer and is then sent to another treats the
+# mismatch as an attack.
+AMFS_DEFAULT_MCP_URL="https://mcp.sense-lab.ai/mcp"
 
 # ── Colours & helpers ────────────────────────────────────────────────────────
 
@@ -33,6 +41,9 @@ fatal()   { error "$@"; exit 1; }
 CLIENT_FLAG=""
 API_KEY=""
 API_URL=""
+MCP_URL=""
+REMOTE=false
+JOIN_TOKEN=""
 UNINSTALL=false
 AUTO_YES=false
 
@@ -41,6 +52,9 @@ while [[ $# -gt 0 ]]; do
         --client)     CLIENT_FLAG="$2"; shift 2 ;;
         --api-key)    API_KEY="$2"; shift 2 ;;
         --api-url)    API_URL="$2"; shift 2 ;;
+        --mcp-url)    MCP_URL="$2"; REMOTE=true; shift 2 ;;
+        --remote)     REMOTE=true; shift ;;
+        --join)       JOIN_TOKEN="$2"; shift 2 ;;
         --uninstall)  UNINSTALL=true; shift ;;
         -y|--yes)     AUTO_YES=true; shift ;;
         -h|--help)
@@ -56,15 +70,49 @@ Options:
                         claude-code, codex, windsurf, vscode, or "all"
   --api-key <key>       Connect to AMFS SaaS with this API key
   --api-url <url>       SaaS API URL (default: https://amfs-login.sense-lab.ai)
+  --remote              Connect to the hosted MCP endpoint instead of running a
+                        local server. Your client signs in through a browser, so
+                        there is no API key to create or paste.
+  --join <link|token>   A room invite link to accept once connected. Implies
+                        --remote, because redeeming one needs a signed-in user.
+  --mcp-url <url>       Hosted MCP endpoint (default: https://mcp.sense-lab.ai/mcp)
   --uninstall           Remove AMFS MCP config from clients
   -y, --yes             Skip confirmation prompts
   -h, --help            Show this help
+
+Notes:
+  Without --api-key or --remote, this installs the open-source server backed by
+  local files in ~/.amfs/ — which is what it has always done with no flags.
 USAGE
             exit 0
             ;;
         *) fatal "Unknown option: $1 (use --help for usage)" ;;
     esac
 done
+
+# ── Resolve the connection mode ──────────────────────────────────────────────
+#
+# Three modes, and exactly one of them applies: the hosted endpoint, SaaS with a
+# pasted key, or local files. The default — no flags at all — is local files, and
+# nothing below changes that.
+
+if $REMOTE && [[ -n "$API_KEY" ]]; then
+    fatal "--remote and --api-key are different ways to authenticate; pass one.
+  --remote signs in through a browser and needs no key.
+  --api-key runs a local server against the SaaS API with the key you paste."
+fi
+
+# --join needs a signed-in user, since accepting an invite admits a person rather
+# than a process. A pasted key already identifies one — its creator — so a key
+# invocation is left alone; without one, the browser sign-in is how a user gets
+# attached to the connection, so joining implies --remote.
+if [[ -n "$JOIN_TOKEN" && -z "$API_KEY" ]]; then
+    REMOTE=true
+fi
+
+if [[ -n "$JOIN_TOKEN" ]] && $UNINSTALL; then
+    fatal "--join and --uninstall ask for opposite things."
+fi
 
 # ── OS detection ─────────────────────────────────────────────────────────────
 
@@ -84,6 +132,13 @@ fi
 # ── Step 1: Ensure uv is installed ───────────────────────────────────────────
 
 ensure_uv() {
+    # The hosted endpoint needs no local process, so it needs no Python
+    # toolchain. Installing uv anyway would download a toolchain and edit the
+    # user's PATH to run nothing — the opposite of what --remote is for.
+    if $REMOTE; then
+        return 0
+    fi
+
     if command -v uv &>/dev/null; then
         success "uv is already installed ($(uv --version))"
         return 0
@@ -118,6 +173,14 @@ ensure_uv() {
 # ── Step 2: Pre-install amfs-mcp-server ──────────────────────────────────────
 
 ensure_amfs_mcp() {
+    # Nothing to install for the hosted endpoint — the client talks to it over
+    # HTTP. This is the whole reason --remote exists: no uvx, no Python, and no
+    # key to copy, because the client signs in through a browser.
+    if $REMOTE; then
+        info "Using the hosted SenseLab endpoint — nothing to install"
+        return 0
+    fi
+
     # `--refresh` so the warm-up pulls the latest published build, matching the
     # `--refresh` the generated client config uses at launch.
     if [[ -n "$API_KEY" ]]; then
@@ -157,12 +220,31 @@ vscode_config_path() {
 
 UVX_PATH=""
 
+mcp_url() {
+    echo "${MCP_URL:-$AMFS_DEFAULT_MCP_URL}"
+}
+
 resolve_uvx_path() {
     if [[ -n "$UVX_PATH" ]]; then return; fi
     UVX_PATH="$(command -v uvx 2>/dev/null || echo "uvx")"
 }
 
 build_mcp_json() {
+    # The hosted endpoint is a URL, not a command, so this branch returns before
+    # uvx is even resolved. Placed ahead of the two below and gated on a variable
+    # that is false unless --remote or --join was passed, so neither the bare
+    # `curl | bash` nor the --api-key invocation reaches different code than it
+    # did before this branch existed.
+    if $REMOTE; then
+        cat <<REMOTEJSON
+{
+        "type": "http",
+        "url": "$(mcp_url)"
+    }
+REMOTEJSON
+        return 0
+    fi
+
     resolve_uvx_path
     local env_block="{}"
     local pkg="amfs-mcp-server"
@@ -435,16 +517,25 @@ configure_client() {
                     warn "Claude Code CLI (claude) not found on PATH — skipping"
                     return 1
                 fi
-                resolve_uvx_path
-                local pkg="amfs-mcp-server"
-                if [[ -n "$API_KEY" ]]; then pkg="amfs-mcp-server-pro"; fi
-                # `--refresh` (a uvx flag, before the package) forces a fresh
-                # re-resolve each launch so users never get stuck on a stale
-                # cached build after we publish a fix.
-                local args=("mcp" "add" "senselab" "--" "$UVX_PATH" "--refresh" "$pkg")
-                if [[ -n "$API_KEY" ]]; then
-                    local url="${API_URL:-$AMFS_DEFAULT_API_URL}"
-                    args=("mcp" "add" "senselab" "-e" "AMFS_HTTP_URL=$url" "-e" "AMFS_API_KEY=$API_KEY" "--" "$UVX_PATH" "--refresh" "$pkg")
+                local args
+                if $REMOTE; then
+                    # Claude Code has native support for an HTTP transport, and
+                    # runs the OAuth flow itself on first use.
+                    args=("mcp" "add" "--transport" "http" "senselab" "$(mcp_url)")
+                    # Re-runs stay idempotent; adding a name that exists fails.
+                    claude mcp remove senselab 2>/dev/null || true
+                else
+                    resolve_uvx_path
+                    local pkg="amfs-mcp-server"
+                    if [[ -n "$API_KEY" ]]; then pkg="amfs-mcp-server-pro"; fi
+                    # `--refresh` (a uvx flag, before the package) forces a fresh
+                    # re-resolve each launch so users never get stuck on a stale
+                    # cached build after we publish a fix.
+                    args=("mcp" "add" "senselab" "--" "$UVX_PATH" "--refresh" "$pkg")
+                    if [[ -n "$API_KEY" ]]; then
+                        local url="${API_URL:-$AMFS_DEFAULT_API_URL}"
+                        args=("mcp" "add" "senselab" "-e" "AMFS_HTTP_URL=$url" "-e" "AMFS_API_KEY=$API_KEY" "--" "$UVX_PATH" "--refresh" "$pkg")
+                    fi
                 fi
                 claude "${args[@]}"
                 success "Configured Claude Code"
@@ -465,17 +556,22 @@ configure_client() {
                     warn "Codex CLI (codex) not found on PATH — skipping"
                     return 1
                 fi
-                resolve_uvx_path
-                local pkg="amfs-mcp-server"
-                if [[ -n "$API_KEY" ]]; then pkg="amfs-mcp-server-pro"; fi
-                # codex mcp add <name> [--env KEY=VAL]... -- <command> [args...]
-                # `--refresh` (uvx flag, before the package) forces a fresh
-                # re-resolve each launch so a stale cache can't pin users to an
-                # old build after we publish a fix.
-                local args=("mcp" "add" "senselab" "--" "$UVX_PATH" "--refresh" "$pkg")
-                if [[ -n "$API_KEY" ]]; then
-                    local url="${API_URL:-$AMFS_DEFAULT_API_URL}"
-                    args=("mcp" "add" "senselab" "--env" "AMFS_HTTP_URL=$url" "--env" "AMFS_API_KEY=$API_KEY" "--" "$UVX_PATH" "--refresh" "$pkg")
+                local args
+                if $REMOTE; then
+                    args=("mcp" "add" "senselab" "--url" "$(mcp_url)")
+                else
+                    resolve_uvx_path
+                    local pkg="amfs-mcp-server"
+                    if [[ -n "$API_KEY" ]]; then pkg="amfs-mcp-server-pro"; fi
+                    # codex mcp add <name> [--env KEY=VAL]... -- <command> [args...]
+                    # `--refresh` (uvx flag, before the package) forces a fresh
+                    # re-resolve each launch so a stale cache can't pin users to an
+                    # old build after we publish a fix.
+                    args=("mcp" "add" "senselab" "--" "$UVX_PATH" "--refresh" "$pkg")
+                    if [[ -n "$API_KEY" ]]; then
+                        local url="${API_URL:-$AMFS_DEFAULT_API_URL}"
+                        args=("mcp" "add" "senselab" "--env" "AMFS_HTTP_URL=$url" "--env" "AMFS_API_KEY=$API_KEY" "--" "$UVX_PATH" "--refresh" "$pkg")
+                    fi
                 fi
                 # Replace any existing entry so re-runs stay idempotent.
                 codex mcp remove senselab 2>/dev/null || true
@@ -642,13 +738,40 @@ main() {
     success "Done! Restart your IDE/app to connect to AMFS."
     echo ""
 
-    if [[ -n "$API_KEY" ]]; then
+    if $REMOTE; then
+        info "Configured the hosted SenseLab endpoint ($(mcp_url))"
+        echo "  Your client will open a browser to sign in the first time it"
+        echo "  connects. There is no API key to create."
+        echo ""
+        # Named per client because the reload step differs and getting it wrong
+        # looks like the install failed: the config is on disk and the client is
+        # still running without it.
+        echo "  Claude Code:  run /mcp and approve the sign-in"
+        echo "  Cursor:       Settings → MCP, then sign in"
+        echo "  Codex:        restart codex"
+        echo "  Others:       restart the app"
+    elif [[ -n "$API_KEY" ]]; then
         info "Connected to AMFS SaaS (${API_URL:-$AMFS_DEFAULT_API_URL})"
     else
         info "Using local filesystem storage (~/.amfs/)"
         echo "  To connect to AMFS SaaS, re-run with --api-key <key>"
     fi
     echo ""
+
+    if [[ -n "$JOIN_TOKEN" ]]; then
+        # Not redeemed here, and this is not a shortcoming to fix later. Accepting
+        # an invite needs a signed-in user, and the sign-in has not happened yet
+        # — it happens inside the client, after this script has exited. Doing it
+        # here would mean minting a credential of our own first, which is the
+        # copy-and-paste step --remote exists to remove.
+        info "One step left: accept the room invitation."
+        echo "  Once your client has signed in, ask your agent:"
+        echo ""
+        echo "    Join my SenseLab room with amfs_room_redeem, invite ${JOIN_TOKEN}"
+        echo ""
+        echo "  Or open the invite link in a browser, which does the same thing."
+        echo ""
+    fi
 
     # Claude Desktop has no writable instructions file — surface the one manual
     # step so it recalls proactively like the file-based clients now do.

--- a/install-mcp.sh
+++ b/install-mcp.sh
@@ -478,6 +478,27 @@ detect_clients() {
 
 # ── Configure a single client ────────────────────────────────────────────────
 
+# Say where to paste the endpoint, for a client whose config file cannot hold it.
+#
+# `--remote` writes `{"type": "http", "url": …}`, which is what Cursor, Claude
+# Code, Codex and VS Code understand. Claude Desktop's config file takes stdio
+# servers only — a `url` entry there is ignored — and Windsurf names the same
+# thing `serverUrl`, so it is ignored too. Both reach remote servers through
+# their own UI instead.
+#
+# Writing the file anyway is worse than not touching it: the script says
+# "Configured", the client silently has no SenseLab, and the person has no reason
+# to look at the one place that would have worked. So neither is written to in
+# remote mode, and both are told where to go by hand. The stdio path is
+# unaffected and still writes both files as it always did.
+connector_instructions() {
+    local label="$1" where="$2"
+    warn "$label cannot be configured from here in remote mode."
+    echo "    Add it once, by hand: $where"
+    echo "    Endpoint: $(mcp_url)"
+    echo "    It signs in through a browser; there is no key to paste."
+}
+
 configure_client() {
     local client="$1"
 
@@ -488,6 +509,9 @@ configure_client() {
             if $UNINSTALL; then
                 remove_mcp_config "$path"
                 success "Removed AMFS from Claude Desktop config"
+            elif $REMOTE; then
+                connector_instructions "Claude Desktop" \
+                    "Settings → Connectors → Add custom connector"
             else
                 inject_mcp_config "$path"
                 success "Configured Claude Desktop ($path)"
@@ -587,6 +611,9 @@ configure_client() {
             if $UNINSTALL; then
                 remove_mcp_config "$path"
                 success "Removed AMFS from Windsurf config"
+            elif $REMOTE; then
+                connector_instructions "Windsurf" \
+                    "Settings → Cascade → MCP servers → Add server"
             else
                 inject_mcp_config "$path"
                 success "Configured Windsurf ($path)"

--- a/install-mcp.sh
+++ b/install-mcp.sh
@@ -330,37 +330,47 @@ with open(config_path, 'w') as f:
 " "$config_file" "$amfs_block"
 }
 
-# The three answers has_stdio_senselab gives, named so callers cannot mix up
-# "gone" with "we could not tell" — which is the whole reason it has three.
-readonly SENSELAB_PRESENT=0
-readonly SENSELAB_ABSENT=1
-readonly SENSELAB_UNREADABLE=2
-
-# Whether a config file currently holds a local stdio `senselab` entry.
+# Whether a config file holds a local stdio `senselab` entry: present, absent, or
+# unreadable.
 #
-# The third answer is the reason this parses instead of grepping. `grep -q
-# '"senselab"'` finds the string in a path, a comment, or another server's
-# argument list, and — the case that matters — it cannot tell "the entry is gone"
-# from "the file is unparseable so nothing was removed". remove_mcp_config exits 0
-# on a JSONDecodeError without writing anything, so a caller trusting grep can
-# report a removal that did not happen, which puts back exactly the stale local
-# server the removal exists to prevent.
-has_stdio_senselab() {
-    local config_file="$1"
-    [[ -f "$config_file" ]] || return 1
-    python3 -c "
+# Three answers rather than two, and a word on stdout rather than an exit status.
+#
+# Three, because `grep -q '"senselab"'` cannot tell "the entry is gone" from "the
+# file is unparseable so nothing was removed" — and remove_mcp_config exits 0
+# either way, so a caller trusting grep reports a removal that did not happen and
+# leaves the stale local server it was removing. Grep also matches the name in a
+# path or another server's argument list.
+#
+# A word, because an exit status has to carry both the answer and whether asking
+# worked, and those are different things. If python3 is not on PATH the status is
+# 127, which as a number falls outside a three-way branch and silently means
+# nothing happens. Here every failure of the check becomes "unreadable", which is
+# the answer that warns rather than the one that stays quiet.
+senselab_entry_state() {
+    local config_file="$1" state=""
+
+    if [[ ! -f "$config_file" ]]; then
+        state="absent"
+    else
+        state="$(python3 -c "
 import json, sys
 
 try:
     with open(sys.argv[1]) as f:
         config = json.load(f)
-except (json.JSONDecodeError, OSError):
-    sys.exit(2)
+except (json.JSONDecodeError, OSError, ValueError):
+    sys.exit(1)
 
 entry = (config.get('mcpServers') or {}).get('senselab')
 # A url entry is this script's own remote config, not a local server to clear.
-sys.exit(0 if isinstance(entry, dict) and entry.get('command') else 1)
-" "$config_file"
+print('present' if isinstance(entry, dict) and entry.get('command') else 'absent')
+" "$config_file" 2>/dev/null || true)"
+    fi
+
+    case "$state" in
+        present|absent) echo "$state" ;;
+        *) echo "unreadable" ;;
+    esac
 }
 
 remove_mcp_config() {
@@ -558,27 +568,31 @@ connector_instructions() {
     # way, so "we tried" is not evidence and the one case worth catching is
     # precisely the one where the old server is still there.
     if [[ -n "$config_file" ]]; then
-        local state=$SENSELAB_PRESENT
-        has_stdio_senselab "$config_file" || state=$?
+        local state
+        state="$(senselab_entry_state "$config_file")"
 
-        if [[ $state -eq $SENSELAB_PRESENT ]]; then
-            remove_mcp_config "$config_file"
+        if [[ "$state" == "present" ]]; then
+            # `|| true` because a failure here is not a reason to abandon the
+            # install. The file may be read-only, and the connector instructions
+            # below are still the right thing to print — under `set -e` a bare
+            # call would exit before saying anything at all, including the warning
+            # that the old entry is still there.
+            remove_mcp_config "$config_file" || true
 
-            # Asked again, because the answer is the only evidence. ABSENT is the
-            # one state that is a removal; the other two both mean the old server
-            # may still start, and they share a message because they share a
-            # recovery — open the file and look.
-            state=$SENSELAB_PRESENT
-            has_stdio_senselab "$config_file" || state=$?
-            if [[ $state -eq $SENSELAB_ABSENT ]]; then
+            # Asked again, because the answer is the only evidence a removal
+            # happened. "absent" is the one state that is one; the other two both
+            # mean the old server may still start, and they share a message
+            # because they share a recovery — open the file and look.
+            state="$(senselab_entry_state "$config_file")"
+            if [[ "$state" == "absent" ]]; then
                 success "Removed the old local $label entry ($config_file)"
             else
                 warn "Could not confirm the old local $label entry is gone."
                 echo "    Check $config_file for a \"senselab\" block and remove it —"
                 echo "    until then $label may keep starting the old local server."
             fi
-        elif [[ $state -eq $SENSELAB_UNREADABLE ]]; then
-            warn "$config_file is not readable as JSON, so it was left alone."
+        elif [[ "$state" == "unreadable" ]]; then
+            warn "$config_file could not be read, so it was left alone."
             echo "    If it has a \"senselab\" block, remove it by hand: otherwise"
             echo "    $label keeps starting the old local server."
         fi

--- a/install-mcp.sh
+++ b/install-mcp.sh
@@ -330,6 +330,35 @@ with open(config_path, 'w') as f:
 " "$config_file" "$amfs_block"
 }
 
+# Whether a config file currently holds a local stdio `senselab` entry.
+#
+# 0 = yes, 1 = no, 2 = the file could not be read as JSON.
+#
+# The third answer is the reason this parses instead of grepping. `grep -q
+# '"senselab"'` finds the string in a path, a comment, or another server's
+# argument list, and — the case that matters — it cannot tell "the entry is gone"
+# from "the file is unparseable so nothing was removed". remove_mcp_config exits 0
+# on a JSONDecodeError without writing anything, so a caller trusting grep can
+# report a removal that did not happen, which puts back exactly the stale local
+# server the removal exists to prevent.
+has_stdio_senselab() {
+    local config_file="$1"
+    [[ -f "$config_file" ]] || return 1
+    python3 -c "
+import json, sys
+
+try:
+    with open(sys.argv[1]) as f:
+        config = json.load(f)
+except (json.JSONDecodeError, OSError):
+    sys.exit(2)
+
+entry = (config.get('mcpServers') or {}).get('senselab')
+# A url entry is this script's own remote config, not a local server to clear.
+sys.exit(0 if isinstance(entry, dict) and entry.get('command') else 1)
+" "$config_file"
+}
+
 remove_mcp_config() {
     local config_file="$1"
 
@@ -519,10 +548,28 @@ connector_instructions() {
     # migration silently did nothing and they are still on the old server. Both
     # are worse than either half alone, because the summary says the hosted
     # endpoint is what they are on.
-    if [[ -n "$config_file" && -f "$config_file" ]] \
-        && grep -q '"senselab"' "$config_file" 2>/dev/null; then
-        remove_mcp_config "$config_file"
-        success "Removed the old local $label entry ($config_file)"
+    #
+    # Reported from the state afterwards rather than from the attempt. A file this
+    # cannot parse is left untouched by remove_mcp_config, which exits 0 either
+    # way, so "we tried" is not evidence and the one case worth catching is
+    # precisely the one where the old server is still there.
+    if [[ -n "$config_file" ]]; then
+        local before=0
+        has_stdio_senselab "$config_file" || before=$?
+        if [[ $before -eq 0 ]]; then
+            remove_mcp_config "$config_file"
+            if has_stdio_senselab "$config_file"; then
+                warn "Could not remove the old local $label entry."
+                echo "    Delete the \"senselab\" block from $config_file by hand —"
+                echo "    until then $label keeps starting the old local server."
+            else
+                success "Removed the old local $label entry ($config_file)"
+            fi
+        elif [[ $before -eq 2 ]]; then
+            warn "$config_file is not readable as JSON, so it was left alone."
+            echo "    If it has a \"senselab\" block, remove it by hand: otherwise"
+            echo "    $label keeps starting the old local server."
+        fi
     fi
 
     warn "$label cannot be configured from here in remote mode."

--- a/install-mcp.sh
+++ b/install-mcp.sh
@@ -47,6 +47,15 @@ JOIN_TOKEN=""
 UNINSTALL=false
 AUTO_YES=false
 
+# What the closing summary is allowed to claim.
+#
+# In remote mode some clients are configured and some can only be told where to
+# paste the endpoint, so "Done, restart your app" is true for one run and a lie
+# for another — a run that found only Claude Desktop would report success while
+# nothing had been connected. These count which happened.
+CONFIGURED_COUNT=0
+MANUAL_COUNT=0
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --client)     CLIENT_FLAG="$2"; shift 2 ;;
@@ -491,8 +500,15 @@ detect_clients() {
 # to look at the one place that would have worked. So neither is written to in
 # remote mode, and both are told where to go by hand. The stdio path is
 # unaffected and still writes both files as it always did.
+# Report a client we actually wrote a config for, and count it as one.
+configured() {
+    CONFIGURED_COUNT=$((CONFIGURED_COUNT + 1))
+    success "$1"
+}
+
 connector_instructions() {
     local label="$1" where="$2"
+    MANUAL_COUNT=$((MANUAL_COUNT + 1))
     warn "$label cannot be configured from here in remote mode."
     echo "    Add it once, by hand: $where"
     echo "    Endpoint: $(mcp_url)"
@@ -514,7 +530,7 @@ configure_client() {
                     "Settings → Connectors → Add custom connector"
             else
                 inject_mcp_config "$path"
-                success "Configured Claude Desktop ($path)"
+                configured "Configured Claude Desktop ($path)"
             fi
             ;;
         cursor)
@@ -525,7 +541,7 @@ configure_client() {
                 success "Removed AMFS from Cursor config"
             else
                 inject_mcp_config "$path"
-                success "Configured Cursor ($path)"
+                configured "Configured Cursor ($path)"
             fi
             ;;
         claude-code)
@@ -562,7 +578,7 @@ configure_client() {
                     fi
                 fi
                 claude "${args[@]}"
-                success "Configured Claude Code"
+                configured "Configured Claude Code"
                 install_claude_code_skill
                 upsert_senselab_block "$HOME/.claude/CLAUDE.md"
                 success "Installed SenseLab recall-first memory guide (skill + ~/.claude/CLAUDE.md)"
@@ -600,7 +616,7 @@ configure_client() {
                 # Replace any existing entry so re-runs stay idempotent.
                 codex mcp remove senselab 2>/dev/null || true
                 codex "${args[@]}"
-                success "Configured Codex"
+                configured "Configured Codex"
                 upsert_senselab_block "$HOME/.codex/AGENTS.md"
                 success "Installed SenseLab recall-first memory guide (~/.codex/AGENTS.md)"
             fi
@@ -616,7 +632,7 @@ configure_client() {
                     "Settings → Cascade → MCP servers → Add server"
             else
                 inject_mcp_config "$path"
-                success "Configured Windsurf ($path)"
+                configured "Configured Windsurf ($path)"
             fi
             ;;
         vscode)
@@ -627,7 +643,7 @@ configure_client() {
                 success "Removed AMFS from VS Code config"
             else
                 inject_mcp_config "$path"
-                success "Configured VS Code ($path)"
+                configured "Configured VS Code ($path)"
             fi
             ;;
         *)
@@ -762,10 +778,20 @@ main() {
 
     echo ""
     echo "──────────────────"
-    success "Done! Restart your IDE/app to connect to AMFS."
+    # Only claim a restart will do it if something was written for a client to
+    # pick up. A remote run that found only Claude Desktop has written nothing,
+    # and telling that person to restart sends them to look for a connection
+    # that will not be there instead of at the instructions just printed.
+    if (( CONFIGURED_COUNT > 0 )); then
+        success "Done! Restart your IDE/app to connect to AMFS."
+    elif (( MANUAL_COUNT > 0 )); then
+        warn "Nothing was configured automatically — see the step above."
+    else
+        warn "No clients were configured."
+    fi
     echo ""
 
-    if $REMOTE; then
+    if $REMOTE && (( CONFIGURED_COUNT > 0 )); then
         info "Configured the hosted SenseLab endpoint ($(mcp_url))"
         echo "  Your client will open a browser to sign in the first time it"
         echo "  connects. There is no API key to create."
@@ -777,6 +803,9 @@ main() {
         echo "  Cursor:       Settings → MCP, then sign in"
         echo "  Codex:        restart codex"
         echo "  Others:       restart the app"
+    elif $REMOTE; then
+        info "The hosted SenseLab endpoint is $(mcp_url)"
+        echo "  Signing in happens in a browser; there is no API key to create."
     elif [[ -n "$API_KEY" ]]; then
         info "Connected to AMFS SaaS (${API_URL:-$AMFS_DEFAULT_API_URL})"
     else

--- a/tests/unit/test_install_mcp_script.py
+++ b/tests/unit/test_install_mcp_script.py
@@ -1,0 +1,190 @@
+"""What `install-mcp.sh` writes into a user's MCP config, for each invocation.
+
+The script is published at a raw GitHub URL and piped straight into bash, so a
+change to it reaches everyone who runs the one-liner on the next release — there
+is no version anyone is pinned to. Until now nothing tested it at all.
+
+The reason these exist is narrower than "the installer should work". A keyless
+`--remote` mode was added, and the only way it could do damage is by changing
+what the two invocations already in use produce: the bare `curl | bash`, and the
+`--api-key` form the onboarding wizard hands out. Both are pinned below exactly,
+so a future edit that reroutes them shows up here instead of in a support thread
+about an agent that stopped remembering anything.
+
+The functions are exercised by sourcing the script with a stubbed `main`, which
+is what lets a config be built without touching a real client's files.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "install-mcp.sh"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="bash is needed to run the installer"
+)
+
+
+#: The script's entry point, called on its own final line.
+ENTRY_POINT = "main"
+
+
+def _sourceable(tmp: Path) -> Path:
+    """A copy of the script with its final `main` call removed.
+
+    Stubbing `main` before sourcing does not work — the script defines its own
+    further down, which replaces the stub, and then calls it. Rather than add a
+    test-only escape hatch to a file people pipe from curl into bash, the entry
+    point is stripped here. `test_the_entry_point_is_still_the_last_line` is what
+    keeps that honest: if the script stops ending this way, that fails rather
+    than every assertion below quietly testing a real install.
+    """
+    lines = SCRIPT.read_text().splitlines()
+    while lines and not lines[-1].strip():
+        lines.pop()
+    assert lines[-1].strip() == ENTRY_POINT
+    copy = tmp / "install-mcp-under-test.sh"
+    copy.write_text("\n".join(lines[:-1]) + "\n")
+    return copy
+
+
+def _run(args: str, snippet: str, tmp_path: Path) -> str:
+    """Source the script with the given flags and run one snippet against it.
+
+    Parsing and the config builders run while nothing detects a client or writes
+    a file. `--help` and `--uninstall` are the only paths that exit during
+    parsing, and neither is used here.
+    """
+    script = _sourceable(tmp_path)
+    program = f"""
+set -euo pipefail
+# shellcheck disable=SC1090
+source {script!s} {args}
+{snippet}
+"""
+    proc = subprocess.run(
+        ["bash", "-c", program], capture_output=True, text=True, timeout=60,
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    return proc.stdout
+
+
+@pytest.fixture()
+def build_config(tmp_path: Path):
+    """Build the MCP config block the script would write, for some flags."""
+
+    def _build(args: str = "") -> dict:
+        return json.loads(_run(args, "build_mcp_json", tmp_path))
+
+    return _build
+
+
+def test_the_entry_point_is_still_the_last_line() -> None:
+    """Everything below depends on being able to strip it."""
+    lines = [ln for ln in SCRIPT.read_text().splitlines() if ln.strip()]
+    assert lines[-1].strip() == ENTRY_POINT
+
+
+class TestTheDefaultInvocationIsUnchanged:
+    """`curl -sSL … | bash`, with no flags. The most-run form of the script."""
+
+    def test_it_still_installs_the_open_source_server_over_stdio(self, build_config) -> None:
+        built = build_config()
+        assert built["args"] == ["--refresh", "amfs-mcp-server"]
+        assert built["command"].endswith("uvx")
+
+    def test_it_carries_no_credentials_and_no_url(self, build_config) -> None:
+        """Local filesystem storage: there is nothing to authenticate to."""
+        built = build_config()
+        assert built["env"] == {}
+        assert "url" not in built
+        assert "type" not in built
+
+
+class TestThePastedKeyInvocationIsUnchanged:
+    """`--api-key …`, which is what the onboarding wizard hands out."""
+
+    def test_it_installs_the_pro_server_with_the_key_in_the_environment(self, build_config) -> None:
+        built = build_config("--api-key amfs_test_key_123")
+        assert built["args"] == ["--refresh", "amfs-mcp-server-pro"]
+        assert built["env"]["AMFS_API_KEY"] == "amfs_test_key_123"
+        assert built["env"]["AMFS_HTTP_URL"] == "https://amfs-login.sense-lab.ai"
+
+    def test_api_url_still_overrides_the_default_host(self, build_config) -> None:
+        built = build_config("--api-key k --api-url https://staging.example.com")
+        assert built["env"]["AMFS_HTTP_URL"] == "https://staging.example.com"
+
+    def test_it_is_still_a_local_process_rather_than_a_url(self, build_config) -> None:
+        built = build_config("--api-key k")
+        assert "url" not in built
+
+
+class TestTheRemoteMode:
+    def test_it_writes_a_url_and_no_command(self, build_config) -> None:
+        """The point of it: nothing runs locally, so nothing needs installing."""
+        built = build_config("--remote")
+        assert built == {"type": "http", "url": "https://mcp.sense-lab.ai/mcp"}
+
+    def test_it_carries_no_key_because_there_is_nothing_to_carry(self, build_config) -> None:
+        built = build_config("--remote")
+        assert "env" not in built
+        assert not any("key" in str(v).lower() for v in built.values())
+
+    def test_the_endpoint_can_be_pointed_elsewhere(self, build_config) -> None:
+        """So a dev install does not reach the production endpoint."""
+        built = build_config("--mcp-url https://mcp.dev.example.com/mcp")
+        assert built["url"] == "https://mcp.dev.example.com/mcp"
+
+    def test_joining_a_room_implies_it(self, build_config) -> None:
+        """An invite admits a person, and only the browser sign-in has one."""
+        built = build_config("--join tok-abc")
+        assert built["type"] == "http"
+
+
+class TestContradictoryFlagsAreRefused:
+    """Both would otherwise resolve silently, and to the surprising answer.
+
+    `--remote` beat `--api-key` in the order the branches were written, so
+    passing both produced a keyless config and dropped the key without a word.
+    """
+
+    def _fails(self, args: str, tmp_path: Path) -> str:
+        proc = subprocess.run(
+            ["bash", "-c", f"source {_sourceable(tmp_path)!s} {args}"],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert proc.returncode != 0, f"expected a refusal, got {proc.stdout!r}"
+        return proc.stderr
+
+    def test_remote_and_api_key_together(self, tmp_path: Path) -> None:
+        assert "pass one" in self._fails("--remote --api-key k", tmp_path)
+
+    def test_join_and_uninstall_together(self, tmp_path: Path) -> None:
+        assert "opposite" in self._fails("--join tok --uninstall", tmp_path)
+
+    def test_an_api_key_with_a_join_keeps_the_key_path(self, build_config) -> None:
+        """Not a contradiction: a key already identifies the user who made it,
+        and that user is the one the invite would admit."""
+        built = build_config("--api-key amfs_k --join tok-abc")
+        assert built["args"] == ["--refresh", "amfs-mcp-server-pro"]
+        assert built["env"]["AMFS_API_KEY"] == "amfs_k"
+
+
+class TestTheJoinTokenIsNotLeakedByTheScript:
+    def test_it_does_not_appear_in_the_help_text(self) -> None:
+        proc = subprocess.run(
+            ["bash", str(SCRIPT), "--help"],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert proc.returncode == 0
+        assert "--join" in proc.stdout
+        # The flag is documented; no example carries a token shaped like a real
+        # one, so copying the help text cannot hand anyone a live invite.
+        assert "<link|token>" in proc.stdout

--- a/tests/unit/test_install_mcp_script.py
+++ b/tests/unit/test_install_mcp_script.py
@@ -304,6 +304,31 @@ class TestClientsThatCannotHoldAUrl:
         assert "not readable as JSON" in out
         assert "remove it by hand" in out
 
+    def test_a_removal_that_cannot_be_confirmed_is_not_called_a_removal(
+        self, tmp_path: Path
+    ) -> None:
+        """Only "the entry is absent" is evidence of a removal.
+
+        The check after removing was a plain if/else at first, so the two states
+        that are not a removal — still present, and unreadable — collapsed into
+        the success branch between them. Stubbing the removal to do nothing is the
+        cheapest way to hold that open: if any non-absent answer ever reads as
+        success again, this fails.
+        """
+        home = tmp_path / "home"
+        path = self._existing_stdio_config("claude-desktop", home)
+
+        out = _run(
+            "--remote",
+            f"remove_mcp_config() {{ :; }}\n"
+            f"HOME={home!s} configure_client claude-desktop 2>&1 || true",
+            tmp_path,
+        )
+
+        assert "Removed the old local" not in out
+        assert "Could not confirm" in out
+        assert "senselab" in path.read_text()
+
     def test_the_word_senselab_elsewhere_is_not_an_entry(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/test_install_mcp_script.py
+++ b/tests/unit/test_install_mcp_script.py
@@ -186,15 +186,46 @@ class TestClientsThatCannotHoldAUrl:
     the one place the person could have fixed it.
     """
 
-    def _configure(self, client: str, args: str, tmp_path: Path) -> str:
-        home = tmp_path / "home"
-        home.mkdir()
-        out = _run(
+    #: Where each client's config lives under a fake HOME, on this platform.
+    #:
+    #: Only macOS and Linux differ, and only for Claude Desktop; the script picks
+    #: between them itself, so the test asks it rather than guessing.
+    def _config_path(self, client: str, home: Path, tmp_path: Path) -> Path:
+        fn = {
+            "claude-desktop": "claude_desktop_config_path",
+            "windsurf": "windsurf_config_path",
+            "cursor": "cursor_config_path",
+        }[client]
+        return Path(_run("", f"HOME={home!s} {fn}", tmp_path).strip())
+
+    def _existing_stdio_config(self, client: str, home: Path) -> Path:
+        """A config file as a previous stdio install would have left it."""
+        home.mkdir(exist_ok=True)
+        path = self._config_path(client, home, home.parent)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "mcpServers": {
+                "senselab": {
+                    "command": "/opt/homebrew/bin/uvx",
+                    "args": ["--refresh", "amfs-mcp-server-pro"],
+                    "env": {"AMFS_API_KEY": "amfs_old_key"},
+                },
+                "somebody-else": {"command": "node", "args": ["other.js"]},
+            }
+        }, indent=4))
+        return path
+
+    def _configure(
+        self, client: str, args: str, tmp_path: Path, home: Path | None = None
+    ) -> str:
+        if home is None:
+            home = tmp_path / "home"
+            home.mkdir(exist_ok=True)
+        return _run(
             args,
             f'HOME={home!s} configure_client {client} 2>&1 || true',
             tmp_path,
         )
-        return out
 
     @pytest.mark.parametrize("client", ["claude-desktop", "windsurf"])
     def test_remote_mode_tells_the_user_instead_of_writing(
@@ -206,12 +237,50 @@ class TestClientsThatCannotHoldAUrl:
         assert "Configured" not in out
 
     @pytest.mark.parametrize("client", ["claude-desktop", "windsurf"])
-    def test_remote_mode_leaves_the_config_file_alone(
+    def test_remote_mode_writes_no_new_config_file(
         self, client: str, tmp_path: Path
     ) -> None:
         """An ignored entry is not the only cost — the file is shared."""
         self._configure(client, "--remote", tmp_path)
         assert not list((tmp_path / "home").rglob("*.json"))
+
+    @pytest.mark.parametrize("client", ["claude-desktop", "windsurf"])
+    def test_it_takes_out_an_existing_local_entry(
+        self, client: str, tmp_path: Path
+    ) -> None:
+        """Someone switching an existing install over to the hosted endpoint.
+
+        Not writing was only half of it. Left in place, the old block keeps the
+        client launching the local server — so either they add the connector and
+        have two, or they do not and the migration silently did nothing, while
+        the summary says they are on the hosted endpoint.
+        """
+        home = tmp_path / "home"
+        path = self._existing_stdio_config(client, home)
+
+        out = self._configure(client, "--remote", tmp_path, home=home)
+
+        assert "Removed the old local" in out
+        assert "senselab" not in path.read_text()
+
+    @pytest.mark.parametrize("client", ["claude-desktop", "windsurf"])
+    def test_it_leaves_other_servers_in_that_file_alone(
+        self, client: str, tmp_path: Path
+    ) -> None:
+        """The file is shared with every other MCP server the person uses."""
+        home = tmp_path / "home"
+        path = self._existing_stdio_config(client, home)
+
+        self._configure(client, "--remote", tmp_path, home=home)
+
+        assert json.loads(path.read_text())["mcpServers"]["somebody-else"]
+
+    def test_there_is_nothing_to_say_when_there_was_no_old_entry(
+        self, tmp_path: Path
+    ) -> None:
+        """A first-time install should not be told something was removed."""
+        out = self._configure("claude-desktop", "--remote", tmp_path)
+        assert "Removed the old local" not in out
 
     @pytest.mark.parametrize("client", ["claude-desktop", "windsurf"])
     def test_the_stdio_path_still_writes_the_file(
@@ -279,6 +348,58 @@ class TestTheClosingSummaryDoesNotOverclaim:
         out = self._run_main("--remote --client cursor", tmp_path)
         assert "Restart your IDE" in out
         assert "Configured the hosted SenseLab endpoint" in out
+
+
+class TestTheJoinCopyMatchesHowTheUserWillSignIn:
+    """`--join` says what to do next, and next is not the same in both modes.
+
+    In remote mode there is a browser sign-in to wait for. On the key path there
+    is not — the key already names its owner — so "once your client has signed
+    in" describes a step that never happens and reads as a stuck install. The
+    browser fallback is worse than merely wrong there: a browser admits whoever
+    is logged into it, which need not be the account the key belongs to, so
+    following it joins the room as one account while the connected agent belongs
+    to another.
+    """
+
+    def _steps(self, args: str, tmp_path: Path) -> str:
+        return _run(args, "join_next_steps", tmp_path)
+
+    def test_remote_mode_waits_for_the_sign_in(self, tmp_path: Path) -> None:
+        assert "Once your client has signed in" in self._steps(
+            "--join tok-abc", tmp_path
+        )
+
+    def test_the_key_path_does_not_wait_for_one(self, tmp_path: Path) -> None:
+        out = self._steps("--api-key amfs_k --join tok-abc", tmp_path)
+        assert "Once your client has signed in" not in out
+        assert "Ask your agent:" in out
+
+    def test_the_key_path_warns_that_a_browser_may_be_someone_else(
+        self, tmp_path: Path
+    ) -> None:
+        out = self._steps("--api-key amfs_k --join tok-abc", tmp_path)
+        assert "whoever is signed in there" in out
+
+    def test_only_remote_calls_the_browser_the_same_thing(
+        self, tmp_path: Path
+    ) -> None:
+        assert "does the same thing" in self._steps("--join tok", tmp_path)
+        assert "does the same thing" not in self._steps(
+            "--api-key amfs_k --join tok", tmp_path
+        )
+
+    @pytest.mark.parametrize(
+        "args", ["--join tok-abc", "--api-key amfs_k --join tok-abc"]
+    )
+    def test_both_modes_name_the_tool_and_the_token(
+        self, args: str, tmp_path: Path
+    ) -> None:
+        out = self._steps(args, tmp_path)
+        assert "amfs_room_redeem, invite tok-abc" in out
+
+    def test_it_says_nothing_at_all_without_an_invite(self, tmp_path: Path) -> None:
+        assert self._steps("--remote", tmp_path).strip() == ""
 
 
 class TestTheJoinTokenIsNotLeakedByTheScript:

--- a/tests/unit/test_install_mcp_script.py
+++ b/tests/unit/test_install_mcp_script.py
@@ -301,8 +301,52 @@ class TestClientsThatCannotHoldAUrl:
         out = self._configure("claude-desktop", "--remote", tmp_path, home=home)
 
         assert "Removed the old local" not in out
-        assert "not readable as JSON" in out
+        assert "could not be read" in out
         assert "remove it by hand" in out
+
+    def test_a_check_that_cannot_run_at_all_warns_rather_than_going_quiet(
+        self, tmp_path: Path
+    ) -> None:
+        """No python3 on PATH, which is the shape of every unexpected failure.
+
+        The state used to arrive as an exit status, which had to carry both the
+        answer and whether asking worked. A missing interpreter exits 127, and as
+        a number that fell outside the three-way branch — so nothing was removed,
+        nothing was said, and the summary still reported the hosted endpoint.
+        """
+        home = tmp_path / "home"
+        path = self._existing_stdio_config("claude-desktop", home)
+
+        out = _run(
+            "--remote",
+            f"python3() {{ return 127; }}\n"
+            f"HOME={home!s} configure_client claude-desktop 2>&1 || true",
+            tmp_path,
+        )
+
+        assert "Removed the old local" not in out
+        assert "could not be read" in out
+        assert "senselab" in path.read_text()
+
+    def test_a_config_file_it_cannot_write_does_not_abort_the_install(
+        self, tmp_path: Path
+    ) -> None:
+        """`set -e` is on, so a bare removal call exiting non-zero took the whole
+        script with it — before printing the connector instructions, and before
+        the warning that the old entry is still in place."""
+        home = tmp_path / "home"
+        path = self._existing_stdio_config("claude-desktop", home)
+
+        out = _run(
+            "--remote",
+            f"remove_mcp_config() {{ return 1; }}\n"
+            f"HOME={home!s} configure_client claude-desktop 2>&1 || true",
+            tmp_path,
+        )
+
+        assert "Could not confirm" in out
+        assert "Add it once, by hand" in out
+        assert "senselab" in path.read_text()
 
     def test_a_removal_that_cannot_be_confirmed_is_not_called_a_removal(
         self, tmp_path: Path

--- a/tests/unit/test_install_mcp_script.py
+++ b/tests/unit/test_install_mcp_script.py
@@ -282,6 +282,49 @@ class TestClientsThatCannotHoldAUrl:
         out = self._configure("claude-desktop", "--remote", tmp_path)
         assert "Removed the old local" not in out
 
+    def test_a_file_it_cannot_parse_is_reported_not_claimed(
+        self, tmp_path: Path
+    ) -> None:
+        """The case a grep could not distinguish.
+
+        `remove_mcp_config` leaves an unparseable file untouched and exits 0
+        either way, so reporting from the attempt rather than the result claimed
+        a removal that did not happen — putting back the stale local server the
+        removal exists to prevent, with a success line over the top of it.
+        """
+        home = tmp_path / "home"
+        home.mkdir()
+        path = self._config_path("claude-desktop", home, tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"mcpServers": {"senselab": {"command": "uvx"},,,')
+
+        out = self._configure("claude-desktop", "--remote", tmp_path, home=home)
+
+        assert "Removed the old local" not in out
+        assert "not readable as JSON" in out
+        assert "remove it by hand" in out
+
+    def test_the_word_senselab_elsewhere_is_not_an_entry(
+        self, tmp_path: Path
+    ) -> None:
+        """A path or another server's arguments can carry the name."""
+        home = tmp_path / "home"
+        home.mkdir()
+        path = self._config_path("claude-desktop", home, tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "mcpServers": {
+                "other": {"command": "node", "args": ["/opt/senselab/x.js"]}
+            }
+        }))
+
+        out = self._configure("claude-desktop", "--remote", tmp_path, home=home)
+
+        assert "Removed the old local" not in out
+        assert "Could not remove" not in out
+        assert "not readable as JSON" not in out
+        assert json.loads(path.read_text())["mcpServers"]["other"]
+
     @pytest.mark.parametrize("client", ["claude-desktop", "windsurf"])
     def test_the_stdio_path_still_writes_the_file(
         self, client: str, tmp_path: Path

--- a/tests/unit/test_install_mcp_script.py
+++ b/tests/unit/test_install_mcp_script.py
@@ -235,6 +235,52 @@ class TestClientsThatCannotHoldAUrl:
         assert "https://mcp.sense-lab.ai/mcp" in written[0].read_text()
 
 
+class TestTheClosingSummaryDoesNotOverclaim:
+    """A full run, end to end, for what the last lines say happened.
+
+    The summary used to be written from the flags rather than from the outcome:
+    `--remote` printed "Configured the hosted SenseLab endpoint" and "restart
+    your IDE/app" whether or not a single file had been written. A remote run
+    that found only Claude Desktop wrote nothing and still reported success,
+    which sends someone to look for a connection instead of at the one
+    instruction that would have worked.
+    """
+
+    def _run_main(self, args: str, tmp_path: Path) -> str:
+        home = tmp_path / "home"
+        home.mkdir()
+        proc = subprocess.run(
+            ["bash", str(SCRIPT), *args.split(), "--yes"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env={"HOME": str(home), "PATH": "/usr/bin:/bin:/usr/sbin:/sbin"},
+        )
+        return proc.stdout + proc.stderr
+
+    def test_a_client_it_cannot_write_to_is_not_called_configured(
+        self, tmp_path: Path
+    ) -> None:
+        out = self._run_main("--remote --client claude-desktop", tmp_path)
+        assert "Nothing was configured automatically" in out
+        assert "Restart your IDE" not in out
+
+    def test_it_still_names_the_endpoint_that_needs_pasting(
+        self, tmp_path: Path
+    ) -> None:
+        """The run is not useless — it is the instruction that is the product."""
+        out = self._run_main("--remote --client claude-desktop", tmp_path)
+        assert "https://mcp.sense-lab.ai/mcp" in out
+        assert "Add custom connector" in out
+
+    def test_a_client_it_did_write_to_is_told_to_restart(
+        self, tmp_path: Path
+    ) -> None:
+        out = self._run_main("--remote --client cursor", tmp_path)
+        assert "Restart your IDE" in out
+        assert "Configured the hosted SenseLab endpoint" in out
+
+
 class TestTheJoinTokenIsNotLeakedByTheScript:
     def test_it_does_not_appear_in_the_help_text(self) -> None:
         proc = subprocess.run(

--- a/tests/unit/test_install_mcp_script.py
+++ b/tests/unit/test_install_mcp_script.py
@@ -177,6 +177,64 @@ class TestContradictoryFlagsAreRefused:
         assert built["env"]["AMFS_API_KEY"] == "amfs_k"
 
 
+class TestClientsThatCannotHoldAUrl:
+    """Claude Desktop and Windsurf, in remote mode.
+
+    Claude Desktop's config file takes stdio servers only, and Windsurf calls the
+    field `serverUrl`. Writing `{"type": "http", "url": …}` into either is
+    ignored, so the script reporting "Configured" would be a lie that also hides
+    the one place the person could have fixed it.
+    """
+
+    def _configure(self, client: str, args: str, tmp_path: Path) -> str:
+        home = tmp_path / "home"
+        home.mkdir()
+        out = _run(
+            args,
+            f'HOME={home!s} configure_client {client} 2>&1 || true',
+            tmp_path,
+        )
+        return out
+
+    @pytest.mark.parametrize("client", ["claude-desktop", "windsurf"])
+    def test_remote_mode_tells_the_user_instead_of_writing(
+        self, client: str, tmp_path: Path
+    ) -> None:
+        out = self._configure(client, "--remote", tmp_path)
+        assert "cannot be configured from here" in out
+        assert "https://mcp.sense-lab.ai/mcp" in out
+        assert "Configured" not in out
+
+    @pytest.mark.parametrize("client", ["claude-desktop", "windsurf"])
+    def test_remote_mode_leaves_the_config_file_alone(
+        self, client: str, tmp_path: Path
+    ) -> None:
+        """An ignored entry is not the only cost — the file is shared."""
+        self._configure(client, "--remote", tmp_path)
+        assert not list((tmp_path / "home").rglob("*.json"))
+
+    @pytest.mark.parametrize("client", ["claude-desktop", "windsurf"])
+    def test_the_stdio_path_still_writes_the_file(
+        self, client: str, tmp_path: Path
+    ) -> None:
+        """The regression this could have caused, stated as a test."""
+        out = self._configure(client, "", tmp_path)
+        assert "Configured" in out
+        written = list((tmp_path / "home").rglob("*.json"))
+        assert len(written) == 1
+        assert "amfs-mcp-server" in written[0].read_text()
+
+    def test_cursor_is_configured_by_file_in_remote_mode(
+        self, tmp_path: Path
+    ) -> None:
+        """It understands the URL form, so it is not in the told-by-hand set."""
+        out = self._configure("cursor", "--remote", tmp_path)
+        assert "Configured Cursor" in out
+        written = list((tmp_path / "home").rglob("mcp.json"))
+        assert len(written) == 1
+        assert "https://mcp.sense-lab.ai/mcp" in written[0].read_text()
+
+
 class TestTheJoinTokenIsNotLeakedByTheScript:
     def test_it_does_not_appear_in_the_help_text(self) -> None:
         proc = subprocess.run(


### PR DESCRIPTION
## Why

The installer knew one shape: a local `uvx` process authenticated with a pasted API key. That made creating and copying a key the price of entry, even though the hosted MCP endpoint has authenticated with browser OAuth for a while and needs no key at all.

This is the open-source half of a change whose other half is in `amfs-internal`: people who are sent a room invite link sign up, read the room in the dashboard, and never connect an agent. The dashboard now serves agent-readable instructions for an invite link, and this is the command those instructions point at.

## What

- `--remote` writes the hosted HTTP endpoint instead of a local command. Nothing is installed — no `uv`, no Python, no key to create — and the client runs the sign-in itself on first use.
- `--join <link|token>` takes an invite link, implies `--remote`, and names the one remaining step after the client has signed in. It deliberately does not redeem the invite: accepting one admits a person, the sign-in happens inside the client after this script has exited, and doing it here would mean minting a credential first, which is the copy-and-paste being removed.
- `--mcp-url` points a dev install somewhere other than production.
- `--remote` with `--api-key` is now refused. Passing both used to produce a keyless config and drop the key without a word.
- In remote mode, Claude Desktop and Windsurf are told where to paste the endpoint rather than written to. Claude Desktop's config file takes stdio servers only and Windsurf names the field `serverUrl`, so a `url` entry in either is ignored — and a script that says "Configured" while the client silently has no SenseLab is worse than one that says where to go.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The script is curl-piped by users and edits MCP client configs; regressions could break onboarding, though extensive new tests explicitly guard default and API-key paths.
> 
> **Overview**
> Adds **browser OAuth / hosted MCP** as a first-class install path so users are not forced to create and paste an API key.
> 
> **`install-mcp.sh`** gains `--remote` (writes `{"type":"http","url":…}` to supported clients, skips `uv`/local server install), `--mcp-url` for non-prod endpoints, and `--join <link|token>` (implies remote when no key; prints post-sign-in `amfs_room_redeem` steps without redeeming in the script). **`--remote` + `--api-key`** and **`--join` + `--uninstall`** now **fatal** instead of silently dropping the key. Claude Desktop and Windsurf get **manual connector instructions** (their configs ignore HTTP URL entries); migrating to remote **strips old stdio `senselab` blocks** with verified state via `senselab_entry_state`. Claude Code/Codex use HTTP MCP in remote mode. The **closing message** only claims “restart” when something was actually auto-configured.
> 
> **`docs/guides/mcp.md`** documents `curl | bash -s -- --remote` and `--join`.
> 
> New **`tests/unit/test_install_mcp_script.py`** pins unchanged default/`--api-key` output and covers remote, flags, per-client behavior, and summary/join copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bdd7b149f0ba178f2ed6c58fe3d07f3db4df45d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->