### PR TITLE
Add Dependabot config to group updates by ecosystem (stop per-dependency PR floods)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+# Dependabot configuration.
+#
+# Why this file exists
+# --------------------
+# Even without it, Dependabot ran SECURITY updates from the repo's security
+# settings — but ungrouped: one PR per vulnerable dependency, in every ecosystem
+# it found. With a backlog of advisories across the Python (uv) lock and several
+# npm package.json files, that produced a flood of single-dependency PRs, and
+# each one triggers a deploy on merge (see .github/workflows/trigger-deploy.yml).
+#
+# The `groups` blocks below collapse each ecosystem/directory into ONE pull
+# request — security and version updates alike — so the same advisories arrive
+# as a handful of reviewable, single-deploy PRs instead of dozens.
+#
+# Weekly cadence + open-pull-requests-limit keep the volume predictable.
+version: 2
+updates:
+  # Python (uv workspace) at the repo root.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python:
+        patterns: ["*"]
+
+  # npm — every package.json in the repo. `directories` fans out to each
+  # manifest; the group then collapses that manifest's updates into one PR.
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/demo"
+      - "/desktop"
+      - "/packages/browser-extension"
+      - "/packages/sdk-typescript"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm:
+        patterns: ["*"]
+
+  # GitHub Actions used by the workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,10 @@
 # each one triggers a deploy on merge (see .github/workflows/trigger-deploy.yml).
 #
 # The `groups` blocks below collapse each ecosystem/directory into ONE pull
-# request — security and version updates alike — so the same advisories arrive
-# as a handful of reviewable, single-deploy PRs instead of dozens.
+# request. Grouping applies per update *type*, so every ecosystem gets two
+# groups: one `applies-to: security-updates` (the backlog that motivated this)
+# and one `applies-to: version-updates`. Without the security-updates group,
+# advisories would keep arriving one PR per dependency.
 #
 # Weekly cadence + open-pull-requests-limit keep the volume predictable.
 version: 2
@@ -22,23 +24,32 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     groups:
-      python:
+      python-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      python-version:
+        applies-to: version-updates
         patterns: ["*"]
 
-  # npm — every package.json in the repo. `directories` fans out to each
-  # manifest; the group then collapses that manifest's updates into one PR.
+  # npm — every committed package.json in the repo. `directories` fans out to
+  # each manifest; the groups then collapse that manifest's updates into one PR
+  # per update type. (/desktop is intentionally absent: it has no committed
+  # package.json.)
   - package-ecosystem: "npm"
     directories:
       - "/"
       - "/demo"
-      - "/desktop"
       - "/packages/browser-extension"
       - "/packages/sdk-typescript"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
     groups:
-      npm:
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      npm-version:
+        applies-to: version-updates
         patterns: ["*"]
 
   # GitHub Actions used by the workflows.
@@ -48,5 +59,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     groups:
-      actions:
+      actions-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      actions-version:
+        applies-to: version-updates
         patterns: ["*"]


### PR DESCRIPTION
## What's going on

The repo has Dependabot **security updates** enabled via repo settings, but there was **no `.github/dependabot.yml`** — so Dependabot opens **one PR per vulnerable dependency**, ungrouped, across every ecosystem it finds.

Right now there are **24 open advisories (19 npm + 5 pip)** spread over the Python `uv.lock` and multiple `package.json` manifests (`/`, `/demo`, `/desktop`, `/packages/browser-extension`, `/packages/sdk-typescript`). That's the source of the repeated single-dependency PR waves — and each one triggers a deploy on merge.

## The fix

This config declares each ecosystem/directory with a `groups: patterns: ["*"]` block, so Dependabot **collapses each ecosystem into a single PR** (security *and* version updates), on a weekly cadence with a per-ecosystem PR limit. The same advisories then arrive as a handful of reviewable, one-deploy PRs instead of dozens.

Note: declaring the ecosystems also enables *scheduled version updates* (previously only security updates ran). With grouping + weekly cadence + `open-pull-requests-limit: 5`, that's a net large reduction in volume, not an increase.

## Recommended rollout

1. Merge this PR.
2. Close the current ungrouped wave (#345–#351 and any siblings). Dependabot re-creates the outstanding security advisories as **grouped** PRs (one per ecosystem) on its next run.

## Test plan

- [ ] Dependabot validates the config (check the repo's Dependabot page after merge)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to Dependabot grouping and cadence; no application, auth, or data-handling code.
> 
> **Overview**
> Adds `.github/dependabot.yml` so Dependabot no longer opens one PR per vulnerable dependency.
> 
> Updates for **uv**, **npm** (root, `demo`, `browser-extension`, `sdk-typescript`), and **GitHub Actions** are grouped into one security PR and one version PR per ecosystem, on a weekly schedule with `open-pull-requests-limit: 5`. This also turns on scheduled version updates (previously only ungrouped security updates ran). `/desktop` is omitted because it has no committed `package.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce72ea337846927cd84d554dd80206160406e42b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->