### PR TITLE
Answer origin root with 200 for connector/gateway validators

### DIFF
--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -636,6 +636,16 @@ def _health_payload() -> dict[str, str]:
     return payload
 
 
+@app.get("/")
+async def root() -> dict[str, str]:
+    # A reachable, unauthenticated 200 at the origin root. Generic API gateways
+    # and connector validators (e.g. Fly.io Sprites' custom_api "test request")
+    # probe base_url/ to confirm the service is live before saving a connector;
+    # without this they get a 404 and refuse the connector. Returns the same
+    # health payload as /health.
+    return _health_payload()
+
+
 @app.get("/health")
 async def health() -> dict[str, str]:
     return _health_payload()

--- a/tests/unit/test_root_route.py
+++ b/tests/unit/test_root_route.py
@@ -1,0 +1,36 @@
+"""The origin root answers 200 without auth.
+
+Generic API gateways and connector validators (e.g. Fly.io Sprites' custom_api
+"test request") probe ``base_url/`` to confirm the service is live before saving
+a connector. A 404 there makes them refuse the connector, so the root must be a
+reachable, unauthenticated 200 — the same contract as ``/health``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+from fastapi.testclient import TestClient  # noqa: E402
+
+import amfs_http.server as server  # noqa: E402
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(server.app)
+
+
+def test_root_returns_200_without_auth(client: TestClient) -> None:
+    resp = client.get("/")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    # Reports the same payload as /health so validators see a live service.
+    assert body == client.get("/health").json()
+
+
+def test_root_needs_no_api_key(client: TestClient) -> None:
+    # No X-AMFS-API-Key / Authorization header at all: still 200. The route is
+    # outside the /api/ prefix that carries auth, so it never reaches the gate.
+    assert client.get("/").status_code == 200


### PR DESCRIPTION
## Why
Provisioning SenseLab as a Fly.io Sprites `custom_api` connector fails with `{"error":"API key validation failed"}`. The cause isn't auth (Bearer works on dev) — Sprites' `custom_api` **test request** probes `base_url/` before saving, and SenseLab answered **404** at the root (only `/health` and `/api/v1/*` existed). Same reason the dashboard "Test Connection" 404'd.

## What
Add an unauthenticated `GET /` that returns the same payload as `/health`.

## Why it's safe for existing clients
- The route is **outside the `/api/` prefix**. The Pro tenant/auth/metering middleware early-returns for any non-`/api/` path (`if not request.url.path.startswith("/api/"): return await call_next(request)`), so it never touches `/`.
- Every real client — `amfs-mcp-server`, `amfs-mcp-server-pro`, the SDK, the HTTP adapter — uses `/api/v1/*`, which is unchanged. Nothing currently depends on `/` returning 404 (confirmed: `/`→404, `/health`→200, no `401`).
- Purely additive; rides in the already-unpublished `amfs-http-server` `0.3.15`.

## Reaching dev
The dev Pro image builds the OSS http-server from source (`COPY amfs/packages/http-server` + `pip install ./packages/http-server`), so this lands on the dev env on the next rebuild after merging to `dev` — no PyPI publish needed.

## Tests
`tests/unit/test_root_route.py`: `GET /` returns 200 without auth and matches `/health`. Passing locally alongside `test_bearer_auth.py` (8 passed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive liveness route that only returns the existing health/version payload; it does not change auth on `/api/` or expose memory data.
> 
> **Overview**
> Adds an unauthenticated `GET /` that returns the same payload as `/health`, so gateway/connector validators that probe `base_url/` (e.g. Fly.io Sprites `custom_api`) get 200 instead of 404 and can save the connector.
> 
> The route sits outside `/api/` and does not use `verify_api_key`, matching the existing `/health` contract. Real clients still use `/api/v1/*`. Unit tests cover 200 without an API key and payload equality with `/health`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a50b6837180b9061512df794fe0f8a8799ed3be3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->