### PR TITLE
Bulk read, server-side aggregation, and auto-maintained room index

### DIFF
--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -84,6 +84,8 @@ After setup, your AI agents have tools across five categories:
 | `amfs_search` | Search entries with filters and progressive retrieval (`depth`: 1=Hot, 2=+Warm, 3=all) |
 | `amfs_retrieve` | Natural language retrieval with semantic + recency + confidence scoring |
 | `amfs_list` | List entries for an entity |
+| `amfs_export` | Bulk-fetch full (untruncated) entry values for an entity to a local file, with an inline fallback for small sets — the fast path for reading a whole room/entity without per-entry calls or context truncation |
+| `amfs_aggregate` | Compute a number over an entity's records server-side (`count`/`sum`/`mean`/`min`/`max`/`stats`, optional `group_by` and `row_path`) without pulling records into context |
 | `amfs_stats` | Get a memory overview (entry counts, outcome counts) |
 | `amfs_history` | Retrieve version history of an entry with optional time range |
 | `amfs_graph_neighbors` | Explore the knowledge graph around an entity |
@@ -408,6 +410,26 @@ For non-IDE environments (CI bots, deploy scripts), set `AMFS_AGENT_ID`:
 8. **Outcome committed** — `amfs_commit_outcome` snapshots the full decision trace (all reads, writes, and contexts) and back-propagates confidence.
 9. **Traces persist** — `amfs_list_traces` and `amfs_get_trace` let future agents learn from past decisions.
 10. **Knowledge compounds** — The next agent starts with compiled context, cross-agent reads, and full decision history.
+
+### Working with data-heavy entities and rooms
+
+When an entity or room holds a lot of structured data (hundreds of batch
+entries, thousands of records), do **not** list-and-read every entry — that
+truncates values, floods context, and does not survive compaction. Instead:
+
+1. **Orient** — read the entity digest via `amfs_briefing`. For a room-scoped
+   entity it now carries a `schema_profile` (which fields exist, their types and
+   ranges, `row_path` candidates) and `materialized_aggregates`, so you know the
+   shape before reading anything.
+2. **Compute** — call `amfs_aggregate` for the numbers you actually need
+   (counts, sums, means, group-by). The reduction happens server-side; records
+   never enter your context.
+3. **Only if you need the raw rows** — call `amfs_export` to spool the full,
+   untruncated values to a local file and process them there.
+
+This turns what used to be dozens of truncated per-entry reads into two or three
+calls. Inside a SenseLab room, the room-wide equivalents `amfs_room_aggregate`
+and `amfs_room_schema` span every topic in the room in a single call.
 
 ### Example Scenario
 

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -420,7 +420,10 @@ truncates values, floods context, and does not survive compaction. Instead:
 1. **Orient** — read the entity digest via `amfs_briefing`. For a room-scoped
    entity it now carries a `schema_profile` (which fields exist, their types and
    ranges, `row_path` candidates) and `materialized_aggregates`, so you know the
-   shape before reading anything.
+   shape before reading anything. The digest is compiled from a bounded,
+   top-confidence slice of entries; for a large entity these rollups are a
+   sample (flagged with `sampled: true` and a `note`), so treat `amfs_aggregate`
+   — which runs over the full set — as authoritative for exact numbers.
 2. **Compute** — call `amfs_aggregate` for the numbers you actually need
    (counts, sums, means, group-by). The reduction happens server-side; records
    never enter your context.

--- a/docs/reference/sdk-mcp-parity.md
+++ b/docs/reference/sdk-mcp-parity.md
@@ -34,6 +34,8 @@ AMFS exposes memory three ways: the **MCP server** (for agents), the **Python SD
 | History | `amfs_history` | `history` | `history`, `historyAsync` |
 | Stats | `amfs_stats` | `stats` | `stats`, `statsAsync` |
 | Graph neighbors | `amfs_graph_neighbors` | `graph_neighbors` (adapter) | `graphNeighborsAsync` |
+| Bulk export | `amfs_export` | — (use `list`) | — |
+| Server-side aggregate | `amfs_aggregate` | — (HTTP `POST /api/v1/aggregate`) | — |
 
 ## Tracing & outcomes
 
@@ -66,6 +68,8 @@ These MCP tools are **not** mirrored 1:1 in the SDKs, by design. They are either
 | `amfs_export_training_data` | Pro (HTTP-proxied) | Calls `GET /api/v1/pro/export`. Exposed on the TS `HttpAdapter` as `exportTrainingDataAsync`; Python calls the endpoint directly. |
 | `amfs_room_*`, `amfs_negotiate_*` | Pro (rooms backend) | Multi-agent rooms/negotiation require the Pro rooms service. The TS SDK has `room*`/`negotiate*` methods; `amfs_negotiate_cancel` has **no OSS backend endpoint**, so it's not added as an SDK method (it would be a broken stub). |
 | `amfs_verify`, `amfs_commit_batch`, `amfs_merge_base` | SDK-covered | Present in the Python SDK (`verify`, `transaction`, `common_ancestor`) and TS SDK (`verify`, `transaction`, `commonAncestor`). |
+| `amfs_export` | MCP-only | Spools full untruncated values to a **local file** on the MCP client's machine — a file-system convenience that only makes sense in-process. SDK callers already have `list`/`read` returning full values with no truncation, so there is nothing to mirror. |
+| `amfs_aggregate` | MCP-backed by OSS endpoint | Reduces server-side via `POST /api/v1/aggregate` (visibility-filtered before the reduce). SDK callers can hit the same endpoint through the `HttpAdapter`; a dedicated `aggregate` method is not yet exposed. |
 
 {: .warning }
 **Consolidation contract caveat.** Two consolidation tools disagree with the API they proxy: `amfs_consolidate(dry_run=True)` is not honoured as a preview by the handler (it performs a real run), and `amfs_consolidation_candidates` requires an `entity_path` the tool doesn't always send. Until the server contract is fixed, prefer `amfs_consolidation_candidates(entity_path=...)` for previews and avoid relying on `dry_run`. SDK wrappers forward these params but inherit the same server behavior.

--- a/packages/agent-guide/reference.md
+++ b/packages/agent-guide/reference.md
@@ -91,6 +91,33 @@ List entries for an entity.
 |:----------|:-----|:---------|:------------|
 | `entity_path` | `str` | No | Scope to entity (omit for all) |
 
+### amfs_export
+
+Bulk-fetch full (untruncated) entry values for an entity. Spools to a local file
+when the payload is large, with an inline fallback for small sets. Use this
+instead of listing-and-reading every entry in a data-heavy entity or room.
+
+| Parameter | Type | Required | Description |
+|:----------|:-----|:---------|:------------|
+| `entity_path` | `str` | Yes | Entity to export |
+| `format` | `str` | No | `"jsonl"` (default) or `"json"` |
+| `row_path` | `str` | No | Dotted field holding a list to flatten into rows (e.g. `"listings"`) |
+| `inline_char_budget` | `int` | No | Return inline instead of writing a file when the payload fits this budget |
+
+### amfs_aggregate
+
+Compute a number over an entity's records **server-side**, without pulling
+records into context. Non-numeric values are ignored for numeric ops (never
+coerced to zero); `n` reports how many rows actually contributed.
+
+| Parameter | Type | Required | Description |
+|:----------|:-----|:---------|:------------|
+| `entity_path` | `str` | Yes | Entity to aggregate over |
+| `op` | `str` | No | `"count"` (default), `"sum"`, `"mean"`, `"min"`, `"max"`, `"stats"` |
+| `field` | `str` | No | Dotted field for numeric ops (e.g. `"price"`) — required unless `op="count"` |
+| `group_by` | `str` | No | Dotted field to group results by |
+| `row_path` | `str` | No | Dotted field holding a list to flatten into rows first |
+
 ### amfs_history
 
 Retrieve version history of an entry.

--- a/packages/core/src/amfs_core/aggregates.py
+++ b/packages/core/src/amfs_core/aggregates.py
@@ -180,6 +180,279 @@ def extended_stats_from_entries(entries: "list[MemoryEntry]") -> dict:
     }
 
 
+# ── Bulk aggregation + schema profiling over structured entry values ───
+# These power three things that share one implementation so they can never
+# disagree: the server-side /api/v1/aggregate endpoint, the MCP amfs_aggregate
+# local fallback, and the room-index schema profile carried on entity digests.
+# The input is a list of MemoryEntry whose values are records (dicts) or JSON
+# arrays of records; the caller is responsible for having already scoped and
+# visibility-filtered the entries.
+
+AGGREGATE_OPS = ("count", "sum", "mean", "min", "max", "stats")
+_DEFAULT_MAX_ENUM = 25
+
+
+def coerce_value(value: object) -> object:
+    """Return a structured value, parsing JSON strings when possible.
+
+    Entry values arrive either already parsed (Postgres JSONB / the HTTP
+    response shape) or as JSON strings; callers must handle both, so this is
+    the single coercion point.
+    """
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except (json.JSONDecodeError, ValueError):
+            return value
+    return value
+
+
+def _get_path(row: object, path: str) -> object:
+    """Dotted-path getter over dict rows; returns None if any segment misses."""
+    cur = row
+    for part in path.split("."):
+        if isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        else:
+            return None
+    return cur
+
+
+def iter_rows(entries: "list[MemoryEntry]", row_path: str | None = None) -> list:
+    """Flatten entries into the records to aggregate over.
+
+    Without ``row_path`` each entry's coerced value is one row (or, if it is a
+    list, each element is a row). With ``row_path`` the value at that dotted
+    path is expected to be a list — one row per element — which is how a batch
+    entry like ``{"listings": [...]}`` fans out into per-listing rows.
+    """
+    rows: list = []
+    for entry in entries:
+        val = coerce_value(getattr(entry, "value", entry))
+        if row_path:
+            target = _get_path(val, row_path) if isinstance(val, dict) else None
+            if isinstance(target, list):
+                rows.extend(target)
+            elif target is not None:
+                rows.append(target)
+        elif isinstance(val, list):
+            rows.extend(val)
+        else:
+            rows.append(val)
+    return rows
+
+
+def _to_number(x: object) -> float | None:
+    """Coerce to a number, treating bools and non-numeric strings as absent."""
+    if isinstance(x, bool):
+        return None
+    if isinstance(x, (int, float)):
+        return x
+    if isinstance(x, str):
+        try:
+            return float(x)
+        except ValueError:
+            return None
+    return None
+
+
+def _numeric_summary(values: list[float]) -> dict:
+    if not values:
+        return {"n": 0, "sum": 0, "mean": None, "min": None, "max": None}
+    total = sum(values)
+    return {
+        "n": len(values),
+        "sum": total,
+        "mean": total / len(values),
+        "min": min(values),
+        "max": max(values),
+    }
+
+
+def _group_key(g: object) -> str:
+    if g is None:
+        return "null"
+    if isinstance(g, (str, int, float, bool)):
+        return str(g)
+    return json.dumps(g, default=str, sort_keys=True)
+
+
+def aggregate_entries(
+    entries: "list[MemoryEntry]",
+    *,
+    op: str,
+    field: str | None = None,
+    group_by: str | None = None,
+    row_path: str | None = None,
+) -> dict:
+    """Compute one aggregate over the records inside ``entries``.
+
+    ``op`` is one of AGGREGATE_OPS. Numeric ops (sum/mean/min/max/stats) require
+    ``field``; ``count`` does not. ``group_by`` produces one result per distinct
+    value of that field. ``row_path`` flattens a list-valued field into rows
+    first. Non-numeric field values are ignored for numeric ops (never coerced
+    to zero), so ``n`` reports how many rows actually contributed.
+    """
+    if op not in AGGREGATE_OPS:
+        raise ValueError(f"unknown op {op!r}; expected one of {list(AGGREGATE_OPS)}")
+    if op != "count" and not field:
+        raise ValueError(f"op {op!r} requires a field")
+
+    rows = iter_rows(entries, row_path)
+
+    def _compute(group_rows: list) -> dict:
+        if op == "count":
+            return {"count": len(group_rows)}
+        values = [
+            n for r in group_rows
+            if (n := _to_number(_get_path(r, field) if isinstance(r, dict) else None)) is not None
+        ]
+        summary = _numeric_summary(values)
+        if op == "stats":
+            return summary
+        return {op: summary[op], "n": summary["n"]}
+
+    result: dict = {
+        "op": op,
+        "field": field,
+        "row_path": row_path,
+        "total_rows": len(rows),
+    }
+    if group_by:
+        groups: dict[str, list] = {}
+        for r in rows:
+            g = _get_path(r, group_by) if isinstance(r, dict) else None
+            groups.setdefault(_group_key(g), []).append(r)
+        result["group_by"] = group_by
+        result["groups"] = [
+            {"key": key, **_compute(group_rows)}
+            for key, group_rows in sorted(groups.items(), key=lambda kv: kv[0])
+        ]
+    else:
+        result.update(_compute(rows))
+    return result
+
+
+def _type_name(v: object) -> str:
+    if isinstance(v, bool):
+        return "bool"
+    if isinstance(v, int):
+        return "int"
+    if isinstance(v, float):
+        return "float"
+    if isinstance(v, str):
+        return "string"
+    if isinstance(v, list):
+        return "list"
+    if isinstance(v, dict):
+        return "object"
+    return type(v).__name__
+
+
+def _row_path_candidates(entries: "list[MemoryEntry]") -> list[dict]:
+    """Detect list-of-object fields at the entry-value level.
+
+    These are the ``row_path`` values an agent should aggregate over (e.g. a
+    batch entry ``{"listings": [ {...}, ... ]}`` yields candidate ``listings``).
+    """
+    seen: dict[str, dict] = {}
+    for entry in entries:
+        val = coerce_value(getattr(entry, "value", entry))
+        if not isinstance(val, dict):
+            continue
+        for k, v in val.items():
+            if isinstance(v, list) and v and any(isinstance(el, dict) for el in v):
+                info = seen.setdefault(k, {"field": k, "entries": 0, "total_rows": 0})
+                info["entries"] += 1
+                info["total_rows"] += len(v)
+    return sorted(seen.values(), key=lambda c: c["total_rows"], reverse=True)
+
+
+def room_schema_profile(
+    entries: "list[MemoryEntry]",
+    *,
+    row_path: str | None = None,
+    max_enum: int = _DEFAULT_MAX_ENUM,
+) -> dict:
+    """A compact, always-cheap map of what a room/entity contains.
+
+    Returns the fields present across records, their inferred types, non-null
+    counts, numeric ranges, low-cardinality value sets (enums), per-key record
+    counts, and the ``row_path`` candidates an agent should aggregate over. The
+    output is a few KB regardless of how many records the room holds, so an
+    agent reads it once and knows exactly which amfs_aggregate / amfs_export
+    calls to make instead of pulling everything to find out.
+    """
+    rows = iter_rows(entries, row_path)
+
+    fields: dict[str, dict] = {}
+
+    def _observe(name: str, value: object) -> None:
+        info = fields.setdefault(
+            name,
+            {"types": set(), "non_null": 0, "numbers": [], "values": set()},
+        )
+        if value is None:
+            info["types"].add("null")
+            return
+        info["non_null"] += 1
+        info["types"].add(_type_name(value))
+        num = _to_number(value)
+        if num is not None:
+            info["numbers"].append(num)
+        if info["values"] is None:
+            return
+        if isinstance(value, (str, int, float, bool)):
+            info["values"].add(value)
+            if len(info["values"]) > max_enum:
+                info["values"] = None
+        else:
+            info["values"] = None
+
+    for r in rows:
+        if isinstance(r, dict):
+            for k, v in r.items():
+                _observe(k, v)
+        else:
+            _observe("_value", r)
+
+    field_out: list[dict] = []
+    for name, info in sorted(fields.items()):
+        item: dict = {
+            "field": name,
+            "types": sorted(info["types"]),
+            "non_null": info["non_null"],
+        }
+        if info["numbers"]:
+            item["numeric_range"] = {
+                "min": min(info["numbers"]),
+                "max": max(info["numbers"]),
+            }
+        if info["values"] is None:
+            item["cardinality"] = f">{max_enum}"
+        else:
+            item["cardinality"] = len(info["values"])
+            item["values"] = sorted(info["values"], key=lambda x: str(x))
+        field_out.append(item)
+
+    per_key: dict[str, int] = {}
+    for entry in entries:
+        key = getattr(entry, "key", None)
+        if key is not None:
+            per_key[key] = per_key.get(key, 0) + 1
+
+    return {
+        "total_entries": len(entries),
+        "total_rows": len(rows),
+        "row_path": row_path,
+        "fields": field_out,
+        "record_counts_by_key": per_key,
+        "row_path_candidates": _row_path_candidates(entries),
+    }
+
+
 def share_stats_from_traces(
     traces: "list[DecisionTrace]",
     *,

--- a/packages/cortex/src/amfs_cortex/strategies.py
+++ b/packages/cortex/src/amfs_cortex/strategies.py
@@ -18,6 +18,46 @@ if TYPE_CHECKING:
     from amfs_postgres.adapter import PostgresAdapter
 
 
+def _structured_profile(entries: list) -> tuple[dict | None, dict | None]:
+    """Compute a schema profile + materialized aggregates for tabular entities.
+
+    This is what makes heavy (e.g. room) usage fast: an agent reading the digest
+    learns the shape of the data and gets common numeric rollups precomputed,
+    without listing every record. Returns (None, None) when the entries are not
+    record-shaped (plain-text memories), so ordinary entities are unaffected.
+    Never raises — profiling must not break digest compilation.
+    """
+    try:
+        from amfs_core.aggregates import aggregate_entries, room_schema_profile
+
+        base = room_schema_profile(entries)
+        candidates = base.get("row_path_candidates") or []
+        row_path = candidates[0]["field"] if candidates else None
+        profile = room_schema_profile(entries, row_path=row_path) if row_path else base
+
+        field_names = [f["field"] for f in profile["fields"] if f["field"] != "_value"]
+        if not field_names or profile["total_rows"] == 0:
+            return None, None
+
+        materialized: dict = {"total_rows": profile["total_rows"]}
+        if row_path:
+            materialized["row_path"] = row_path
+        numeric_fields = [
+            f["field"] for f in profile["fields"]
+            if "numeric_range" in f and f["field"] != "_value"
+        ]
+        field_stats: dict = {}
+        for fld in numeric_fields[:10]:
+            res = aggregate_entries(entries, op="stats", field=fld, row_path=row_path)
+            field_stats[fld] = {k: res.get(k) for k in ("n", "sum", "mean", "min", "max")}
+        if field_stats:
+            materialized["numeric_fields"] = field_stats
+        return profile, materialized
+    except Exception:  # noqa: BLE001 - profiling is best-effort
+        logger.debug("schema profiling failed for entity digest", exc_info=True)
+        return None, None
+
+
 def _confidence_label(c: float) -> str:
     if c >= 0.95:
         return "very high"
@@ -96,20 +136,30 @@ class RuleBasedStrategy:
             avg_conf, outcome_linked, risk_keys, ext_event_count,
         )
 
+        summary: dict[str, Any] = {
+            "narrative": narrative,
+            "total_keys": len(entries),
+            "top_keys": top_keys,
+            "agents": sorted(agents),
+            "external_sources": sorted(external_sources),
+            "avg_confidence": avg_conf,
+            "last_write": last_write.isoformat(),
+            "outcome_linked": outcome_linked,
+            "external_events": ext_event_count,
+        }
+
+        # Room/tabular entities: carry an always-fresh schema profile and
+        # precomputed numeric rollups so an agent can orient and get common
+        # aggregates in this one briefing call instead of reading every record.
+        schema_profile, materialized = _structured_profile(entries)
+        if schema_profile is not None:
+            summary["schema_profile"] = schema_profile
+            summary["materialized_aggregates"] = materialized
+
         return Digest(
             digest_type=DigestType.ENTITY,
             scope=entity_path,
-            summary={
-                "narrative": narrative,
-                "total_keys": len(entries),
-                "top_keys": top_keys,
-                "agents": sorted(agents),
-                "external_sources": sorted(external_sources),
-                "avg_confidence": avg_conf,
-                "last_write": last_write.isoformat(),
-                "outcome_linked": outcome_linked,
-                "external_events": ext_event_count,
-            },
+            summary=summary,
             entry_count=len(entries),
             source_agents=sorted(agents | {f"webhook/{s}" for s in external_sources} | {f"external/{s}" for s in external_sources}),
             compiled_at=datetime.now(timezone.utc),

--- a/packages/cortex/src/amfs_cortex/strategies.py
+++ b/packages/cortex/src/amfs_cortex/strategies.py
@@ -14,6 +14,13 @@ from amfs_core.models import Digest, DigestType
 
 logger = logging.getLogger(__name__)
 
+#: How many entries a single entity digest compiles from. The search is ordered
+#: by confidence, so a digest for an entity with more keys than this is built
+#: from the top slice — which the schema profile / materialized aggregates must
+#: disclose, since presenting a partial rollup as the entity's totals would
+#: disagree with a full amfs_aggregate.
+_ENTITY_DIGEST_LIMIT = 1000
+
 if TYPE_CHECKING:
     from amfs_postgres.adapter import PostgresAdapter
 
@@ -88,7 +95,7 @@ class RuleBasedStrategy:
 
         entries = adapter.search(SearchQuery(
             entity_path=entity_path,
-            limit=1000,
+            limit=_ENTITY_DIGEST_LIMIT,
             sort_by="confidence",
             # Digest narrative/top_keys summarise knowledge, not stored code files.
             include_artifacts=False,
@@ -153,6 +160,22 @@ class RuleBasedStrategy:
         # aggregates in this one briefing call instead of reading every record.
         schema_profile, materialized = _structured_profile(entries)
         if schema_profile is not None:
+            # The digest is built from at most _ENTITY_DIGEST_LIMIT entries. When
+            # the entity has more, these rollups are a top-confidence sample, not
+            # the entity's totals — say so, and point at amfs_aggregate (which
+            # runs over the full set) for exact numbers.
+            if len(entries) >= _ENTITY_DIGEST_LIMIT:
+                note = (
+                    f"Computed from the {_ENTITY_DIGEST_LIMIT} highest-confidence "
+                    "entries; this entity has at least that many, so treat these "
+                    "as a sample and use amfs_aggregate for exact totals."
+                )
+                schema_profile["sampled"] = True
+                schema_profile["sample_size"] = len(entries)
+                schema_profile["note"] = note
+                if materialized is not None:
+                    materialized["sampled"] = True
+                    materialized["note"] = note
             summary["schema_profile"] = schema_profile
             summary["materialized_aggregates"] = materialized
 

--- a/packages/http-server/src/amfs_http/models.py
+++ b/packages/http-server/src/amfs_http/models.py
@@ -60,6 +60,23 @@ class SearchRequest(BaseModel):
     include_artifacts: bool = True
 
 
+class AggregateRequest(BaseModel):
+    """Server-side aggregation over the records stored under one entity path.
+
+    entity_path is required: an unscoped query strips shared @room/ paths, so
+    an unscoped aggregate would silently return empty for every room. The
+    reducer runs after visibility filtering so a caller can never aggregate over
+    entries they cannot read.
+    """
+
+    entity_path: str
+    op: str = "count"
+    field: str | None = None
+    group_by: str | None = None
+    row_path: str | None = None
+    branch: str = "main"
+
+
 class RetrieveRequest(BaseModel):
     """Semantic (meaning-based) retrieval request.
 

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -5518,6 +5518,24 @@ def _filter_briefing_digests(vis: Any, digests: list) -> list:
             else:
                 digest.summary.pop("who_to_ask")
 
+        # schema_profile / materialized_aggregates are computed over EVERY entry
+        # in the entity, so their sums, ranges and enum values can disclose data
+        # authored by agents this caller cannot see — the same data amfs_read /
+        # amfs_search / amfs_aggregate would refuse them. The digest is compiled
+        # once and served to callers of differing visibility, so it cannot be
+        # re-scoped per caller here; keep the rollups only when the caller can
+        # actually reach everything they summarise. A room member reaches every
+        # entry on the topic; otherwise every source agent must be visible.
+        if "schema_profile" in digest.summary or "materialized_aggregates" in digest.summary:
+            room_ok = scope in room_map
+            all_agents_visible = bool(source_agents) and all(
+                _is_agent_visible_for_entity(a, scope, user_agents, room_map)
+                for a in source_agents
+            )
+            if not (room_ok or all_agents_visible):
+                digest.summary.pop("schema_profile", None)
+                digest.summary.pop("materialized_aggregates", None)
+
         if source_agents:
             has_visible = any(
                 _is_agent_visible_for_entity(a, scope, user_agents, room_map)

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -54,6 +54,7 @@ from amfs_core.quality import HeuristicQualityEvaluator
 from amfs_http.auth import verify_api_key
 from amfs_http.models import (
     AddTeamMemberRequest,
+    AggregateRequest,
     ContextRequest,
     CreateAPIKeyRequest,
     CreateSnapshotRequest,
@@ -1163,6 +1164,55 @@ async def list_entity_summaries(
         summaries = mem._adapter.entity_summaries()
 
     return json.loads(json.dumps({"entities": summaries}, default=str))
+
+
+@app.post("/api/v1/aggregate")
+async def aggregate_entries_endpoint(
+    request: Request,
+    req: AggregateRequest,
+    _auth: str | None = Depends(verify_api_key),
+) -> dict[str, Any]:
+    """Compute one aggregate server-side over the records under an entity path.
+
+    Returns only the computed result, not the raw records — so an agent can get
+    a sum/mean/group-by across thousands of records without pulling any of them
+    into context. The visibility filter is applied BEFORE reducing (same order
+    as /api/v1/entities), so a caller can never aggregate over entries they
+    can't read.
+    """
+    from amfs_core.aggregates import AGGREGATE_OPS, aggregate_entries
+
+    if req.op not in AGGREGATE_OPS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown op {req.op!r}; expected one of {list(AGGREGATE_OPS)}",
+        )
+    if req.op != "count" and not req.field:
+        raise HTTPException(
+            status_code=400, detail=f"op {req.op!r} requires a 'field'"
+        )
+
+    mem = _get_memory()
+    entries = mem.list(req.entity_path, branch=req.branch)
+
+    vis = _get_visibility_filter(request)
+    if vis is not None and vis.should_filter():
+        entries = vis.filter_entries(entries)
+
+    try:
+        result = aggregate_entries(
+            entries,
+            op=req.op,
+            field=req.field,
+            group_by=req.group_by,
+            row_path=req.row_path,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    result["entity_path"] = req.entity_path
+    result["entries_scanned"] = len(entries)
+    return json.loads(json.dumps(result, default=str))
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -1211,7 +1211,14 @@ def amfs_export(
             "prefer amfs_aggregate so records never enter your context."
         ),
     }
-    if len(content) <= inline_char_budget:
+    # Gate the inline copy on the size it will ACTUALLY occupy in this manifest,
+    # not on len(content): a CSV file is compact, but manifest["inline"] embeds
+    # the raw records which re-serialize as JSON — far larger for csv/json — so
+    # comparing the file size would let a small CSV smuggle a huge inline blob
+    # past the context budget.
+    inline_serialized = json.dumps(records, default=str)
+    manifest["inline_chars"] = len(inline_serialized)
+    if len(inline_serialized) <= inline_char_budget:
         manifest["inline"] = records
     return json.dumps(manifest, default=str)
 

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -1096,6 +1096,180 @@ def amfs_list(entity_path: str | None = None) -> str:
     }, default=str)
 
 
+@mcp.tool(tags={"core"}, annotations={"readOnlyHint": True})
+def amfs_export(
+    entity_path: str,
+    format: str = "jsonl",
+    row_path: str | None = None,
+    inline_char_budget: int = 20000,
+) -> str:
+    """Bulk-fetch every entry under an entity path with FULL values, to a file.
+
+    Use this instead of many amfs_read calls when you need all the data under a
+    path (e.g. an entire room). Unlike amfs_list/amfs_search/amfs_retrieve, this
+    does NOT truncate values — but to keep your context clean it writes the full
+    data to a local file and returns a manifest (path, count, keys), not the
+    values. Read the file with your filesystem tool, or hand its path to a
+    subagent. Because it is on disk, the data survives conversation compaction:
+    re-crunching is a file read, not a re-fetch.
+
+    Args:
+        entity_path: Path to export (required). For a room, pass its shared
+            path, e.g. "@my-room/listings". An entity path is required —
+            unscoped exports would drop shared/room data.
+        format: "jsonl" (default), "json", or "csv". csv/jsonl combine well
+            with row_path for tabular datasets.
+        row_path: Optional dotted field holding a list of records to flatten
+            into one row each (e.g. "listings" turns 26 batch entries into one
+            row per listing). Omit to export whole entries.
+        inline_char_budget: If the whole payload is at or under this many
+            characters it is ALSO returned inline (for clients without a
+            filesystem tool). Larger payloads return the path only.
+
+    Example: amfs_export("@deals-room/listings", format="csv", row_path="listings")
+    """
+    import csv
+    import io
+    import uuid
+
+    from amfs_core.aggregates import coerce_value, iter_rows
+
+    fmt = format.lower()
+    if fmt not in ("jsonl", "json", "csv"):
+        return json.dumps({"error": f"unknown format {format!r}; use jsonl, json, or csv"})
+
+    mem = _get_memory()
+    entries = mem.list(entity_path)
+    if not entries:
+        return json.dumps({
+            "status": "empty",
+            "count": 0,
+            "entity_path": entity_path,
+            "message": "No entries found for that entity path.",
+        })
+
+    keys = [getattr(e, "key", None) for e in entries]
+    if row_path:
+        records: list[Any] = iter_rows(entries, row_path)
+    else:
+        records = [
+            {**_serialize_entry(e), "value": coerce_value(getattr(e, "value", None))}
+            for e in entries
+        ]
+
+    if fmt == "json":
+        content = json.dumps(records, default=str, indent=2)
+    elif fmt == "jsonl":
+        content = "\n".join(json.dumps(r, default=str) for r in records)
+    else:  # csv
+        dict_rows = [r for r in records if isinstance(r, dict)]
+        columns: list[str] = []
+        for r in dict_rows:
+            for k in r.keys():
+                if k not in columns:
+                    columns.append(k)
+        buf = io.StringIO()
+        if columns:
+            writer = csv.DictWriter(buf, fieldnames=columns, extrasaction="ignore")
+            writer.writeheader()
+            for r in dict_rows:
+                writer.writerow({
+                    k: (v if isinstance(v, (str, int, float, bool)) or v is None
+                        else json.dumps(v, default=str))
+                    for k, v in r.items()
+                })
+        else:
+            writer = csv.writer(buf)
+            writer.writerow(["value"])
+            for r in records:
+                writer.writerow([json.dumps(r, default=str)])
+        content = buf.getvalue()
+
+    export_dir = os.path.join(os.path.expanduser("~"), ".amfs", "exports")
+    os.makedirs(export_dir, exist_ok=True)
+    ext = {"jsonl": "jsonl", "json": "json", "csv": "csv"}[fmt]
+    safe = "".join(c if c.isalnum() else "-" for c in entity_path).strip("-") or "export"
+    path = os.path.join(export_dir, f"{safe}-{uuid.uuid4().hex[:8]}.{ext}")
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(content)
+    except OSError as exc:
+        return json.dumps({"error": f"could not write export file: {exc}"})
+
+    manifest: dict[str, Any] = {
+        "path": path,
+        "format": fmt,
+        "entity_path": entity_path,
+        "row_path": row_path,
+        "entry_count": len(entries),
+        "record_count": len(records),
+        "total_chars": len(content),
+        "keys": keys,
+        "next": (
+            "Full data written to 'path'. Read it with your filesystem tool or "
+            "hand the path to a subagent — it survives compaction. For numbers, "
+            "prefer amfs_aggregate so records never enter your context."
+        ),
+    }
+    if len(content) <= inline_char_budget:
+        manifest["inline"] = records
+    return json.dumps(manifest, default=str)
+
+
+@mcp.tool(tags={"core"}, annotations={"readOnlyHint": True})
+def amfs_aggregate(
+    entity_path: str,
+    op: str = "count",
+    field: str | None = None,
+    group_by: str | None = None,
+    row_path: str | None = None,
+) -> str:
+    """Compute an aggregate over records under an entity path — server-side.
+
+    Use this to answer quantitative questions ("average price", "total yield by
+    city", "how many listings") WITHOUT pulling any records into your context.
+    Only the computed result comes back. Far cheaper than exporting and doing
+    the math token-by-token.
+
+    Args:
+        entity_path: Path to aggregate over (required). For a room use its
+            shared path, e.g. "@my-room/listings".
+        op: "count" (default), "sum", "mean", "min", "max", or "stats"
+            (all numeric stats at once). Numeric ops require `field`.
+        field: Dotted field to aggregate, e.g. "price" or "meta.yield".
+        group_by: Optional dotted field to group results by (e.g. "city").
+        row_path: Optional dotted field holding a list of records to flatten
+            into rows first (e.g. "listings" for batch entries).
+
+    Example: amfs_aggregate("@deals-room/listings", op="mean", field="price", group_by="city", row_path="listings")
+    """
+    body = {
+        "entity_path": entity_path,
+        "op": op,
+        "field": field,
+        "group_by": group_by,
+        "row_path": row_path,
+    }
+    if os.environ.get("AMFS_HTTP_URL"):
+        return _http_api_call("POST", "/api/v1/aggregate", body=body)
+
+    # Local fallback (filesystem / local-Postgres installs): compute over the
+    # same shared aggregates module so results match the server path.
+    from amfs_core.aggregates import aggregate_entries
+
+    mem = _get_memory()
+    entries = mem.list(entity_path)
+    try:
+        result = aggregate_entries(
+            entries, op=op, field=field, group_by=group_by, row_path=row_path
+        )
+    except ValueError as exc:
+        return json.dumps({"error": str(exc)})
+    result["entity_path"] = entity_path
+    result["entries_scanned"] = len(entries)
+    return json.dumps(result, default=str)
+
+
 @mcp.tool(tags={"extended"}, annotations={"readOnlyHint": True})
 def amfs_graph_neighbors(
     entity: str,

--- a/tests/unit/test_aggregate_endpoint.py
+++ b/tests/unit/test_aggregate_endpoint.py
@@ -1,0 +1,122 @@
+"""Endpoint tests for POST /api/v1/aggregate.
+
+Pins the two properties that keep it correct and safe:
+- entity_path is required and drives scoping (unscoped would drop room data);
+- the visibility filter runs BEFORE reducing, so a restricted user can never
+  aggregate over entries they cannot read.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+from fastapi.testclient import TestClient  # noqa: E402
+
+import amfs_http.server as server  # noqa: E402
+
+
+def _entry(value, key="k", agent="my-agent"):
+    return types.SimpleNamespace(
+        value=value,
+        key=key,
+        provenance=types.SimpleNamespace(agent_id=agent),
+    )
+
+
+class _AdminVis:
+    def should_filter(self):
+        return False
+
+    def filter_entries(self, entries):
+        return list(entries)
+
+
+class _RestrictedVis:
+    def __init__(self, agents=("my-agent",)):
+        self._agents = set(agents)
+
+    def should_filter(self):
+        return True
+
+    def filter_entries(self, entries):
+        return [e for e in entries if e.provenance.agent_id in self._agents]
+
+
+def _client(monkeypatch, entries, vis):
+    mem = types.SimpleNamespace(
+        namespace="test-ns",
+        list=lambda entity_path=None, branch="main": list(entries),
+    )
+    monkeypatch.setattr(server, "_get_memory", lambda: mem)
+    monkeypatch.setattr(server, "_async_adapter", None)
+    monkeypatch.setattr(server, "_get_visibility_filter", lambda request: vis)
+    return TestClient(server.app)
+
+
+def test_count_over_row_path(monkeypatch):
+    entries = [
+        _entry({"listings": [{"price": 100}, {"price": 300}]}, key="b1"),
+        _entry({"listings": [{"price": 200}]}, key="b2"),
+    ]
+    client = _client(monkeypatch, entries, _AdminVis())
+    res = client.post("/api/v1/aggregate", json={
+        "entity_path": "@room/listings", "op": "count", "row_path": "listings",
+    })
+    assert res.status_code == 200
+    body = res.json()
+    assert body["count"] == 3
+    assert body["entity_path"] == "@room/listings"
+
+
+def test_mean_grouped(monkeypatch):
+    entries = [_entry({"listings": [
+        {"price": 100, "city": "A"},
+        {"price": 300, "city": "B"},
+        {"price": 200, "city": "A"},
+    ]}, key="b1")]
+    client = _client(monkeypatch, entries, _AdminVis())
+    res = client.post("/api/v1/aggregate", json={
+        "entity_path": "@room/listings", "op": "mean", "field": "price",
+        "group_by": "city", "row_path": "listings",
+    })
+    assert res.status_code == 200
+    groups = {g["key"]: g for g in res.json()["groups"]}
+    assert groups["A"]["mean"] == 150
+
+
+def test_visibility_filter_applied_before_reduce(monkeypatch):
+    # Two entries, only one authored by the visible agent. A restricted user's
+    # count must not include the foreign entry's rows.
+    entries = [
+        _entry({"listings": [{"p": 1}, {"p": 2}]}, key="mine", agent="my-agent"),
+        _entry({"listings": [{"p": 3}, {"p": 4}, {"p": 5}]}, key="theirs", agent="other-agent"),
+    ]
+    client = _client(monkeypatch, entries, _RestrictedVis(agents=("my-agent",)))
+    res = client.post("/api/v1/aggregate", json={
+        "entity_path": "@room/listings", "op": "count", "row_path": "listings",
+    })
+    assert res.status_code == 200
+    body = res.json()
+    assert body["count"] == 2  # only the visible entry's two rows
+    assert body["entries_scanned"] == 1
+
+
+def test_unknown_op_is_400(monkeypatch):
+    client = _client(monkeypatch, [_entry({"p": 1})], _AdminVis())
+    res = client.post("/api/v1/aggregate", json={"entity_path": "@room/x", "op": "median", "field": "p"})
+    assert res.status_code == 400
+
+
+def test_numeric_op_without_field_is_400(monkeypatch):
+    client = _client(monkeypatch, [_entry({"p": 1})], _AdminVis())
+    res = client.post("/api/v1/aggregate", json={"entity_path": "@room/x", "op": "sum"})
+    assert res.status_code == 400
+
+
+def test_entity_path_is_required(monkeypatch):
+    client = _client(monkeypatch, [_entry({"p": 1})], _AdminVis())
+    res = client.post("/api/v1/aggregate", json={"op": "count"})
+    assert res.status_code == 422  # pydantic: missing required field

--- a/tests/unit/test_aggregates_bulk.py
+++ b/tests/unit/test_aggregates_bulk.py
@@ -1,0 +1,164 @@
+"""Unit tests for bulk aggregation + schema profiling over entry values.
+
+These pure functions back three surfaces that must always agree: the
+/api/v1/aggregate endpoint, the amfs_aggregate MCP local fallback, and the
+room-index schema profile carried on entity digests. The cases here pin the
+behaviours that are easy to regress: value coercion (parsed object vs JSON
+string), row_path flattening, numeric ops ignoring non-numbers, group_by, and
+schema inference.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from amfs_core.aggregates import (
+    AGGREGATE_OPS,
+    aggregate_entries,
+    coerce_value,
+    iter_rows,
+    room_schema_profile,
+)
+
+
+def _entry(value, key="k"):
+    return types.SimpleNamespace(value=value, key=key)
+
+
+# ── coercion ───────────────────────────────────────────────────────────
+
+
+def test_coerce_passthrough_for_objects():
+    assert coerce_value({"a": 1}) == {"a": 1}
+    assert coerce_value([1, 2]) == [1, 2]
+
+
+def test_coerce_parses_json_strings():
+    assert coerce_value('{"a": 1}') == {"a": 1}
+    assert coerce_value("[1, 2]") == [1, 2]
+
+
+def test_coerce_leaves_plain_strings_alone():
+    assert coerce_value("just text") == "just text"
+
+
+# ── row flattening ───────────────────────────────────────────────────────
+
+
+def test_iter_rows_without_row_path_one_row_per_entry():
+    rows = iter_rows([_entry({"a": 1}), _entry({"a": 2})])
+    assert rows == [{"a": 1}, {"a": 2}]
+
+
+def test_iter_rows_flattens_list_valued_field():
+    entries = [
+        _entry({"listings": [{"p": 1}, {"p": 2}]}),
+        _entry('{"listings": [{"p": 3}]}'),  # JSON string form
+    ]
+    rows = iter_rows(entries, row_path="listings")
+    assert rows == [{"p": 1}, {"p": 2}, {"p": 3}]
+
+
+# ── aggregation ──────────────────────────────────────────────────────────
+
+
+def test_count_over_rows():
+    entries = [_entry({"listings": [{"p": 1}, {"p": 2}]}), _entry({"listings": [{"p": 3}]})]
+    res = aggregate_entries(entries, op="count", row_path="listings")
+    assert res["count"] == 3
+    assert res["total_rows"] == 3
+
+
+def test_numeric_ops_ignore_non_numbers():
+    entries = [_entry({"p": 10}), _entry({"p": "not-a-number"}), _entry({"p": "30"})]
+    res = aggregate_entries(entries, op="stats", field="p")
+    # "30" coerces to a number; the non-numeric string is dropped, not zeroed.
+    assert res["n"] == 2
+    assert res["sum"] == 40
+    assert res["mean"] == 20
+    assert res["min"] == 10
+    assert res["max"] == 30
+
+
+def test_string_and_object_values_aggregate_together():
+    entries = [_entry({"p": 100}), _entry('{"p": 300}')]
+    res = aggregate_entries(entries, op="mean", field="p")
+    assert res["mean"] == 200
+
+
+def test_group_by_partitions_rows():
+    entries = [_entry({"listings": [
+        {"p": 100, "city": "A"},
+        {"p": 300, "city": "B"},
+        {"p": 200, "city": "A"},
+    ]})]
+    res = aggregate_entries(entries, op="stats", field="p", group_by="city", row_path="listings")
+    groups = {g["key"]: g for g in res["groups"]}
+    assert groups["A"]["mean"] == 150
+    assert groups["A"]["n"] == 2
+    assert groups["B"]["sum"] == 300
+
+
+def test_dotted_field_path():
+    entries = [_entry({"meta": {"yield": 5.0}}), _entry({"meta": {"yield": 7.0}})]
+    res = aggregate_entries(entries, op="mean", field="meta.yield")
+    assert res["mean"] == 6.0
+
+
+def test_unknown_op_raises():
+    with pytest.raises(ValueError):
+        aggregate_entries([_entry({"p": 1})], op="median", field="p")
+
+
+def test_numeric_op_without_field_raises():
+    with pytest.raises(ValueError):
+        aggregate_entries([_entry({"p": 1})], op="sum")
+
+
+def test_count_needs_no_field():
+    assert "count" in AGGREGATE_OPS
+    assert aggregate_entries([_entry({"p": 1})], op="count")["count"] == 1
+
+
+# ── schema profile ───────────────────────────────────────────────────────
+
+
+def test_schema_profile_infers_fields_types_ranges():
+    entries = [
+        _entry({"listings": [
+            {"price": 100, "city": "A", "active": True},
+            {"price": 300, "city": "B", "active": False},
+        ]}, key="batch-1"),
+        _entry({"listings": [{"price": 200, "city": "A", "active": True}]}, key="batch-2"),
+    ]
+    prof = room_schema_profile(entries, row_path="listings")
+    assert prof["total_rows"] == 3
+    by_name = {f["field"]: f for f in prof["fields"]}
+    assert by_name["price"]["numeric_range"] == {"min": 100, "max": 300}
+    assert set(by_name["city"]["values"]) == {"A", "B"}
+    assert by_name["city"]["cardinality"] == 2
+    assert "bool" in by_name["active"]["types"]
+
+
+def test_schema_profile_detects_row_path_candidates():
+    entries = [_entry({"listings": [{"p": 1}, {"p": 2}]}, key="b1")]
+    prof = room_schema_profile(entries)
+    cands = {c["field"]: c for c in prof["row_path_candidates"]}
+    assert "listings" in cands
+    assert cands["listings"]["total_rows"] == 2
+
+
+def test_schema_profile_counts_records_per_key():
+    entries = [_entry({"a": 1}, key="b1"), _entry({"a": 2}, key="b2"), _entry({"a": 3}, key="b2")]
+    prof = room_schema_profile(entries)
+    assert prof["record_counts_by_key"] == {"b1": 1, "b2": 2}
+
+
+def test_high_cardinality_field_hides_enum():
+    entries = [_entry({"listings": [{"id": i} for i in range(100)]}, key="b1")]
+    prof = room_schema_profile(entries, row_path="listings", max_enum=25)
+    by_name = {f["field"]: f for f in prof["fields"]}
+    assert by_name["id"]["cardinality"] == ">25"
+    assert "values" not in by_name["id"]

--- a/tests/unit/test_briefing_visibility.py
+++ b/tests/unit/test_briefing_visibility.py
@@ -242,6 +242,53 @@ class TestWhoToAskVisibility:
         assert _filter_briefing_digests(vis, [d]) == []
 
 
+class TestSchemaProfileVisibility:
+    """schema_profile / materialized_aggregates are computed over EVERY entry in
+    the entity, so their sums, ranges and enums can disclose data authored by
+    agents the caller cannot see. They must be redacted unless the caller can
+    reach everything they summarise.
+    """
+
+    @staticmethod
+    def _with_aggregates(d: Digest) -> Digest:
+        d.summary["schema_profile"] = {"total_rows": 42, "fields": [{"field": "price"}]}
+        d.summary["materialized_aggregates"] = {"numeric_fields": {"price": {"sum": 1000}}}
+        return d
+
+    def test_kept_when_every_source_agent_is_visible(self):
+        vis = _mock_vis({"my-agent"})
+        d = self._with_aggregates(_digest(source_agents=["my-agent"]))
+        result = _filter_briefing_digests(vis, [d])
+        assert "schema_profile" in result[0].summary
+        assert "materialized_aggregates" in result[0].summary
+
+    def test_redacted_when_any_source_agent_is_hidden(self):
+        # The digest still survives (my-agent is visible), but the rollups are
+        # built partly from foreign-agent's entries, so they must be stripped.
+        vis = _mock_vis({"my-agent"})
+        d = self._with_aggregates(
+            _digest(source_agents=["my-agent", "foreign-agent"]),
+        )
+        result = _filter_briefing_digests(vis, [d])
+        assert len(result) == 1
+        assert "schema_profile" not in result[0].summary
+        assert "materialized_aggregates" not in result[0].summary
+
+    def test_kept_for_a_room_member_even_with_hidden_co_authors(self):
+        # Room membership grants access to every entry on the topic, so the
+        # room-wide rollups disclose nothing the caller cannot already read.
+        vis = _mock_vis(
+            {"my-agent"},
+            room_map={"myapp/auth": {"my-agent", "teammate"}},
+        )
+        d = self._with_aggregates(
+            _digest(scope="myapp/auth", source_agents=["teammate"]),
+        )
+        result = _filter_briefing_digests(vis, [d])
+        assert len(result) == 1
+        assert "schema_profile" in result[0].summary
+
+
 class TestAdminBypass:
 
     def test_admin_should_filter_false(self):

--- a/tests/unit/test_entity_digest_schema.py
+++ b/tests/unit/test_entity_digest_schema.py
@@ -1,0 +1,65 @@
+"""The entity digest carries a schema profile + materialized aggregates for
+record-shaped (room/tabular) entities, and leaves plain-text entities alone.
+
+This is what makes a room briefing a one-call orientation: the digest served by
+/api/v1/briefing already contains the shape of the data and precomputed numeric
+rollups, so an agent need not list every record.
+"""
+
+from __future__ import annotations
+
+import types
+from datetime import datetime, timezone
+
+from amfs_cortex.strategies import RuleBasedStrategy, _structured_profile
+
+
+def _e(value, key, conf=0.9):
+    return types.SimpleNamespace(
+        value=value,
+        key=key,
+        confidence=conf,
+        outcome_count=0,
+        provenance=types.SimpleNamespace(
+            agent_id="a1", written_at=datetime.now(timezone.utc)
+        ),
+    )
+
+
+def test_plain_text_entities_get_no_profile():
+    prof, agg = _structured_profile([_e("just a note", "n1"), _e("another", "n2")])
+    assert prof is None
+    assert agg is None
+
+
+def test_record_entities_get_profile_and_aggregates():
+    entries = [_e({"listings": [{"price": 100, "city": "A"}, {"price": 300, "city": "B"}]}, "b1")]
+    prof, agg = _structured_profile(entries)
+    assert prof is not None
+    assert agg["total_rows"] == 2
+    assert agg["row_path"] == "listings"
+    assert "price" in agg["numeric_fields"]
+    assert agg["numeric_fields"]["price"]["mean"] == 200
+
+
+class _Adapter:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def search(self, query, branch="main"):
+        return list(self._entries)
+
+
+def test_compile_entity_carries_schema_profile():
+    entries = [_e({"listings": [{"price": 100, "city": "A"}]}, "b1")]
+    digest = RuleBasedStrategy().compile_entity("@room/listings", _Adapter(entries), "default")
+    assert digest is not None
+    assert "schema_profile" in digest.summary
+    assert "materialized_aggregates" in digest.summary
+
+
+def test_compile_entity_plain_text_has_no_schema_profile():
+    entries = [_e("a runbook note", "runbook")]
+    digest = RuleBasedStrategy().compile_entity("ops/notes", _Adapter(entries), "default")
+    assert digest is not None
+    assert "schema_profile" not in digest.summary

--- a/tests/unit/test_entity_digest_schema.py
+++ b/tests/unit/test_entity_digest_schema.py
@@ -63,3 +63,33 @@ def test_compile_entity_plain_text_has_no_schema_profile():
     digest = RuleBasedStrategy().compile_entity("ops/notes", _Adapter(entries), "default")
     assert digest is not None
     assert "schema_profile" not in digest.summary
+
+
+def test_small_entity_profile_is_not_flagged_sampled():
+    entries = [_e({"listings": [{"price": 100, "city": "A"}]}, "b1")]
+    digest = RuleBasedStrategy().compile_entity("@room/listings", _Adapter(entries), "default")
+    assert "sampled" not in digest.summary["schema_profile"]
+    assert "sampled" not in digest.summary["materialized_aggregates"]
+
+
+def test_large_entity_profile_is_flagged_as_a_sample(monkeypatch):
+    """When the entity has as many keys as the digest cap, the rollups are a
+    top-confidence sample and must say so — otherwise they read as the totals
+    and disagree with a full amfs_aggregate."""
+    import amfs_cortex.strategies as strategies
+
+    monkeypatch.setattr(strategies, "_ENTITY_DIGEST_LIMIT", 3)
+    entries = [
+        _e({"price": 100}, "k1"),
+        _e({"price": 200}, "k2"),
+        _e({"price": 300}, "k3"),
+    ]
+    digest = strategies.RuleBasedStrategy().compile_entity(
+        "@room/listings", _Adapter(entries), "default",
+    )
+    prof = digest.summary["schema_profile"]
+    agg = digest.summary["materialized_aggregates"]
+    assert prof["sampled"] is True
+    assert prof["sample_size"] == 3
+    assert "amfs_aggregate" in prof["note"]
+    assert agg["sampled"] is True

--- a/tests/unit/test_mcp_tools_smoke.py
+++ b/tests/unit/test_mcp_tools_smoke.py
@@ -107,6 +107,30 @@ class TestReadSurfaceSmoke:
         assert payload["entry_count"] >= 1
         assert "path" in payload
 
+    def test_export_inline_gate_keys_on_inline_payload_size(self, srv):
+        # The inline copy embeds the raw records, which re-serialize as JSON and
+        # can dwarf a compact CSV file. The gate must compare the budget to that
+        # inline size (reported as inline_chars), not the file's — otherwise a
+        # small CSV would smuggle a huge inline blob past the context budget.
+        srv.amfs_write(
+            "smoke/rows", "batch",
+            json.dumps({"rows": [{"v": "x" * 200} for _ in range(20)]}),
+        )
+        below = _ok(
+            "amfs_export",
+            srv.amfs_export("smoke/rows", format="csv", row_path="rows",
+                            inline_char_budget=10),
+        )
+        assert below["inline_chars"] > 10
+        assert "inline" not in below
+
+        at_or_above = _ok(
+            "amfs_export",
+            srv.amfs_export("smoke/rows", format="csv", row_path="rows",
+                            inline_char_budget=below["inline_chars"]),
+        )
+        assert "inline" in at_or_above
+
     def test_aggregate_local_fallback(self, srv):
         # No AMFS_HTTP_URL in this test env, so amfs_aggregate must compute
         # locally over the same aggregates module rather than erroring.

--- a/tests/unit/test_mcp_tools_smoke.py
+++ b/tests/unit/test_mcp_tools_smoke.py
@@ -101,6 +101,18 @@ class TestReadSurfaceSmoke:
     def test_stats(self, srv):
         _ok("amfs_stats", srv.amfs_stats())
 
+    def test_export(self, srv):
+        # Bulk export writes full values to a file and returns a manifest.
+        payload = _ok("amfs_export", srv.amfs_export("smoke/db"))
+        assert payload["entry_count"] >= 1
+        assert "path" in payload
+
+    def test_aggregate_local_fallback(self, srv):
+        # No AMFS_HTTP_URL in this test env, so amfs_aggregate must compute
+        # locally over the same aggregates module rather than erroring.
+        payload = _ok("amfs_aggregate", srv.amfs_aggregate("smoke/db", op="count"))
+        assert "count" in payload
+
     def test_retrieve(self, srv):
         # THE regression: retrieve forwards include_artifacts down the stack.
         _ok("amfs_retrieve", srv.amfs_retrieve(query="retry policy"))


### PR DESCRIPTION
## Summary

Cuts the cost of using a data-heavy entity/room from dozens of truncated per-entry reads (the 40-minute case) down to two or three calls, across three layers:

- **`amfs_export` (MCP)** — bulk-fetch full, untruncated entry values to a local file, with an inline fallback for small sets. The fast path for reading a whole entity/room without per-entry calls or the 2000-char list truncation.
- **`amfs_aggregate` (MCP) + `POST /api/v1/aggregate`** — reduce records server-side (`count`/`sum`/`mean`/`min`/`max`/`stats`, optional `group_by` and `row_path`), with visibility filtering applied **before** the reduce. Reducers live in `amfs_core.aggregates` so MCP, HTTP, and Cortex share one implementation.
- **Entity-digest enrichment** — `compile_entity` now emits a `schema_profile` (fields, types, ranges, `row_path` candidates) and `materialized_aggregates` for record-shaped entities, so an agent reading a briefing knows the shape and key numbers before reading a single record. This is write-triggered via the existing Cortex worker (the `amfs_write` NOTIFY already recompiles the exact entity_path, room paths included), so a room stays current with no new plumbing.

Docs updated: `docs/guides/mcp.md` (tool table + data-heavy workflow), `docs/reference/sdk-mcp-parity.md`, `packages/agent-guide/reference.md`.

Companion PR (rooms/gateway wiring): raia-live/amfs-internal `feat/room-bulk-read-aggregate-index`.

## Test plan

- [x] `pytest tests/unit/test_aggregates_bulk.py` — reducers, row flattening, numeric coercion, schema profiling
- [x] `pytest tests/unit/test_entity_digest_schema.py` — digest enrichment for record-shaped vs plain-text entities
- [x] `pytest tests/unit/test_mcp_tools_smoke.py` — `amfs_export` manifest/path, `amfs_aggregate` local fallback
- [ ] `pytest tests/unit/test_aggregate_endpoint.py` — visibility + error paths (needs `fastapi`; runs in CI)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches visibility-sensitive data paths: aggregates run after ACL filtering, and digest schema/numeric rollups are redacted unless the caller can see every summarized entry. Also writes untruncated memory values to local files.
> 
> **Overview**
> Cuts data-heavy entity/room work from many truncated reads down to briefing + `amfs_aggregate` + optional `amfs_export`.
> 
> **Server-side reduce.** Shared `aggregate_entries` / `room_schema_profile` in `amfs_core.aggregates` power `POST /api/v1/aggregate` and MCP `amfs_aggregate` (`count`/`sum`/`mean`/`min`/`max`/`stats`, `group_by`, `row_path`). Visibility is applied **before** the reduce; `entity_path` is required.
> 
> **Bulk export.** MCP `amfs_export` writes full untruncated values to `~/.amfs/exports` (jsonl/json/csv), with inline payload only when the *serialized records* fit the budget.
> 
> **Digest orientation.** Entity compilation now attaches `schema_profile` and `materialized_aggregates` for record-shaped data. Rollups over the 1000-entry confidence cap are flagged `sampled`; briefing strips them unless the caller is a room member or can see every source agent. Plain-text entities are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cc3d431513d822276827dd368e97e66fa1c5e76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->