### PR TITLE
Flatten bare top-level arrays in amfs_export / amfs_aggregate

### DIFF
--- a/packages/adapters/http/pyproject.toml
+++ b/packages/adapters/http/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "amfs-adapter-http"
-version = "0.1.11"
+version = "0.1.12"
 description = "AMFS HTTP adapter — routes memory operations through the authenticated REST API"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 dependencies = [
     # 0.3.14 adds the capture fields this adapter now sends on the outcome record,
     # including the tool_calls that carry the action half of a training example.
-    "amfs-core>=0.3.15",
+    "amfs-core>=0.3.16",
     "httpx>=0.27,<1",
 ]
 

--- a/packages/adapters/postgres/pyproject.toml
+++ b/packages/adapters/postgres/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "amfs-adapter-postgres"
-version = "0.2.3"
+version = "0.2.4"
 description = "AMFS Postgres adapter with back-propagation triggers"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 dependencies = [
     # 0.3.14 adds the capture fields this adapter now persists and selects back,
     # tool_calls among them.
-    "amfs-core>=0.3.15",
+    "amfs-core>=0.3.16",
     "psycopg[binary]>=3.1,<4",
     "psycopg-pool>=3.1",
 ]

--- a/packages/agent-guide/reference.md
+++ b/packages/agent-guide/reference.md
@@ -101,7 +101,7 @@ instead of listing-and-reading every entry in a data-heavy entity or room.
 |:----------|:-----|:---------|:------------|
 | `entity_path` | `str` | Yes | Entity to export |
 | `format` | `str` | No | `"jsonl"` (default) or `"json"` |
-| `row_path` | `str` | No | Dotted field holding a list to flatten into rows (e.g. `"listings"`) |
+| `row_path` | `str` | No | Dotted field holding a list to flatten into rows (e.g. `"listings"`). Use `"."` when the entry value is itself the list. |
 | `inline_char_budget` | `int` | No | Return inline instead of writing a file when the payload fits this budget |
 
 ### amfs_aggregate
@@ -116,7 +116,7 @@ coerced to zero); `n` reports how many rows actually contributed.
 | `op` | `str` | No | `"count"` (default), `"sum"`, `"mean"`, `"min"`, `"max"`, `"stats"` |
 | `field` | `str` | No | Dotted field for numeric ops (e.g. `"price"`) — required unless `op="count"` |
 | `group_by` | `str` | No | Dotted field to group results by |
-| `row_path` | `str` | No | Dotted field holding a list to flatten into rows first |
+| `row_path` | `str` | No | Dotted field holding a list to flatten into rows first. Use `"."` when the value is itself the list. |
 
 ### amfs_history
 

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-core"
-version = "0.3.15"
+version = "0.3.16"
 description = "AMFS core models, engine, and adapter ABC"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/core/src/amfs_core/aggregates.py
+++ b/packages/core/src/amfs_core/aggregates.py
@@ -209,6 +209,18 @@ def coerce_value(value: object) -> object:
     return value
 
 
+# row_path values that mean "the entry value itself" — used when a batch is a
+# bare array rather than ``{"listings": [...]}``.
+_IDENTITY_ROW_PATHS = frozenset({".", "$"})
+
+
+def _normalize_row_path(row_path: str | None) -> str | None:
+    if row_path is None:
+        return None
+    stripped = row_path.strip()
+    return stripped or None
+
+
 def _get_path(row: object, path: str) -> object:
     """Dotted-path getter over dict rows; returns None if any segment misses."""
     cur = row
@@ -220,6 +232,28 @@ def _get_path(row: object, path: str) -> object:
     return cur
 
 
+def _rows_from_value(val: object, row_path: str | None) -> list:
+    """Fan ``val`` out into records, honouring ``row_path``.
+
+    A top-level list is always flattened: there is no dict key to descend into,
+    so a guessed ``row_path`` like ``"properties"`` must not drop the records.
+    """
+    path = _normalize_row_path(row_path)
+    if path in _IDENTITY_ROW_PATHS or path is None:
+        if isinstance(val, list):
+            return list(val)
+        return [val]
+    if isinstance(val, list):
+        return list(val)
+    if isinstance(val, dict):
+        target = _get_path(val, path)
+        if isinstance(target, list):
+            return list(target)
+        if target is not None:
+            return [target]
+    return []
+
+
 def iter_rows(entries: "list[MemoryEntry]", row_path: str | None = None) -> list:
     """Flatten entries into the records to aggregate over.
 
@@ -227,20 +261,14 @@ def iter_rows(entries: "list[MemoryEntry]", row_path: str | None = None) -> list
     list, each element is a row). With ``row_path`` the value at that dotted
     path is expected to be a list — one row per element — which is how a batch
     entry like ``{"listings": [...]}`` fans out into per-listing rows.
+
+    ``row_path="."`` (or ``"$"``) flattens the value itself. If the value is
+    already a list, any ``row_path`` flattens it — wrappers are optional.
     """
     rows: list = []
     for entry in entries:
         val = coerce_value(getattr(entry, "value", entry))
-        if row_path:
-            target = _get_path(val, row_path) if isinstance(val, dict) else None
-            if isinstance(target, list):
-                rows.extend(target)
-            elif target is not None:
-                rows.append(target)
-        elif isinstance(val, list):
-            rows.extend(val)
-        else:
-            rows.append(val)
+        rows.extend(_rows_from_value(val, row_path))
     return rows
 
 
@@ -356,10 +384,16 @@ def _row_path_candidates(entries: "list[MemoryEntry]") -> list[dict]:
 
     These are the ``row_path`` values an agent should aggregate over (e.g. a
     batch entry ``{"listings": [ {...}, ... ]}`` yields candidate ``listings``).
+    A bare top-level array yields candidate ``"."``.
     """
     seen: dict[str, dict] = {}
     for entry in entries:
         val = coerce_value(getattr(entry, "value", entry))
+        if isinstance(val, list) and val and any(isinstance(el, dict) for el in val):
+            info = seen.setdefault(".", {"field": ".", "entries": 0, "total_rows": 0})
+            info["entries"] += 1
+            info["total_rows"] += len(val)
+            continue
         if not isinstance(val, dict):
             continue
         for k, v in val.items():

--- a/packages/http-server/pyproject.toml
+++ b/packages/http-server/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "amfs-http-server"
-version = "0.3.16"
+version = "0.3.17"
 description = "AMFS HTTP/REST API server with SSE support"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 dependencies = [
     # The trace endpoints call amfs_core.capture and read/write task_input, and
     # 0.3.14 / 0.5.7 add the action half: scan_captured_arguments and ToolCall.
-    "amfs>=0.5.9",
-    "amfs-core>=0.3.15",
+    "amfs>=0.5.10",
+    "amfs-core>=0.3.16",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.32",
     "sse-starlette>=2.0",

--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-mcp-server"
-version = "0.7.16"
+version = "0.7.17"
 description = "AMFS MCP Server — expose Agent Memory as MCP tools for Cursor and Claude Code"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -10,7 +10,7 @@ dependencies = [
     # TypeError on the one call agents are told to make at the end of every task.
     # An unbounded dependency is how the equivalent skew reached Pro users.
     # 0.5.7 adds AgentMemory.record_action, which amfs_record_action calls.
-    "amfs>=0.5.9",
+    "amfs>=0.5.10",
     # Direct floor at the import site. amfs_export and amfs_aggregate do
     # `from amfs_core.aggregates import coerce_value, iter_rows, aggregate_entries`.
     # Those were added in amfs-core 0.3.15 — but 0.3.14 was already published
@@ -18,7 +18,13 @@ dependencies = [
     # transitive floor via amfs (>=0.3.14) resolves a core that lacks the symbols
     # and the tool ImportErrors the instant it is called. Floor core directly so
     # a resolver can never pair this server with the broken 0.3.14 wheel.
-    "amfs-core>=0.3.15",
+    # 0.3.16 is the same hazard one degree quieter: iter_rows there flattens a
+    # bare top-level array and accepts row_path=".". Against 0.3.15 that call
+    # raises nothing — it looks in a dict, finds no key, and returns zero rows,
+    # so amfs_export writes an empty file and the agent concludes the data has
+    # no such shape. A silent empty result is worse than an ImportError, so this
+    # floor is the only thing separating the two.
+    "amfs-core>=0.3.16",
     # 0.1.10 for the same reason, one layer down: this adapter builds the
     # /outcomes body field by field, and anything earlier does not copy
     # tool_calls into it. The floor was 0.1.2, which a cached 0.1.9 satisfies —
@@ -26,7 +32,7 @@ dependencies = [
     # trace with an empty list, and the dataset built from those traces has
     # nothing to learn from. Nothing raises: the commit succeeds, and the only
     # symptom is a model that never becomes ready.
-    "amfs-adapter-http>=0.1.11",
+    "amfs-adapter-http>=0.1.12",
     "fastmcp>=2.0",
 ]
 

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -1165,7 +1165,8 @@ def amfs_export(
             with row_path for tabular datasets.
         row_path: Optional dotted field holding a list of records to flatten
             into one row each (e.g. "listings" turns 26 batch entries into one
-            row per listing). Omit to export whole entries.
+            row per listing). Use "." when the entry value IS the list (a
+            bare array, no wrapper key). Omit to export whole entries.
         inline_char_budget: If the whole payload is at or under this many
             characters it is ALSO returned inline (for clients without a
             filesystem tool). Larger payloads return the path only.
@@ -1193,7 +1194,8 @@ def amfs_export(
         })
 
     keys = [getattr(e, "key", None) for e in entries]
-    if row_path:
+    flatten = bool((row_path or "").strip())
+    if flatten:
         records: list[Any] = iter_rows(entries, row_path)
     else:
         records = [
@@ -1255,6 +1257,16 @@ def amfs_export(
             "prefer amfs_aggregate so records never enter your context."
         ),
     }
+    if not flatten:
+        bare = sum(
+            1 for e in entries
+            if isinstance(coerce_value(getattr(e, "value", None)), list)
+        )
+        if bare:
+            manifest["hint"] = (
+                f"{bare} of {len(entries)} entries store a top-level array. "
+                "Re-run with row_path='.' to flatten into one row per record."
+            )
     # Gate the inline copy on the size it will ACTUALLY occupy in this manifest,
     # not on len(content): a CSV file is compact, but manifest["inline"] embeds
     # the raw records which re-serialize as JSON — far larger for csv/json — so
@@ -1290,7 +1302,8 @@ def amfs_aggregate(
         field: Dotted field to aggregate, e.g. "price" or "meta.yield".
         group_by: Optional dotted field to group results by (e.g. "city").
         row_path: Optional dotted field holding a list of records to flatten
-            into rows first (e.g. "listings" for batch entries).
+            into rows first (e.g. "listings" for batch entries). Use "." when
+            the entry value is itself the list.
 
     Example: amfs_aggregate("@deals-room/listings", op="mean", field="price", group_by="city", row_path="listings")
     """

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs"
-version = "0.5.9"
+version = "0.5.10"
 description = "AMFS Python SDK — Agent Memory File System"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -8,7 +8,7 @@ dependencies = [
     # 0.3.14 adds ToolCall, ReadTracker.record_action and
     # capture.scan_captured_arguments. record_action and commit_outcome below use
     # all three unconditionally, so an older core raises rather than degrading.
-    "amfs-core>=0.3.15",
+    "amfs-core>=0.3.16",
     "amfs-adapter-filesystem",
     "pyyaml>=6.0,<7",
 ]

--- a/tests/unit/test_aggregates_bulk.py
+++ b/tests/unit/test_aggregates_bulk.py
@@ -61,6 +61,22 @@ def test_iter_rows_flattens_list_valued_field():
     assert rows == [{"p": 1}, {"p": 2}, {"p": 3}]
 
 
+def test_iter_rows_flattens_bare_array_without_row_path():
+    rows = iter_rows([_entry([{"p": 1}, {"p": 2}]), _entry([{"p": 3}])])
+    assert rows == [{"p": 1}, {"p": 2}, {"p": 3}]
+
+
+def test_iter_rows_dot_flattens_bare_array():
+    rows = iter_rows([_entry([{"p": 1}, {"p": 2}])], row_path=".")
+    assert rows == [{"p": 1}, {"p": 2}]
+
+
+def test_iter_rows_guessed_wrapper_still_flattens_bare_array():
+    # Agents guess "properties" / "listings" even when the value IS the list.
+    rows = iter_rows([_entry([{"p": 1}, {"p": 2}])], row_path="properties")
+    assert rows == [{"p": 1}, {"p": 2}]
+
+
 # ── aggregation ──────────────────────────────────────────────────────────
 
 
@@ -148,6 +164,14 @@ def test_schema_profile_detects_row_path_candidates():
     cands = {c["field"]: c for c in prof["row_path_candidates"]}
     assert "listings" in cands
     assert cands["listings"]["total_rows"] == 2
+
+
+def test_schema_profile_candidate_for_bare_array():
+    entries = [_entry([{"p": 1}, {"p": 2}], key="b1"), _entry([{"p": 3}], key="b2")]
+    prof = room_schema_profile(entries)
+    cands = {c["field"]: c for c in prof["row_path_candidates"]}
+    assert cands["."]["total_rows"] == 3
+    assert cands["."]["entries"] == 2
 
 
 def test_schema_profile_counts_records_per_key():

--- a/tests/unit/test_mcp_tools_smoke.py
+++ b/tests/unit/test_mcp_tools_smoke.py
@@ -131,6 +131,27 @@ class TestReadSurfaceSmoke:
         )
         assert "inline" in at_or_above
 
+    def test_export_flattens_bare_array_with_dot_row_path(self, srv):
+        srv.amfs_write(
+            "smoke/bare", "chunk",
+            json.dumps([{"addr": "1 Main"}, {"addr": "2 Main"}]),
+        )
+        payload = _ok(
+            "amfs_export",
+            srv.amfs_export("smoke/bare", format="csv", row_path="."),
+        )
+        assert payload["entry_count"] == 1
+        assert payload["record_count"] == 2
+        csv_text = Path(payload["path"]).read_text()
+        assert "1 Main" in csv_text
+        assert "2 Main" in csv_text
+
+    def test_export_hints_when_values_are_bare_arrays(self, srv):
+        srv.amfs_write("smoke/bare2", "chunk", json.dumps([{"addr": "1 Main"}]))
+        payload = _ok("amfs_export", srv.amfs_export("smoke/bare2", format="csv"))
+        assert payload["record_count"] == 1
+        assert "row_path='.'" in payload["hint"]
+
     def test_aggregate_local_fallback(self, srv):
         # No AMFS_HTTP_URL in this test env, so amfs_aggregate must compute
         # locally over the same aggregates module rather than erroring.

--- a/uv.lock
+++ b/uv.lock
@@ -8,10 +8,6 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
-[options]
-exclude-newer = "2026-08-23T04:18:34.009715Z"
-exclude-newer-span = "P2D"
-
 [manifest]
 members = [
     "amfs",

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
+[options]
+exclude-newer = "2026-08-23T04:18:34.009715Z"
+exclude-newer-span = "P2D"
+
 [manifest]
 members = [
     "amfs",
@@ -184,7 +188,7 @@ wheels = [
 
 [[package]]
 name = "amfs"
-version = "0.5.8"
+version = "0.5.10"
 source = { editable = "packages/sdk-python" }
 dependencies = [
     { name = "amfs-adapter-filesystem" },
@@ -216,7 +220,7 @@ requires-dist = [
 
 [[package]]
 name = "amfs-adapter-http"
-version = "0.1.10"
+version = "0.1.12"
 source = { editable = "packages/adapters/http" }
 dependencies = [
     { name = "amfs-core" },
@@ -231,7 +235,7 @@ requires-dist = [
 
 [[package]]
 name = "amfs-adapter-postgres"
-version = "0.2.2"
+version = "0.2.4"
 source = { editable = "packages/adapters/postgres" }
 dependencies = [
     { name = "amfs-core" },
@@ -330,7 +334,7 @@ provides-extras = ["cli"]
 
 [[package]]
 name = "amfs-core"
-version = "0.3.14"
+version = "0.3.16"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "pydantic" },
@@ -395,7 +399,7 @@ provides-extras = ["crewai"]
 
 [[package]]
 name = "amfs-http-server"
-version = "0.3.15"
+version = "0.3.17"
 source = { editable = "packages/http-server" }
 dependencies = [
     { name = "amfs" },
@@ -465,11 +469,12 @@ provides-extras = ["langgraph"]
 
 [[package]]
 name = "amfs-mcp-server"
-version = "0.7.15"
+version = "0.7.17"
 source = { editable = "packages/mcp-server" }
 dependencies = [
     { name = "amfs" },
     { name = "amfs-adapter-http" },
+    { name = "amfs-core" },
     { name = "fastmcp" },
 ]
 
@@ -477,6 +482,7 @@ dependencies = [
 requires-dist = [
     { name = "amfs", editable = "packages/sdk-python" },
     { name = "amfs-adapter-http", editable = "packages/adapters/http" },
+    { name = "amfs-core", editable = "packages/core" },
     { name = "fastmcp", specifier = ">=2.0" },
 ]
 


### PR DESCRIPTION
## Summary

`iter_rows` only descended into dicts, so `row_path` resolved to nothing whenever an entry stored a **bare JSON array** instead of a `{"listings": [...]}` wrapper. The tool did not fail — it returned **zero rows**, which reads as "this data has no such shape" rather than "you named a key that cannot exist here."

Found on a real room: 116 entries holding 1,873 property records, unexportable per-record. Every guessed `row_path` (`properties`, `listings`, `value`) returned 0, and the agent driving it concluded the storage had to be rewritten as `{"properties": [...]}`. It did not.

- Flatten the value itself when it is already a list; accept `row_path="."` (or `"$"`) to say so explicitly. A guessed wrapper name now flattens too, because on a bare array there is no key to be wrong about.
- `_row_path_candidates` reports `"."`, so schema profiling and entity digests describe these rooms by field instead of as opaque `_value` blobs.
- A whole-entry export that sees bare arrays now says so in the manifest `hint`.
- Whole-entry export (no `row_path`) is unchanged.

## Why the version bumps

This only reaches clients as a release, and `auto-publish` only fires on manifest changes — editing `aggregates.py` alone publishes nothing. That is the same idempotency miss that left `amfs-core` 0.3.14 stale.

| Package | Version |
|---|---|
| `amfs-core` | 0.3.15 → **0.3.16** (the fix) |
| `amfs-mcp-server` | 0.7.16 → **0.7.17** |
| `amfs` | 0.5.9 → **0.5.10** |
| `amfs-adapter-http` | 0.1.11 → **0.1.12** |
| `amfs-adapter-postgres` | 0.2.3 → **0.2.4** |
| `amfs-http-server` | 0.3.16 → **0.3.17** |

The load-bearing line is `amfs-mcp-server` flooring `amfs-core>=0.3.16` at the import site. Paired with 0.3.15, the new `row_path="."` raises nothing and writes an empty file — a silent empty result is worse than the ImportError this same floor was added to prevent. Sibling floors cascade with version bumps so the corrected metadata actually ships (precedent: 27e2e8c).

`amfs-mcp-server-pro` needs no release: it floors `amfs-mcp-server>=0.7.14`, so `uvx` resolves 0.7.17, whose floor drags in core 0.3.16.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared row-flattening used by export, aggregate, and schema profiling; wrong pairing of package versions was a prior silent-data bug, mitigated by explicit `amfs-core>=0.3.16` floors.
> 
> **Overview**
> **Export and aggregate** now treat memory entries whose value is a bare JSON array (not wrapped in a dict key) as one row per element. Previously, `iter_rows` only walked dict paths, so a wrong or missing `row_path` on those entries yielded **zero rows** with no error.
> 
> Core changes in `amfs_core.aggregates`: new `_rows_from_value` logic flists top-level lists even when `row_path` names a nonexistent wrapper; **`row_path="."` or `"$"`** explicitly means “the value is the list.” Schema profiling adds **`"."`** as a `row_path` candidate for bare arrays.
> 
> **`amfs_export`** treats any non-empty `row_path` (including `"."`) as flatten mode and adds a manifest **hint** when whole-entry export sees top-level arrays, suggesting `row_path='.'`. Docs and tool docstrings describe the `"."` option.
> 
> **Releases**: bumps `amfs-core` to **0.3.16** and aligned floors/versions across SDK, MCP server, HTTP server, and adapters so clients cannot pair the new MCP behavior with older core that would silently export empty files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6efec0c5ea7cf04e8edff55e5b516df7b29ffcf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->