### PR TITLE
Accept API key via Authorization: Bearer in the REST API (v0.3.15)

### DIFF
--- a/packages/http-server/pyproject.toml
+++ b/packages/http-server/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "amfs-http-server"
-version = "0.3.14"
+version = "0.3.15"
 description = "AMFS HTTP/REST API server with SSE support"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 dependencies = [
     # The trace endpoints call amfs_core.capture and read/write task_input, and
     # 0.3.14 / 0.5.7 add the action half: scan_captured_arguments and ToolCall.
-    "amfs>=0.5.7",
+    "amfs>=0.5.8",
     "amfs-core>=0.3.14",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.32",

--- a/packages/http-server/src/amfs_http/auth.py
+++ b/packages/http-server/src/amfs_http/auth.py
@@ -9,11 +9,18 @@ import threading
 import time
 
 from fastapi import HTTPException, Security, status
-from fastapi.security import APIKeyHeader
+from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
 
 logger = logging.getLogger(__name__)
 
 API_KEY_HEADER = APIKeyHeader(name="X-AMFS-API-Key", auto_error=False)
+
+# Also accept the key as `Authorization: Bearer <amfs_key>`. Credential-brokering
+# gateways (e.g. Fly.io Sprites connectors) store the key once and inject it as a
+# bearer token, so they can't set our custom X-AMFS-API-Key header. auto_error is
+# off so a missing/other-scheme Authorization header falls through to the API-key
+# header rather than 403-ing before verify_api_key runs.
+BEARER_SCHEME = HTTPBearer(auto_error=False)
 
 _AUTH_CACHE_TTL = 120.0
 _auth_cache: dict[str, float] = {}
@@ -79,7 +86,15 @@ def generate_api_key() -> str:
     return f"amfs_{secrets.token_urlsafe(32)}"
 
 
-async def verify_api_key(api_key: str | None = Security(API_KEY_HEADER)) -> str | None:
+async def verify_api_key(
+    api_key: str | None = Security(API_KEY_HEADER),
+    bearer: HTTPAuthorizationCredentials | None = Security(BEARER_SCHEME),
+) -> str | None:
+    # X-AMFS-API-Key is canonical; fall back to the bearer token so gateways that
+    # can only inject `Authorization: Bearer <key>` authenticate the same way.
+    if not api_key and bearer is not None:
+        api_key = bearer.credentials
+
     env_keys = get_api_keys()
     if not env_keys:
         if not os.environ.get("AMFS_POSTGRES_DSN"):

--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-mcp-server"
-version = "0.7.13"
+version = "0.7.15"
 description = "AMFS MCP Server — expose Agent Memory as MCP tools for Cursor and Claude Code"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     # TypeError on the one call agents are told to make at the end of every task.
     # An unbounded dependency is how the equivalent skew reached Pro users.
     # 0.5.7 adds AgentMemory.record_action, which amfs_record_action calls.
-    "amfs>=0.5.7",
+    "amfs>=0.5.8",
     # 0.1.10 for the same reason, one layer down: this adapter builds the
     # /outcomes body field by field, and anything earlier does not copy
     # tool_calls into it. The floor was 0.1.2, which a cached 0.1.9 satisfies —

--- a/tests/unit/test_bearer_auth.py
+++ b/tests/unit/test_bearer_auth.py
@@ -1,0 +1,69 @@
+"""The REST API accepts its key from X-AMFS-API-Key *or* Authorization: Bearer.
+
+X-AMFS-API-Key is the canonical header and every existing SDK/HttpAdapter client
+keeps working unchanged. Bearer is an additive fallback: credential-brokering
+gateways (e.g. Fly.io Sprites connectors) store the key once and inject it as
+``Authorization: Bearer <amfs_key>``, and cannot set a custom header. These tests
+pin that both sources authenticate, that the custom header wins when both are
+present, and that a bad/absent credential still 401s.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+from fastapi import HTTPException  # noqa: E402
+from fastapi.security import HTTPAuthorizationCredentials  # noqa: E402
+
+from amfs_http.auth import verify_api_key  # noqa: E402
+
+KEY = "amfs_testkey_123"
+
+
+def _bearer(token: str) -> HTTPAuthorizationCredentials:
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+
+def _call(**kwargs) -> str | None:
+    return asyncio.run(verify_api_key(**kwargs))
+
+
+@pytest.fixture()
+def keyed_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enforce a known env key and no DB, so only the header logic is exercised."""
+    monkeypatch.setenv("AMFS_API_KEYS", KEY)
+    monkeypatch.delenv("AMFS_POSTGRES_DSN", raising=False)
+
+
+class TestBearerFallback:
+    def test_custom_header_still_authenticates(self, keyed_env) -> None:
+        assert _call(api_key=KEY, bearer=None) == KEY
+
+    def test_bearer_authenticates(self, keyed_env) -> None:
+        assert _call(api_key=None, bearer=_bearer(KEY)) == KEY
+
+    def test_custom_header_wins_over_bearer(self, keyed_env) -> None:
+        # A valid X-AMFS-API-Key is used even if a (wrong) bearer is also present.
+        assert _call(api_key=KEY, bearer=_bearer("wrong")) == KEY
+
+    def test_bad_bearer_is_rejected(self, keyed_env) -> None:
+        with pytest.raises(HTTPException) as exc:
+            _call(api_key=None, bearer=_bearer("amfs_not_a_real_key"))
+        assert exc.value.status_code == 401
+
+    def test_no_credential_is_rejected(self, keyed_env) -> None:
+        with pytest.raises(HTTPException) as exc:
+            _call(api_key=None, bearer=None)
+        assert exc.value.status_code == 401
+
+
+class TestOpenModeUnaffected:
+    def test_bearer_does_not_break_open_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # No env keys and no DB DSN => open mode returns None regardless of headers.
+        monkeypatch.delenv("AMFS_API_KEYS", raising=False)
+        monkeypatch.delenv("AMFS_POSTGRES_DSN", raising=False)
+        assert _call(api_key=None, bearer=_bearer(KEY)) is None
+        assert _call(api_key=None, bearer=None) is None


### PR DESCRIPTION
## Summary
- REST `verify_api_key` now accepts the API key via `Authorization: Bearer` as a fallback to the canonical `X-AMFS-API-Key` header. This is **additive** — `X-AMFS-API-Key` still takes precedence and existing SDK/HttpAdapter clients are unchanged. It lets credential-brokering gateways (e.g. Fly.io Sprites connectors) that can only inject a bearer token authenticate against the REST API.
- Raise the `amfs` dependency floor to `0.5.8` in `amfs-mcp-server` and `amfs-http-server` to match the `amfs` version in the repo (prevents `uvx` resolving a stale `amfs` that lacks features the current code calls; enforced by `test_dependency_floors`).
- Bump `amfs-http-server` to `0.3.15`.

## Test plan
- [x] New `tests/unit/test_bearer_auth.py` (6 cases): both header sources authenticate, `X-AMFS-API-Key` wins on conflict, bad/absent credential 401s, open mode unaffected.
- [x] Existing http-server route/auth tests (50) pass — the added `HTTPBearer` scheme doesn't disturb existing routes.
- [x] `test_dependency_floors` 9/9 pass.

## Notes
The live dev backend's auth gate is the Pro `_bearer_api_key` override (handled separately in `amfs-internal`); this OSS change covers self-hosters running bare `amfs-http`, and keeps the two front doors consistent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication: a new accepted credential source on the REST API. Behavior is additive and covered by tests, but a mistake here would widen or break access.
> 
> **Overview**
> REST auth now accepts the AMFS API key as `Authorization: Bearer` in addition to the canonical `X-AMFS-API-Key` header, so credential-brokering gateways that can only inject a bearer token can authenticate. The custom header still wins when both are present; existing SDK clients are unchanged. Open mode (no env keys, no DB) is unaffected.
> 
> Also raises the `amfs` floor to `>=0.5.8` in `amfs-http-server` and `amfs-mcp-server`, and bumps the HTTP server to `0.3.15`. New unit tests cover both sources, header precedence, 401s, and open mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3ca4d4b739cef05d1e36b86dd36d39c642fe197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->