### PR TITLE
Publish amfs-core aggregate functions (fix amfs_export ImportError)

### DIFF
--- a/packages/adapters/http/pyproject.toml
+++ b/packages/adapters/http/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-adapter-http"
-version = "0.1.10"
+version = "0.1.11"
 description = "AMFS HTTP adapter — routes memory operations through the authenticated REST API"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/adapters/http/pyproject.toml
+++ b/packages/adapters/http/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 dependencies = [
     # 0.3.14 adds the capture fields this adapter now sends on the outcome record,
     # including the tool_calls that carry the action half of a training example.
-    "amfs-core>=0.3.14",
+    "amfs-core>=0.3.15",
     "httpx>=0.27,<1",
 ]
 

--- a/packages/adapters/postgres/pyproject.toml
+++ b/packages/adapters/postgres/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-adapter-postgres"
-version = "0.2.2"
+version = "0.2.3"
 description = "AMFS Postgres adapter with back-propagation triggers"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/adapters/postgres/pyproject.toml
+++ b/packages/adapters/postgres/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 dependencies = [
     # 0.3.14 adds the capture fields this adapter now persists and selects back,
     # tool_calls among them.
-    "amfs-core>=0.3.14",
+    "amfs-core>=0.3.15",
     "psycopg[binary]>=3.1,<4",
     "psycopg-pool>=3.1",
 ]

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-core"
-version = "0.3.14"
+version = "0.3.15"
 description = "AMFS core models, engine, and adapter ABC"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/http-server/pyproject.toml
+++ b/packages/http-server/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     # The trace endpoints call amfs_core.capture and read/write task_input, and
     # 0.3.14 / 0.5.7 add the action half: scan_captured_arguments and ToolCall.
     "amfs>=0.5.8",
-    "amfs-core>=0.3.14",
+    "amfs-core>=0.3.15",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.32",
     "sse-starlette>=2.0",

--- a/packages/http-server/pyproject.toml
+++ b/packages/http-server/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "amfs-http-server"
-version = "0.3.15"
+version = "0.3.16"
 description = "AMFS HTTP/REST API server with SSE support"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 dependencies = [
     # The trace endpoints call amfs_core.capture and read/write task_input, and
     # 0.3.14 / 0.5.7 add the action half: scan_captured_arguments and ToolCall.
-    "amfs>=0.5.8",
+    "amfs>=0.5.9",
     "amfs-core>=0.3.15",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.32",

--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-mcp-server"
-version = "0.7.15"
+version = "0.7.16"
 description = "AMFS MCP Server — expose Agent Memory as MCP tools for Cursor and Claude Code"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -11,6 +11,14 @@ dependencies = [
     # An unbounded dependency is how the equivalent skew reached Pro users.
     # 0.5.7 adds AgentMemory.record_action, which amfs_record_action calls.
     "amfs>=0.5.8",
+    # Direct floor at the import site. amfs_export and amfs_aggregate do
+    # `from amfs_core.aggregates import coerce_value, iter_rows, aggregate_entries`.
+    # Those were added in amfs-core 0.3.15 — but 0.3.14 was already published
+    # WITHOUT them (the aggregate code merged without bumping core), so the
+    # transitive floor via amfs (>=0.3.14) resolves a core that lacks the symbols
+    # and the tool ImportErrors the instant it is called. Floor core directly so
+    # a resolver can never pair this server with the broken 0.3.14 wheel.
+    "amfs-core>=0.3.15",
     # 0.1.10 for the same reason, one layer down: this adapter builds the
     # /outcomes body field by field, and anything earlier does not copy
     # tool_calls into it. The floor was 0.1.2, which a cached 0.1.9 satisfies —

--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     # TypeError on the one call agents are told to make at the end of every task.
     # An unbounded dependency is how the equivalent skew reached Pro users.
     # 0.5.7 adds AgentMemory.record_action, which amfs_record_action calls.
-    "amfs>=0.5.8",
+    "amfs>=0.5.9",
     # Direct floor at the import site. amfs_export and amfs_aggregate do
     # `from amfs_core.aggregates import coerce_value, iter_rows, aggregate_entries`.
     # Those were added in amfs-core 0.3.15 — but 0.3.14 was already published
@@ -26,7 +26,7 @@ dependencies = [
     # trace with an empty list, and the dataset built from those traces has
     # nothing to learn from. Nothing raises: the commit succeeds, and the only
     # symptom is a model that never becomes ready.
-    "amfs-adapter-http>=0.1.10",
+    "amfs-adapter-http>=0.1.11",
     "fastmcp>=2.0",
 ]
 

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     # 0.3.14 adds ToolCall, ReadTracker.record_action and
     # capture.scan_captured_arguments. record_action and commit_outcome below use
     # all three unconditionally, so an older core raises rather than degrading.
-    "amfs-core>=0.3.14",
+    "amfs-core>=0.3.15",
     "amfs-adapter-filesystem",
     "pyyaml>=6.0,<7",
 ]

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs"
-version = "0.5.8"
+version = "0.5.9"
 description = "AMFS Python SDK — Agent Memory File System"
 requires-python = ">=3.11"
 license = "Apache-2.0"


### PR DESCRIPTION
## Problem
Calling **amfs_export** (or **amfs_aggregate**) via `uvx amfs-mcp-server-pro` fails with:

```
ImportError: cannot import name 'coerce_value' from 'amfs_core.aggregates'
```

Reproduced with a fresh `--refresh` resolve: `amfs-core 0.3.14` + `amfs-mcp-server 0.7.15` + `amfs 0.5.8`, and the **published 0.3.14 wheel's `aggregates.py` contains only the old stats helpers** — none of `coerce_value` / `iter_rows` / `aggregate_entries` / `room_schema_profile`.

## Root cause
The bulk-read/aggregate feature (#323, `eb86ada`) added those functions to `amfs_core/aggregates.py` **but did not bump `packages/core/pyproject.toml`** — it stayed at `0.3.14`, which had already been published (in #309, before #323). `auto-publish.yml` is idempotent (`uv publish --check-url ... || echo "Skipping (already published)"`), so no new core wheel was ever cut. Meanwhile `amfs-mcp-server` shipped `amfs_export`/`amfs_aggregate` (which import the symbols) at `0.7.15`. Every fresh resolve therefore pairs the new server with the stale core → ImportError on first call. The tag-triggered smoke gate in `release.yml` that would have caught this doesn't run on the branch-push auto-publish path.

## Fix
- Bump **amfs-core → 0.3.15** so the aggregate functions actually get published. Verified: a wheel built from this branch contains all four symbols.
- Add a **direct `amfs-core>=0.3.15` floor** on **amfs-mcp-server** (bumped **0.7.15 → 0.7.16**) — the package that imports the symbols — so a resolver can never pair it with the broken `0.3.14` again. This matches the existing tight-floor discipline in that manifest.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging/version floors only; no runtime logic changes. Residual risk is a bad publish or leftover cache still resolving 0.3.14 until the new wheels are live.
> 
> **Overview**
> Bumps **amfs-core to 0.3.15** so the already-merged aggregate helpers (`coerce_value`, `iter_rows`, `aggregate_entries`) actually ship. Published **0.3.14** never included them because the feature landed without a version bump, so `amfs_export` / `amfs_aggregate` ImportError on a fresh resolve.
> 
> Adds a **direct `amfs-core>=0.3.15` floor** on `amfs-mcp-server` (0.7.16) so resolvers cannot pair the server with the broken 0.3.14 wheel. Cascades matching floors and patch versions: `amfs` 0.5.9, `amfs-http-server` 0.3.16, HTTP adapter 0.1.11, Postgres adapter 0.2.3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27e2e8c98a09186aeed57ab2db6d6e024eee5dfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->