### PR TITLE
Keep a copy of the API key before overwriting it

### DIFF
--- a/install-mcp.sh
+++ b/install-mcp.sh
@@ -284,12 +284,110 @@ ENVJSON
 MCPJSON
 }
 
+# ── Not throwing away the key that is already on disk ────────────────────────
+#
+# The `senselab` block holds AMFS_API_KEY, and the service keeps only a hash of
+# a key, never the key. So the copy in a client's config file is the only copy
+# there is: once this script rewrites or deletes that block, nobody — not the
+# dashboard, not support — can give the same key back, and every other client
+# still pointing at it stops working with no way to repair them.
+#
+# Three paths here do exactly that, and only one of them is asked for in those
+# words. `--uninstall` at least says "remove". `--remote` clears the old stdio
+# entry as a migration. And a plain re-run overwrites, which is the one that
+# actually bites: `curl | bash` with no key downgrades a working keyed install
+# to the free server and takes the key with it, and so does a re-run with a
+# placeholder pasted out of a doc.
+#
+# So copy the file first — but only when there is something to lose, meaning a
+# key on disk that differs from the one going in. A first install, a keyless
+# install over nothing, and an idempotent re-run with the same key all leave no
+# backup behind, because in none of them does a key stop existing.
+
+# The copy itself: where it goes, and saying so.
+#
+# 0600 because the file it came from holds a credential and the directory it
+# lands in may not be private. A failed copy is reported rather than fatal: it
+# almost certainly means the file is read-only, so the write about to follow
+# will fail too and abandoning the install here would only make the message
+# about the wrong thing.
+keep_a_copy_of_the_key() {
+    local file="$1" dest
+    dest="$file.senselab-backup-$(date -u +%Y%m%d%H%M%S)"
+
+    if cp "$file" "$dest" 2>/dev/null; then
+        chmod 600 "$dest" 2>/dev/null || true
+        info "Kept a copy of the API key already in that config: $dest"
+        echo "    SenseLab stores keys hashed and cannot reissue the same one, so"
+        echo "    this copy is the only one left. Delete it once you are sure the"
+        echo "    new connection works."
+    else
+        warn "Could not copy $file before changing it."
+        echo "    The API key in it is about to be replaced, and SenseLab cannot"
+        echo "    hand the same one back. Copy the file yourself if you need it."
+    fi
+}
+
+# Before this script rewrites or deletes a `senselab` block it owns.
+#
+# `incoming` is the key that is about to take its place, empty for a removal or
+# a keyless install — which is why the comparison is against a string and not a
+# flag: "no key going in" and "a different key going in" both lose what is
+# there, and both want a copy.
+backup_key_at_risk() {
+    local config_file="$1" incoming="${2:-}" existing=""
+
+    [[ -f "$config_file" ]] || return 0
+
+    existing="$(python3 -c '
+import json, sys
+
+try:
+    with open(sys.argv[1]) as f:
+        config = json.load(f)
+except (json.JSONDecodeError, OSError, ValueError):
+    sys.exit(0)
+
+entry = (config.get("mcpServers") or {}).get("senselab")
+if isinstance(entry, dict):
+    print((entry.get("env") or {}).get("AMFS_API_KEY") or "")
+' "$config_file" 2>/dev/null || true)"
+
+    if [[ -n "$existing" && "$existing" != "$incoming" ]]; then
+        keep_a_copy_of_the_key "$config_file"
+    fi
+}
+
+# Before asking a client's own CLI to drop the entry.
+#
+# Claude Code and Codex are configured through `claude mcp` and `codex mcp`
+# rather than by writing their files, so there is no block of ours to read and
+# compare. The marker is enough: if AMFS_API_KEY is in the file the CLI keeps,
+# a copy of that file genuinely preserves the key, and if it is not, this says
+# nothing rather than claiming a rescue it did not perform. That also covers
+# being wrong about where a given version of those tools stores it.
+backup_cli_store() {
+    local file="$1" incoming="${2:-}"
+
+    [[ -f "$file" ]] || return 0
+    grep -q "AMFS_API_KEY" "$file" 2>/dev/null || return 0
+    # -F because a key is not a pattern. Re-adding the key already in there
+    # changes nothing, so there is nothing to keep.
+    if [[ -n "$incoming" ]] && grep -qF -- "$incoming" "$file" 2>/dev/null; then
+        return 0
+    fi
+
+    keep_a_copy_of_the_key "$file"
+}
+
 # ── JSON merge (portable, no jq dependency) ──────────────────────────────────
 
 inject_mcp_config() {
     local config_file="$1"
     local amfs_block
     amfs_block="$(build_mcp_json)"
+
+    backup_key_at_risk "$config_file" "$API_KEY"
 
     local dir
     dir="$(dirname "$config_file")"
@@ -379,6 +477,8 @@ remove_mcp_config() {
     if [[ ! -f "$config_file" ]]; then
         return 0
     fi
+
+    backup_key_at_risk "$config_file" ""
 
     python3 -c "
 import json, sys
@@ -675,6 +775,7 @@ configure_client() {
         claude-code)
             if $UNINSTALL; then
                 if command -v claude &>/dev/null; then
+                    backup_cli_store "$HOME/.claude.json"
                     claude mcp remove senselab 2>/dev/null || true
                     success "Removed AMFS from Claude Code"
                 fi
@@ -691,6 +792,7 @@ configure_client() {
                     # runs the OAuth flow itself on first use.
                     args=("mcp" "add" "--transport" "http" "senselab" "$(mcp_url)")
                     # Re-runs stay idempotent; adding a name that exists fails.
+                    backup_cli_store "$HOME/.claude.json"
                     claude mcp remove senselab 2>/dev/null || true
                 else
                     resolve_uvx_path
@@ -715,6 +817,7 @@ configure_client() {
         codex)
             if $UNINSTALL; then
                 if command -v codex &>/dev/null; then
+                    backup_cli_store "$HOME/.codex/config.toml"
                     codex mcp remove senselab 2>/dev/null || true
                     success "Removed AMFS from Codex"
                 fi
@@ -741,7 +844,9 @@ configure_client() {
                         args=("mcp" "add" "senselab" "--env" "AMFS_HTTP_URL=$url" "--env" "AMFS_API_KEY=$API_KEY" "--" "$UVX_PATH" "--refresh" "$pkg")
                     fi
                 fi
-                # Replace any existing entry so re-runs stay idempotent.
+                # Replace any existing entry so re-runs stay idempotent — which
+                # means a re-run with a different key, or none, drops the old one.
+                backup_cli_store "$HOME/.codex/config.toml" "$API_KEY"
                 codex mcp remove senselab 2>/dev/null || true
                 codex "${args[@]}"
                 configured "Configured Codex"
@@ -818,6 +923,16 @@ prompt_clients() {
 
     local action="Configure"
     if $UNINSTALL; then action="Remove AMFS from"; fi
+
+    # Said before the question, because after it the key is already gone. Anyone
+    # uninstalling to reinstall cleanly is about to find out that "cleanly" costs
+    # them a credential, and this is the last moment that is useful to know.
+    if $UNINSTALL; then
+        warn "This takes your API key with it."
+        echo "    SenseLab stores keys hashed, so the same one cannot be reissued."
+        echo "    A copy of any config holding it is kept next to the original."
+        echo ""
+    fi
 
     printf "${BOLD}$action all detected clients? [Y/n/list]:${NC} "
     read -r answer </dev/tty 2>/dev/null || answer="y"

--- a/install-mcp.sh
+++ b/install-mcp.sh
@@ -371,9 +371,23 @@ backup_cli_store() {
 
     [[ -f "$file" ]] || return 0
     grep -q "AMFS_API_KEY" "$file" 2>/dev/null || return 0
-    # -F because a key is not a pattern. Re-adding the key already in there
-    # changes nothing, so there is nothing to keep.
-    if [[ -n "$incoming" ]] && grep -qF -- "$incoming" "$file" 2>/dev/null; then
+
+    # Re-adding the key already in there changes nothing, so there is nothing to
+    # keep — but only the whole stored value counts as "already in there".
+    #
+    # Matching the incoming key as a bare substring reintroduced the bug this
+    # function exists to prevent. A placeholder like `amfs_k` is a substring of
+    # every real key that happens to begin with those characters, so the copy
+    # was skipped and `codex mcp remove` then deleted the only one left. Short
+    # keys are exactly the ones people paste by mistake.
+    #
+    # Both formats these CLIs write quote the value — JSON for Claude Code,
+    # TOML for Codex — so requiring the quotes, on the same line as the name,
+    # compares the value end to end. A form neither branch recognises falls
+    # through to making a copy, which is the direction to be wrong in: a spare
+    # file costs nothing against a credential that cannot be reissued.
+    if [[ -n "$incoming" ]] && grep -F "AMFS_API_KEY" "$file" 2>/dev/null |
+        grep -qF -e "\"$incoming\"" -e "'$incoming'"; then
         return 0
     fi
 

--- a/tests/unit/test_install_mcp_script.py
+++ b/tests/unit/test_install_mcp_script.py
@@ -416,6 +416,295 @@ class TestClientsThatCannotHoldAUrl:
         assert "https://mcp.sense-lab.ai/mcp" in written[0].read_text()
 
 
+class TestTheKeyOnDiskSurvivesBeingReplaced:
+    """The `senselab` block is the only copy of the user's API key.
+
+    SenseLab stores keys hashed, so no part of the product can hand the same one
+    back — a key this script overwrites or deletes is gone, and every client
+    still pointing at it is unrepairable without minting a new one and visiting
+    them all.
+
+    That is not hypothetical. It happened here: an `--uninstall` and then a run
+    carrying a six-character placeholder left a real key unrecoverable. Nothing
+    warned, nothing kept a copy, and the file had been rewritten by the time
+    anyone looked. The three paths that reach it are all normal use — removing
+    an install, migrating one to `--remote`, and re-running the one-liner, which
+    without `--api-key` quietly downgrades a keyed install to the free server.
+
+    So the rule these hold: if a key is on disk and is about to stop being on
+    disk, a copy is made first and its location is said out loud. When nothing
+    is at risk, no copy appears — a backup on every idempotent re-run would
+    train people to ignore them.
+    """
+
+    #: A key long enough to be recognisably real rather than a placeholder.
+    REAL_KEY = "amfs_xZnxjg8Jhl1Sd0liWX2uga_g9qdqgo18xSKDBbMtJaU"
+
+    def _config_path(self, client: str, home: Path, tmp_path: Path) -> Path:
+        fn = {
+            "cursor": "cursor_config_path",
+            "claude-desktop": "claude_desktop_config_path",
+        }[client]
+        return Path(_run("", f"HOME={home!s} {fn}", tmp_path).strip())
+
+    def _keyed_config(
+        self, home: Path, tmp_path: Path, client: str = "cursor"
+    ) -> Path:
+        """A config as a working `--api-key` install would have left it."""
+        home.mkdir(exist_ok=True)
+        path = self._config_path(client, home, tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "mcpServers": {
+                "senselab": {
+                    "command": "/opt/homebrew/bin/uvx",
+                    "args": ["--refresh", "amfs-mcp-server-pro"],
+                    "env": {
+                        "AMFS_HTTP_URL": "https://amfs-login.sense-lab.ai",
+                        "AMFS_API_KEY": self.REAL_KEY,
+                    },
+                },
+                "somebody-else": {"command": "node", "args": ["other.js"]},
+            }
+        }, indent=4))
+        return path
+
+    def _configure(
+        self, client: str, args: str, tmp_path: Path, home: Path, extra: str = ""
+    ) -> str:
+        return _run(
+            args,
+            f"{extra}HOME={home!s} configure_client {client} 2>&1 || true",
+            tmp_path,
+        )
+
+    def _backups(self, path: Path) -> list[Path]:
+        return sorted(path.parent.glob(f"{path.name}.senselab-backup-*"))
+
+    def _the_one_backup(self, path: Path) -> Path:
+        found = self._backups(path)
+        assert len(found) == 1, f"expected one copy, found {found}"
+        return found[0]
+
+    def test_an_uninstall_keeps_the_key_it_takes_away(self, tmp_path: Path) -> None:
+        """Anyone uninstalling to reinstall cleanly is about to need this."""
+        home = tmp_path / "home"
+        path = self._keyed_config(home, tmp_path)
+
+        out = self._configure("cursor", "--uninstall", tmp_path, home)
+
+        assert self.REAL_KEY in self._the_one_backup(path).read_text()
+        assert "senselab" not in path.read_text()
+        assert "Kept a copy" in out
+
+    def test_a_keyless_rerun_keeps_the_key_it_downgrades(
+        self, tmp_path: Path
+    ) -> None:
+        """The incident, exactly: `curl | bash` over a working keyed install.
+
+        No flags means the free local server and no `env` block at all, so the
+        key is dropped by a run whose output otherwise reads like a success.
+        """
+        home = tmp_path / "home"
+        path = self._keyed_config(home, tmp_path)
+
+        self._configure("cursor", "", tmp_path, home)
+
+        assert self.REAL_KEY in self._the_one_backup(path).read_text()
+        assert self.REAL_KEY not in path.read_text()
+
+    def test_a_rerun_with_a_different_key_keeps_the_old_one(
+        self, tmp_path: Path
+    ) -> None:
+        """A placeholder pasted out of a doc, or a second account's key."""
+        home = tmp_path / "home"
+        path = self._keyed_config(home, tmp_path)
+
+        self._configure("cursor", "--api-key amfs_k", tmp_path, home)
+
+        assert self.REAL_KEY in self._the_one_backup(path).read_text()
+        assert "amfs_k" in json.loads(path.read_text())[
+            "mcpServers"]["senselab"]["env"]["AMFS_API_KEY"]
+
+    def test_the_remote_migration_keeps_the_key_it_clears(
+        self, tmp_path: Path
+    ) -> None:
+        """`--remote` deletes the stdio block as a migration, key and all.
+
+        The user asked to switch endpoints, not to give up a credential, and
+        going back afterwards is what needs it.
+        """
+        home = tmp_path / "home"
+        path = self._keyed_config(home, tmp_path, client="claude-desktop")
+
+        out = self._configure("claude-desktop", "--remote", tmp_path, home)
+
+        assert self.REAL_KEY in self._the_one_backup(path).read_text()
+        assert "Removed the old local" in out
+
+    def test_a_rerun_with_the_same_key_leaves_nothing_behind(
+        self, tmp_path: Path
+    ) -> None:
+        """Re-running the wizard's own line is how people repair a config.
+
+        Nothing stops existing, so a copy would be litter — and a directory of
+        backups nobody needed is how the one that matters gets ignored.
+        """
+        home = tmp_path / "home"
+        path = self._keyed_config(home, tmp_path)
+
+        out = self._configure(
+            "cursor", f"--api-key {self.REAL_KEY}", tmp_path, home
+        )
+
+        assert self._backups(path) == []
+        assert "Kept a copy" not in out
+
+    def test_a_first_install_leaves_nothing_behind(self, tmp_path: Path) -> None:
+        home = tmp_path / "home"
+        home.mkdir()
+
+        out = self._configure("cursor", f"--api-key {self.REAL_KEY}", tmp_path, home)
+
+        path = self._config_path("cursor", home, tmp_path)
+        assert self._backups(path) == []
+        assert "Kept a copy" not in out
+
+    def test_a_config_holding_no_key_is_not_copied(self, tmp_path: Path) -> None:
+        """The free local server has no `env`, so there is nothing to lose."""
+        home = tmp_path / "home"
+        home.mkdir()
+        path = self._config_path("cursor", home, tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "mcpServers": {"senselab": {"command": "uvx", "args": ["amfs-mcp-server"]}}
+        }))
+
+        out = self._configure("cursor", "--uninstall", tmp_path, home)
+
+        assert self._backups(path) == []
+        assert "Kept a copy" not in out
+
+    def test_the_copy_is_not_left_readable_by_everyone(
+        self, tmp_path: Path
+    ) -> None:
+        """It is a credential in a directory that may not be private."""
+        home = tmp_path / "home"
+        path = self._keyed_config(home, tmp_path)
+
+        self._configure("cursor", "--uninstall", tmp_path, home)
+
+        assert self._the_one_backup(path).stat().st_mode & 0o777 == 0o600
+
+    def test_it_says_where_the_copy_is_and_why_it_matters(
+        self, tmp_path: Path
+    ) -> None:
+        """A backup nobody is told about is not a rescue.
+
+        The path has to be in the output because the name carries a timestamp,
+        and the reason has to be there because "just make another one" is the
+        obvious assumption and it is wrong — the same key never comes back.
+        """
+        home = tmp_path / "home"
+        path = self._keyed_config(home, tmp_path)
+
+        out = self._configure("cursor", "--uninstall", tmp_path, home)
+
+        assert str(self._the_one_backup(path)) in out
+        assert "cannot reissue the same one" in out
+
+    def test_a_file_it_cannot_read_is_not_claimed_as_saved(
+        self, tmp_path: Path
+    ) -> None:
+        """An unparseable config is left alone by the removal, so nothing is
+        lost and nothing needs keeping — but claiming a copy that does not exist
+        would be worse than saying nothing."""
+        home = tmp_path / "home"
+        home.mkdir()
+        path = self._config_path("cursor", home, tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"mcpServers": {"senselab": {"env": {,,,')
+
+        out = self._configure("cursor", "--uninstall", tmp_path, home)
+
+        assert self._backups(path) == []
+        assert "Kept a copy" not in out
+
+    def test_a_copy_that_fails_says_so_instead_of_going_quiet(
+        self, tmp_path: Path
+    ) -> None:
+        """The write that follows will probably fail too, but not certainly —
+        and a silent failure here is the exact shape of the original loss."""
+        home = tmp_path / "home"
+        self._keyed_config(home, tmp_path)
+
+        out = self._configure(
+            "cursor", "--uninstall", tmp_path, home, extra="cp() { return 1; }\n"
+        )
+
+        assert "Could not copy" in out
+        assert "cannot" in out and "hand the same one back" in out
+
+    def test_the_uninstall_prompt_says_it_before_asking(
+        self, tmp_path: Path
+    ) -> None:
+        """Order is the whole point: after the answer, the key is already gone."""
+        home = tmp_path / "home"
+        home.mkdir()
+
+        out = _run(
+            "--uninstall",
+            "detect_clients() { DETECTED_CLIENTS=(cursor); }\n"
+            "configure_client() { :; }\n"
+            f"HOME={home!s} prompt_clients 2>&1 || true",
+            tmp_path,
+        )
+
+        assert "takes your API key with it" in out
+        assert out.index("takes your API key") < out.index("Remove AMFS from all")
+
+    def test_a_cli_managed_store_is_kept_when_it_holds_the_key(
+        self, tmp_path: Path
+    ) -> None:
+        """Claude Code is configured through its own CLI, not by writing files.
+
+        There is no block of ours to compare, so the marker is the test: finding
+        AMFS_API_KEY in the file that CLI keeps means a copy really does preserve
+        the key, and not finding it means saying nothing.
+        """
+        home = tmp_path / "home"
+        home.mkdir()
+        store = home / ".claude.json"
+        store.write_text(json.dumps({
+            "mcpServers": {"senselab": {"env": {"AMFS_API_KEY": self.REAL_KEY}}}
+        }))
+
+        out = self._configure(
+            "claude-code", "--uninstall", tmp_path, home,
+            extra="command() { :; }\nclaude() { :; }\n",
+        )
+
+        assert self.REAL_KEY in self._the_one_backup(store).read_text()
+        assert "Kept a copy" in out
+
+    def test_a_cli_managed_store_without_the_key_is_left_alone(
+        self, tmp_path: Path
+    ) -> None:
+        """Where a given version of those tools keeps it is not ours to assume."""
+        home = tmp_path / "home"
+        home.mkdir()
+        store = home / ".claude.json"
+        store.write_text(json.dumps({"projects": {"/tmp/x": {"allowedTools": []}}}))
+
+        out = self._configure(
+            "claude-code", "--uninstall", tmp_path, home,
+            extra="command() { :; }\nclaude() { :; }\n",
+        )
+
+        assert self._backups(store) == []
+        assert "Kept a copy" not in out
+
+
 class TestTheClosingSummaryDoesNotOverclaim:
     """A full run, end to end, for what the last lines say happened.
 

--- a/tests/unit/test_install_mcp_script.py
+++ b/tests/unit/test_install_mcp_script.py
@@ -687,6 +687,72 @@ class TestTheKeyOnDiskSurvivesBeingReplaced:
         assert self.REAL_KEY in self._the_one_backup(store).read_text()
         assert "Kept a copy" in out
 
+    def _cli_store_decision(
+        self, stored: str, incoming: str, tmp_path: Path, quote: str = '"'
+    ) -> tuple[str, list[Path]]:
+        """Ask `backup_cli_store` directly, for one stored/incoming pair.
+
+        The two CLIs own these files, so the shape that matters is a line
+        carrying the name and the quoted value — JSON uses `:`, TOML uses `=`,
+        and either may quote with `'`. Calling the function rather than a whole
+        client path is what makes the quoting the only variable.
+        """
+        store = tmp_path / "cli-store"
+        store.write_text(
+            f"  AMFS_API_KEY = {quote}{stored}{quote}\n"
+            '  command = "uvx"\n  args = ["--refresh", "amfs-mcp-server-pro"]\n'
+        )
+        out = _run("", f'backup_cli_store {store!s} "{incoming}" 2>&1 || true', tmp_path)
+        return out, self._backups(store)
+
+    def test_a_shorter_key_is_not_mistaken_for_the_one_stored(
+        self, tmp_path: Path
+    ) -> None:
+        """The bug this function exists to prevent, reintroduced inside it.
+
+        Matching the incoming key as a bare substring meant a placeholder like
+        `amfs_k` counted as already present in any real key beginning with those
+        characters. The copy was skipped, `codex mcp remove` deleted the entry,
+        and the key was gone — which is the original incident exactly, and short
+        keys are the ones people paste by mistake.
+        """
+        stored = "amfs_kREALKEYcontinuesWellPastThePlaceholder"
+
+        out, backups = self._cli_store_decision(stored, "amfs_k", tmp_path)
+
+        assert len(backups) == 1, "a prefix must not count as the stored key"
+        assert stored in backups[0].read_text()
+        assert "Kept a copy" in out
+
+    def test_a_different_key_entirely_is_kept(self, tmp_path: Path) -> None:
+        out, backups = self._cli_store_decision(
+            self.REAL_KEY, "amfs_someOtherAccountsKey", tmp_path
+        )
+        assert len(backups) == 1
+        assert self.REAL_KEY in backups[0].read_text()
+        assert "Kept a copy" in out
+
+    @pytest.mark.parametrize("quote", ['"', "'"])
+    def test_re_adding_the_same_key_keeps_nothing(
+        self, quote: str, tmp_path: Path
+    ) -> None:
+        """Nothing stops existing, in either quoting style those CLIs use."""
+        out, backups = self._cli_store_decision(
+            self.REAL_KEY, self.REAL_KEY, tmp_path, quote=quote
+        )
+        assert backups == []
+        assert "Kept a copy" not in out
+
+    def test_a_longer_key_containing_the_stored_one_is_kept(
+        self, tmp_path: Path
+    ) -> None:
+        """The mirror image, in case the comparison is ever loosened again."""
+        stored = "amfs_short"
+
+        _, backups = self._cli_store_decision(stored, f"{stored}AndThenSome", tmp_path)
+
+        assert len(backups) == 1
+
     def test_a_cli_managed_store_without_the_key_is_left_alone(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Why

The `senselab` block in a client's MCP config is the **only** copy of a user's API key — the service stores an Argon2 hash (`_ph.hash(raw_key)` in `amfs_tenant/repository.py`) and cannot reissue the same key. Anything here that rewrites or deletes that block destroys a credential nobody can hand back, and leaves every other client still pointing at it broken with no way to repair them.

This is not hypothetical. It happened during the work on #317: an `--uninstall` run against a real config, then a run carrying the six-character placeholder `amfs_k` from a doc. Nothing warned, nothing kept a copy, and the file had already been rewritten by the time anyone looked.

Three paths reach it, and only one of them says "remove":

| Path | What the user asked for | What happens to the key |
| --- | --- | --- |
| `--uninstall` | remove the install | deleted |
| `--remote` | switch endpoints | deleted as part of the stdio migration |
| `curl \| bash` (no key) | install/repair | overwritten — downgrades a keyed install to the free server |

The third is the dangerous one: it reads as a success and takes the key silently.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Installer-only, defensive credential preservation with broad unit tests; no server or auth logic changes, though users may accumulate backup files next to configs.
> 
> **Overview**
> **Prevents silent loss of `AMFS_API_KEY`** when `install-mcp.sh` rewrites or removes the `senselab` MCP block — uninstall, `--remote` migration, keyless `curl | bash`, or a re-run with a different key.
> 
> Before touching JSON configs, **`backup_key_at_risk`** copies the file to a timestamped `*.senselab-backup-*` sibling (mode **0600**) when an on-disk key differs from the incoming one; idempotent same-key re-runs and first installs skip backup. **`backup_cli_store`** does the same for Claude Code (`~/.claude.json`) and Codex (`~/.codex/config.toml`) before `mcp remove`, using **quoted full-value** matching so short placeholders like `amfs_k` are not treated as equal to a longer stored key.
> 
> Interactive **`--uninstall`** now warns that keys cannot be reissued **before** the confirmation prompt. Extensive unit tests cover uninstall, downgrade, remote migration, CLI stores, copy failures, and messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81486aab33b062f21f953265aadf8000fe2d69d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->