### PR TITLE
Make the Postgres adapter fit to import large datasets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,15 @@ services:
       retries: 3
 
   postgres:
-    image: pgvector/pgvector:pg16
+    # Pinned, not `pg16`. The floating tag moves, and the extension version
+    # decides whether HNSW searches can be trusted: `hnsw.iterative_scan`
+    # arrived in pgvector 0.8.0, and without it an HNSW index post-filters,
+    # walking the global proximity graph and then discarding rows that fail the
+    # WHERE clause. A query scoped to a small slice of a large table then gets
+    # results that are missing rather than merely mis-ranked, which is the kind
+    # of wrong answer nobody notices. Local, CI and Cloud SQL agreeing on one
+    # version is the only way that stays true.
+    image: pgvector/pgvector:0.8.1-pg16
     environment:
       POSTGRES_USER: amfs
       POSTGRES_PASSWORD: amfs

--- a/helm/amfs/values.yaml
+++ b/helm/amfs/values.yaml
@@ -45,7 +45,9 @@ postgres:
   external: false
   dsn: ""
   # Built-in Postgres (set external=false)
-  image: pgvector/pgvector:pg16
+  # Pinned rather than the floating `pg16` tag: HNSW recall depends on
+  # `hnsw.iterative_scan`, which needs pgvector >= 0.8.0. See docker-compose.yml.
+  image: pgvector/pgvector:0.8.1-pg16
   password: amfs
   storage: 10Gi
 

--- a/packages/adapters/postgres/src/amfs_postgres/__init__.py
+++ b/packages/adapters/postgres/src/amfs_postgres/__init__.py
@@ -2,5 +2,20 @@
 
 from amfs_postgres.adapter import PostgresAdapter
 from amfs_postgres.async_adapter import AsyncPostgresAdapter
+from amfs_postgres.tenant_gucs import (
+    TENANT_GUC_NAMES,
+    set_tenant_gucs,
+    tenant_transaction,
+)
 
-__all__ = ["PostgresAdapter", "AsyncPostgresAdapter"]
+__all__ = [
+    "PostgresAdapter",
+    "AsyncPostgresAdapter",
+    # Anything doing tenant-scoped work on its own connections needs these
+    # rather than a private import: the four settings are one list in one place,
+    # and tenant_transaction is the only form that is safe behind a
+    # transaction-mode pooler. See amfs_postgres.tenant_gucs.
+    "TENANT_GUC_NAMES",
+    "set_tenant_gucs",
+    "tenant_transaction",
+]

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -1441,7 +1441,25 @@ class PostgresAdapter(AdapterABC):
 
         ``max_rows`` bounds the work for a caller that wants to make progress
         without running to completion, such as a worker doing this between other
-        jobs.
+        jobs. It counts rows *examined*, not rows successfully embedded, and the
+        difference is the whole value of it: counting successes would mean a run
+        of rows the embedder cannot handle does not count against the budget, so
+        a caller asking for 1000 rows of work would keep fetching batches until
+        it found 1000 that worked -- walking every remaining row in the store if
+        none of them do. A bound that a bad row can lift is not a bound, and the
+        caller that needs one is precisely the one on a time slice.
+
+        The return value is still the number of rows *updated*, which is the
+        useful figure for a migration and the one the integration test asserts
+        on. When the two differ, the warning below says by how much.
+
+        One cost this does not pay off: each call starts its cursor from the
+        beginning, so rows that permanently fail are re-examined by every
+        subsequent call. That is bounded by the number of such rows rather than
+        growing, and it does not block progress -- a call still reaches new rows
+        after paying it -- so it is left as a known overhead instead of being
+        fixed with a resume cursor that no caller yet wants. If failures ever
+        grow to the point of eating a time slice, that is the fix.
 
         TODO(integration-test): covered by tests/integration/test_postgres_embeddings.py
         (needs AMFS_TEST_PG_DSN + pgvector); unvalidated in unit CI.
@@ -1450,13 +1468,14 @@ class PostgresAdapter(AdapterABC):
             return 0
         updated = 0
         failed = 0
+        examined = 0
         last_id = "00000000-0000-0000-0000-000000000000"
         while True:
-            if max_rows is not None and updated >= max_rows:
+            if max_rows is not None and examined >= max_rows:
                 break
             limit = batch_size
             if max_rows is not None:
-                limit = min(limit, max_rows - updated)
+                limit = min(limit, max_rows - examined)
             with self._pool.connection() as conn:
                 with conn.cursor() as cur:
                     cur.execute(
@@ -1470,6 +1489,7 @@ class PostgresAdapter(AdapterABC):
                         break
                     for r in rows:
                         last_id = r["id"]
+                        examined += 1
                         try:
                             value = (
                                 json.loads(r["value"])
@@ -1492,9 +1512,9 @@ class PostgresAdapter(AdapterABC):
                         updated += 1
         if failed:
             logger.warning(
-                "backfill_embeddings: %d rows updated, %d could not be embedded "
-                "and remain without one",
-                updated, failed,
+                "backfill_embeddings: examined %d rows, updated %d, %d could not "
+                "be embedded and remain without one",
+                examined, updated, failed,
             )
         return updated
 

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -154,8 +154,13 @@ def pool_bounds(
     return min(low, high), high
 
 
-def statement_timeout_options() -> str | None:
-    """The libpq ``options`` string carrying the statement ceiling, if set.
+#: Passed as ``statement_timeout`` to mean "no ceiling for this process",
+#: distinct from passing nothing, which means "whatever the environment says".
+NO_STATEMENT_TIMEOUT = "0"
+
+
+def statement_timeout_options(override: str | None = None) -> str | None:
+    """The libpq ``options`` string carrying the statement ceiling, if any.
 
     A ceiling on how long any one statement may run. Off unless asked for,
     because the right ceiling depends on the deployment: a request-serving
@@ -167,9 +172,76 @@ def statement_timeout_options() -> str | None:
     request that asked for it holds its locks with nobody left to want the
     answer, which is how a single slow query became a production outage on
     2026-08-12; see _apply_schema.
+
+    ``override`` exists because this is applied through libpq ``options``, which
+    makes it a property of the *connection* and therefore of the whole pool.
+    That is the right shape for a service but the wrong shape for a process that
+    does both kinds of work: a bulk load, a per-partition index build and an
+    embedding backfill are all single statements that legitimately outlast any
+    request, and inheriting a request-shaped ceiling from a shared environment
+    variable aborts them partway. A process that knows what it is passes its own
+    value, or :data:`NO_STATEMENT_TIMEOUT` to opt out, rather than depending on
+    how the environment happens to be configured around it.
     """
-    timeout = os.environ.get("AMFS_POSTGRES_STATEMENT_TIMEOUT", "").strip()
+    timeout = (
+        override
+        if override is not None
+        else os.environ.get("AMFS_POSTGRES_STATEMENT_TIMEOUT", "")
+    ).strip()
     return f"-c statement_timeout={timeout}" if timeout else None
+
+
+#: pgvector's accepted values. ``off`` is its default.
+_HNSW_ITERATIVE_SCAN_MODES = frozenset({"off", "strict_order", "relaxed_order"})
+
+
+def hnsw_iterative_scan_option() -> str | None:
+    """The libpq ``options`` fragment enabling iterative HNSW scans, if asked.
+
+    Without this, an HNSW index *post-filters*: it walks the global proximity
+    graph for the nearest vectors and only then discards the ones failing the
+    query's ``WHERE`` clause. A search restricted to a small slice of a large
+    table -- one tenant, one room, one dataset -- can therefore come back short
+    or empty while the rows it wanted sit unvisited. That failure is quiet, and
+    a quiet wrong answer is worse than a slow one.
+
+    ``hnsw.iterative_scan`` makes the scan keep going until it has enough rows
+    that actually satisfy the filter. It needs pgvector >= 0.8.0.
+
+    Off unless asked for, and deliberately not on by default: this is applied
+    through libpq ``options``, so on a server whose pgvector predates 0.8.0 the
+    setting is unrecognised and *every connection fails to open*. An installer
+    who has not pinned their extension version should not have the adapter stop
+    working because of a flag they never set. Deployments that control their
+    database version -- which is the same set that can pin the image -- opt in.
+    """
+    mode = os.environ.get("AMFS_POSTGRES_HNSW_ITERATIVE_SCAN", "").strip().lower()
+    if not mode:
+        return None
+    if mode not in _HNSW_ITERATIVE_SCAN_MODES:
+        raise ValueError(
+            "AMFS_POSTGRES_HNSW_ITERATIVE_SCAN must be one of "
+            f"{sorted(_HNSW_ITERATIVE_SCAN_MODES)}, got {mode!r}"
+        )
+    return f"-c hnsw.iterative_scan={mode}"
+
+
+def connection_options(statement_timeout: str | None = None) -> str | None:
+    """Everything this process wants set on each connection, as one string.
+
+    libpq takes repeated ``-c`` flags separated by spaces, so the fragments
+    compose. None when nothing is configured, so callers can leave ``options``
+    off the connection entirely rather than passing an empty string.
+    """
+    fragments = [
+        fragment
+        for fragment in (
+            statement_timeout_options(statement_timeout),
+            hnsw_iterative_scan_option(),
+        )
+        if fragment
+    ]
+    return " ".join(fragments) if fragments else None
 
 
 def _tables_created_by(sql: str) -> frozenset[str]:
@@ -223,61 +295,59 @@ class _SingleConnectionPool:
 
 
 class _TenantRLSConnection:
-    """Applies ``amfs.current_account_id`` when a request-scoped tenant is set.
+    """Applies the four tenant settings on every checkout.
 
-    Always sets the GUC on every checkout:
-    - When a tenant is present: sets the real account UUID (RLS filters to that tenant).
-    - When no tenant is present: sets empty string which, via NULLIF in RLS
-      policies, evaluates to NULL — matching zero rows. This prevents stale
-      tenant context from a previous pooled-connection user leaking across
-      requests.
+    All four are set every time, whether or not a request tenant is present:
+    with a tenant, to the real values; without one, to empty, which ``NULLIF``
+    in the policies turns into NULL so nothing matches. Setting them
+    unconditionally is the point — skipping the write when there is no tenant
+    would leave the previous borrower of this pooled connection in place, and
+    ``amfs.current_user_id`` is the setting that grants reach across accounts.
+
+    Session-scoped, which is correct for ``psycopg_pool`` and not correct behind
+    a transaction-mode pooler. See :mod:`amfs_postgres.tenant_gucs` for why, and
+    :func:`~amfs_postgres.tenant_gucs.tenant_transaction` for the form that is.
     """
 
-    _log_counter = 0
+    _tenantless_checkouts = 0
 
     def __init__(self, inner_ctx: Any) -> None:
         self._inner_ctx = inner_ctx
 
     def __enter__(self) -> Any:
-        from amfs_postgres.tenant_context import (
-            get_request_tenant_account_id,
-            get_request_tenant_team_id,
-            get_request_is_account_admin,
-            get_request_user_id,
-        )
+        from amfs_postgres.tenant_gucs import set_tenant_gucs
 
         conn = self._inner_ctx.__enter__()
-        tid = get_request_tenant_account_id()
-        team_id = get_request_tenant_team_id()
-        is_admin = get_request_is_account_admin()
-        user_id = get_request_user_id()
-
-        _TenantRLSConnection._log_counter += 1
-        if _TenantRLSConnection._log_counter <= 20 or not tid:
-            import logging as _logging
-            _logging.getLogger("amfs_postgres.adapter").warning(
-                "[RLS-CONN] account_id=%s team_id=%s is_admin=%s",
-                tid, team_id, is_admin,
-            )
-
         with conn.cursor() as cur:
-            # current_user_id is set unconditionally, like the others: on a
-            # pooled connection, leaving it alone would leave the previous
-            # borrower's user in place, and this is the one GUC that grants
-            # access across accounts rather than restricting within one.
-            cur.execute(
-                "SELECT set_config('amfs.current_account_id', %s, false),"
-                "       set_config('amfs.current_team_id', %s, false),"
-                "       set_config('amfs.is_account_admin', %s, false),"
-                "       set_config('amfs.current_user_id', %s, false)",
-                (
-                    tid if tid else "",
-                    team_id if team_id else "",
-                    "true" if is_admin else "false",
-                    user_id if user_id else "",
-                ),
-            )
+            set_tenant_gucs(cur, local=False)
+        self._warn_if_tenantless()
         return conn
+
+    @staticmethod
+    def _warn_if_tenantless() -> None:
+        """Report tenant-less checkouts, but on a curve rather than every time.
+
+        A checkout with no tenant is worth knowing about, because in a request
+        path it means reads are about to return nothing. It is also completely
+        normal in a worker or a CLI, which have no request to carry one — and
+        those are exactly the processes that check out connections in a tight
+        loop, where one warning per checkout buries the log it was meant to
+        inform. Powers of two keep the first few and then get out of the way.
+        """
+        from amfs_postgres.tenant_context import get_request_tenant_account_id
+
+        if get_request_tenant_account_id():
+            return
+        _TenantRLSConnection._tenantless_checkouts += 1
+        count = _TenantRLSConnection._tenantless_checkouts
+        if count & (count - 1):  # not a power of two
+            return
+        logger.warning(
+            "Postgres checkout with no tenant account_id (%d so far) — "
+            "RLS-protected reads will return no rows. Expected in workers and "
+            "CLIs; a bug in a request path.",
+            count,
+        )
 
     def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Any:
         return self._inner_ctx.__exit__(exc_type, exc, tb)
@@ -325,6 +395,7 @@ class PostgresAdapter(AdapterABC):
         max_pool_size: int | None = None,
         embedder: EmbedderABC | None = None,
         embedding_dim: int = 384,
+        statement_timeout: str | None = None,
     ) -> None:
         self._dsn = dsn
         self._namespace = namespace
@@ -341,16 +412,24 @@ class PostgresAdapter(AdapterABC):
             "row_factory": dict_row,
             "autocommit": True,
         }
-        options = statement_timeout_options()
+        options = connection_options(statement_timeout)
         if options:
             connect_kwargs["options"] = options
         pool_kwargs: dict[str, Any] = {"kwargs": connect_kwargs}
         if _ConnectionPool is not None:
+            from amfs_postgres.tenant_gucs import reset_tenant_gucs
+
             min_size, max_size = pool_bounds(min_pool_size, max_pool_size)
             self._pool = _ConnectionPool(
                 dsn,
                 min_size=min_size,
                 max_size=max_size,
+                # Blank the tenant settings as the connection goes back. Every
+                # checkout already overwrites all four, so this is not what
+                # prevents a leak in normal use; it prevents one from outliving
+                # a checkout that raised partway through, and it means an
+                # idle pooled connection is never sitting on a real tenant.
+                reset=reset_tenant_gucs,
                 **pool_kwargs,
             )
         else:
@@ -1333,12 +1412,36 @@ class PostgresAdapter(AdapterABC):
                 )
         self._detect_optional_columns()
 
-    def backfill_embeddings(self, *, batch_size: int = 200) -> int:
+    def backfill_embeddings(
+        self, *, batch_size: int = 200, max_rows: int | None = None
+    ) -> int:
         """Compute and store embeddings for existing rows that lack one.
 
         Returns the number of rows updated. Requires a configured embedder and
-        the embedding column. Intended as a one-off migration step after
-        enabling write-time embeddings on an existing store.
+        the embedding column. Intended as a migration step after enabling
+        write-time embeddings on an existing store, and as the repair path for
+        rows an import wrote while no embedder was configured.
+
+        Walks a keyset cursor over ``id`` to completion, in the same shape as
+        :meth:`backfill_is_artifact`. Both properties matter, and neither was
+        true before:
+
+        * **It finishes.** The previous version read one batch and returned, so
+          a caller asking to backfill a store with more than ``batch_size``
+          missing embeddings silently got ``batch_size`` of them and no
+          indication there was more.
+        * **A row that cannot be embedded cannot starve the ones behind it.**
+          The previous version ordered by ``written_at`` and skipped failures
+          with ``continue``, leaving them ``NULL``. Every later call therefore
+          re-read the same permanently-failing rows at the head of the batch --
+          a value the embedder chokes on is enough to stall the backfill
+          forever, and the symptom is a store that never finishes backfilling
+          rather than an error. Advancing by ``id`` regardless of outcome is
+          what fixes it, since progress no longer depends on success.
+
+        ``max_rows`` bounds the work for a caller that wants to make progress
+        without running to completion, such as a worker doing this between other
+        jobs.
 
         TODO(integration-test): covered by tests/integration/test_postgres_embeddings.py
         (needs AMFS_TEST_PG_DSN + pgvector); unvalidated in unit CI.
@@ -1346,27 +1449,53 @@ class PostgresAdapter(AdapterABC):
         if self._embedder is None or not self._has_embedding_col:
             return 0
         updated = 0
-        with self._pool.connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    "SELECT id, value FROM amfs_memory_entries "
-                    "WHERE namespace = %s AND embedding IS NULL "
-                    "ORDER BY written_at LIMIT %s",
-                    (self._namespace, batch_size),
-                )
-                rows = cur.fetchall()
-                for r in rows:
-                    try:
-                        value = json.loads(r["value"]) if isinstance(r["value"], str) else r["value"]
-                        vec = self._embedder.embed_value(value)
-                    except Exception:  # noqa: BLE001
-                        logger.warning("backfill embedding failed for row %s", r["id"], exc_info=True)
-                        continue
+        failed = 0
+        last_id = "00000000-0000-0000-0000-000000000000"
+        while True:
+            if max_rows is not None and updated >= max_rows:
+                break
+            limit = batch_size
+            if max_rows is not None:
+                limit = min(limit, max_rows - updated)
+            with self._pool.connection() as conn:
+                with conn.cursor() as cur:
                     cur.execute(
-                        "UPDATE amfs_memory_entries SET embedding = %s WHERE id = %s",
-                        (f"[{','.join(str(v) for v in vec)}]", r["id"]),
+                        "SELECT id, value FROM amfs_memory_entries "
+                        "WHERE namespace = %s AND embedding IS NULL AND id > %s "
+                        "ORDER BY id LIMIT %s",
+                        (self._namespace, last_id, limit),
                     )
-                    updated += 1
+                    rows = cur.fetchall()
+                    if not rows:
+                        break
+                    for r in rows:
+                        last_id = r["id"]
+                        try:
+                            value = (
+                                json.loads(r["value"])
+                                if isinstance(r["value"], str)
+                                else r["value"]
+                            )
+                            vec = self._embedder.embed_value(value)
+                        except Exception:  # noqa: BLE001
+                            failed += 1
+                            logger.warning(
+                                "backfill embedding failed for row %s", r["id"],
+                                exc_info=True,
+                            )
+                            continue
+                        cur.execute(
+                            "UPDATE amfs_memory_entries SET embedding = %s "
+                            "WHERE id = %s",
+                            (f"[{','.join(str(v) for v in vec)}]", r["id"]),
+                        )
+                        updated += 1
+        if failed:
+            logger.warning(
+                "backfill_embeddings: %d rows updated, %d could not be embedded "
+                "and remain without one",
+                updated, failed,
+            )
         return updated
 
     def backfill_is_artifact(self, *, batch_size: int = 200, reembed: bool = True) -> int:

--- a/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
@@ -38,7 +38,7 @@ from amfs_postgres.adapter import (
     _EXCLUDE_SHARED_PATHS,
     PostgresAdapter,
     pool_bounds,
-    statement_timeout_options,
+    connection_options,
 )
 
 logger = logging.getLogger(__name__)
@@ -62,41 +62,17 @@ class _AsyncTenantRLSConnection:
         self._inner_ctx = inner_ctx
 
     async def __aenter__(self) -> Any:
-        from amfs_postgres.tenant_context import (
-            get_request_tenant_account_id,
-            get_request_tenant_team_id,
-            get_request_is_account_admin,
-            get_request_user_id,
-        )
+        from amfs_postgres.tenant_context import get_request_tenant_account_id
+        from amfs_postgres.tenant_gucs import aset_tenant_gucs
 
         conn = await self._inner_ctx.__aenter__()
-        tid = get_request_tenant_account_id()
-        team_id = get_request_tenant_team_id()
-        is_admin = get_request_is_account_admin()
-        user_id = get_request_user_id()
-
-        guc_account = tid if tid else ""
-        guc_team = team_id if team_id else ""
-        guc_admin = "true" if is_admin else "false"
-        guc_user = user_id if user_id else ""
-
-        if not tid:
-            logger.warning(
-                "async pool checkout: tenant account_id is EMPTY "
-                "(tid=%r, team=%r, admin=%r) — RLS reads will return no rows",
-                tid, team_id, is_admin,
-            )
-
         async with conn.cursor() as cur:
-            # Set unconditionally, for the same reason as the other three: a
-            # pooled connection would otherwise keep the previous borrower's
-            # user, and this is the GUC that grants access across accounts.
-            await cur.execute(
-                "SELECT set_config('amfs.current_account_id', %s, false),"
-                "       set_config('amfs.current_team_id', %s, false),"
-                "       set_config('amfs.is_account_admin', %s, false),"
-                "       set_config('amfs.current_user_id', %s, false)",
-                (guc_account, guc_team, guc_admin, guc_user),
+            await aset_tenant_gucs(cur, local=False)
+
+        if not get_request_tenant_account_id():
+            logger.warning(
+                "async pool checkout with no tenant account_id — RLS-protected "
+                "reads will return no rows"
             )
         return conn
 
@@ -143,6 +119,7 @@ class AsyncPostgresAdapter:
         *,
         min_pool_size: int | None = None,
         max_pool_size: int | None = None,
+        statement_timeout: str | None = None,
     ) -> None:
         self._dsn = dsn
         self._namespace = namespace
@@ -155,7 +132,7 @@ class AsyncPostgresAdapter:
         # on — and until this line existed, AMFS_POSTGRES_STATEMENT_TIMEOUT
         # reached only the sync adapter, leaving the request path it was
         # introduced to protect without one.
-        options = statement_timeout_options()
+        options = connection_options(statement_timeout)
         if options:
             connect_kwargs["options"] = options
         min_size, max_size = pool_bounds(min_pool_size, max_pool_size)

--- a/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
@@ -40,6 +40,7 @@ from amfs_postgres.adapter import (
     pool_bounds,
     connection_options,
 )
+from amfs_postgres.tenant_gucs import areset_tenant_gucs
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +143,12 @@ class AsyncPostgresAdapter:
                 min_size=min_size,
                 max_size=max_size,
                 kwargs=connect_kwargs,
+                # The same blanking the sync pool does on return, and this is
+                # the pool that needs it more: these are the hot-path REST
+                # endpoints, so this is where tenants change fastest and where
+                # an idle connection left holding amfs.current_user_id would be
+                # holding the setting that reaches across accounts.
+                reset=areset_tenant_gucs,
                 open=False,
             )
         )

--- a/packages/adapters/postgres/src/amfs_postgres/tenant_gucs.py
+++ b/packages/adapters/postgres/src/amfs_postgres/tenant_gucs.py
@@ -1,0 +1,179 @@
+"""The four Postgres settings that decide what a request can see.
+
+RLS on ``amfs_memory_entries`` is not one predicate but several, layered by the
+SaaS migrations, and between them they read four GUCs:
+
+  - ``amfs.current_account_id``  the outer tenant boundary
+  - ``amfs.current_team_id``     the inner boundary within an account
+  - ``amfs.is_account_admin``    bypasses the team boundary
+  - ``amfs.current_user_id``     grants reach *across* accounts, via rooms
+
+The last two are the dangerous pair. Three of the four narrow what a caller
+sees, so getting them wrong shows up as missing rows; ``current_user_id`` is the
+one that widens, because a user invited to a room in someone else's account
+reaches it through permissive policies keyed on that value and nothing else.
+A stale one is a cross-account read.
+
+They live here rather than in either adapter because the sync and async adapters
+were each carrying their own copy of the same four-statement SQL, which is two
+places to remember when a fifth setting arrives, and drift here is a security
+bug rather than a formatting one.
+
+Session-scoped versus transaction-local
+---------------------------------------
+``set_config(name, value, is_local)`` takes a flag: false lasts for the session,
+true until the end of the current transaction. Both adapters use false today,
+set once per pool checkout, and with ``psycopg_pool`` that is sound — a checkout
+owns its backend for the whole block, and every checkout overwrites all four
+before running anything.
+
+It stops being sound the moment a transaction-mode pooler sits in front, because
+then one client connection maps to a different backend per transaction: the
+values set at checkout land on whichever backend served that statement, and the
+next query can be answered by a backend still carrying another tenant's session.
+Pooler-safe means setting them *inside* the transaction that reads, which is
+what :func:`tenant_transaction` is for.
+
+The trap, which is why this is not a one-line change: with ``autocommit=True``
+-- what both adapters open their pools with -- ``set_config(..., true)`` applies
+to the implicit single-statement transaction it runs in and is gone before the
+next statement. The GUCs read empty, ``NULLIF`` turns that into NULL, and RLS
+matches nothing. It does not raise; it silently returns no rows. The same trap
+is already documented for ``SET LOCAL`` in ``_apply_schema``. So the local form
+is only ever used inside an explicit transaction, and
+:func:`tenant_transaction` asserts it has one rather than trusting the caller.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+from typing import Any
+
+#: In the order the SQL below binds them. Adding one means adding it here and
+#: nowhere else.
+TENANT_GUC_NAMES: tuple[str, ...] = (
+    "amfs.current_account_id",
+    "amfs.current_team_id",
+    "amfs.is_account_admin",
+    "amfs.current_user_id",
+)
+
+
+def _set_config_sql(*, local: bool) -> str:
+    """One statement setting all four, as literal names and a literal flag.
+
+    Only the values are parameterised. The names and the flag are constants from
+    this module, never caller input, so interpolating them cannot carry a
+    payload -- and keeping them out of the parameter list is what lets the whole
+    thing be a single round trip.
+    """
+    flag = "true" if local else "false"
+    return "SELECT " + ", ".join(
+        f"set_config('{name}', %s, {flag})" for name in TENANT_GUC_NAMES
+    )
+
+
+SET_TENANT_GUCS_SESSION = _set_config_sql(local=False)
+SET_TENANT_GUCS_LOCAL = _set_config_sql(local=True)
+
+
+def tenant_guc_values() -> tuple[str, str, str, str]:
+    """The current request's four values, ready to bind.
+
+    Empty string rather than None for the absent case, deliberately: the
+    policies wrap each read in ``NULLIF(..., '')``, so empty becomes NULL and
+    matches zero rows. A missing tenant therefore fails closed. Passing None
+    would reach the same place, but only because psycopg renders it as NULL --
+    empty string says it was meant.
+    """
+    from amfs_postgres.tenant_context import (
+        get_request_is_account_admin,
+        get_request_tenant_account_id,
+        get_request_tenant_team_id,
+        get_request_user_id,
+    )
+
+    account_id = get_request_tenant_account_id()
+    team_id = get_request_tenant_team_id()
+    user_id = get_request_user_id()
+    return (
+        account_id if account_id else "",
+        team_id if team_id else "",
+        "true" if get_request_is_account_admin() else "false",
+        user_id if user_id else "",
+    )
+
+
+CLEAR_TENANT_GUCS = SET_TENANT_GUCS_SESSION
+CLEARED_TENANT_GUC_VALUES: tuple[str, str, str, str] = ("", "", "false", "")
+
+
+def set_tenant_gucs(cur: Any, *, local: bool = False) -> None:
+    """Apply the current request's tenant to an open cursor."""
+    sql = SET_TENANT_GUCS_LOCAL if local else SET_TENANT_GUCS_SESSION
+    cur.execute(sql, tenant_guc_values())
+
+
+async def aset_tenant_gucs(cur: Any, *, local: bool = False) -> None:
+    """Async twin of :func:`set_tenant_gucs`."""
+    sql = SET_TENANT_GUCS_LOCAL if local else SET_TENANT_GUCS_SESSION
+    await cur.execute(sql, tenant_guc_values())
+
+
+def reset_tenant_gucs(conn: Any) -> None:
+    """Blank all four. Suitable as a ``psycopg_pool`` ``reset`` callback.
+
+    Defence in depth for the session-scoped path. Every checkout already
+    overwrites all four before running anything, so this is not what stops a
+    leak today; it stops one from surviving a checkout that failed partway, or a
+    caller that reached the pool without going through the wrapper. Cheap enough
+    to be worth not having to reason about.
+    """
+    with conn.cursor() as cur:
+        cur.execute(CLEAR_TENANT_GUCS, CLEARED_TENANT_GUC_VALUES)
+
+
+def _assert_in_transaction(conn: Any) -> None:
+    """Refuse to proceed unless a transaction is genuinely open.
+
+    This is the guard against the silent-empty-result failure described in the
+    module docstring. If the local ``set_config`` runs outside a transaction it
+    is discarded immediately and every following query reads an empty tenant, so
+    the caller gets no rows and no error. Better to raise here, loudly, than to
+    return an empty page that looks like an empty account.
+    """
+    status = getattr(getattr(conn, "info", None), "transaction_status", None)
+    if status is None:
+        return
+    name = getattr(status, "name", str(status))
+    if name not in ("INTRANS", "INERROR", "ACTIVE"):
+        raise RuntimeError(
+            "tenant_transaction: no open transaction "
+            f"(transaction_status={name}). Transaction-local tenant settings "
+            "would be discarded before the next statement and every read would "
+            "silently return zero rows."
+        )
+
+
+@contextlib.contextmanager
+def tenant_transaction(pool: Any) -> Iterator[Any]:
+    """A connection whose tenant is scoped to one real transaction.
+
+    The pooler-safe way to read or write tenant data: opens an explicit
+    transaction, sets the four settings inside it, and lets Postgres discard
+    them at commit. Nothing is left on the backend for the next borrower, which
+    is what makes it safe to put a transaction-mode pooler in front.
+
+    Unwraps ``_TenantRLSPoolWrapper`` if handed one. The wrapper sets the same
+    four settings session-scoped at checkout, and here that is not merely
+    redundant: through a transaction pooler those writes land on an arbitrary
+    backend and stay there, which is the leak this function exists to avoid.
+    """
+    inner = getattr(pool, "_inner", pool)
+    with inner.connection() as conn:
+        with conn.transaction():
+            _assert_in_transaction(conn)
+            with conn.cursor() as cur:
+                set_tenant_gucs(cur, local=True)
+            yield conn

--- a/packages/adapters/postgres/src/amfs_postgres/tenant_gucs.py
+++ b/packages/adapters/postgres/src/amfs_postgres/tenant_gucs.py
@@ -134,6 +134,20 @@ def reset_tenant_gucs(conn: Any) -> None:
         cur.execute(CLEAR_TENANT_GUCS, CLEARED_TENANT_GUC_VALUES)
 
 
+async def areset_tenant_gucs(conn: Any) -> None:
+    """Async twin of :func:`reset_tenant_gucs`, for ``AsyncConnectionPool``.
+
+    Needed separately because ``psycopg_pool`` awaits the async pool's ``reset``
+    callback, so the sync function cannot be handed to both. Worth more here
+    than on the sync side, not less: this pool serves the HTTP request path,
+    which is the most multi-tenant thing in the system and the place where an
+    idle connection left holding ``amfs.current_user_id`` would be holding the
+    one setting that grants reach across accounts.
+    """
+    async with conn.cursor() as cur:
+        await cur.execute(CLEAR_TENANT_GUCS, CLEARED_TENANT_GUC_VALUES)
+
+
 def _assert_in_transaction(conn: Any) -> None:
     """Refuse to proceed unless a transaction is genuinely open.
 

--- a/tests/unit/test_async_adapter_pool.py
+++ b/tests/unit/test_async_adapter_pool.py
@@ -40,6 +40,26 @@ class TestTheStatementCeiling:
         assert kwargs["row_factory"] is not None
 
 
+class TestTheTenantResetOnReturn:
+    """The sync pool blanks the four tenant settings when a connection goes
+    back. This pool serves the request path, where tenants change fastest, so
+    going without it was the gap that mattered more of the two."""
+
+    def test_the_pool_is_given_a_reset_callback(self):
+        from amfs_postgres.tenant_gucs import areset_tenant_gucs
+
+        assert _pool(AsyncPostgresAdapter(dsn=DSN))._reset is areset_tenant_gucs
+
+    def test_the_callback_is_awaitable(self):
+        # psycopg_pool awaits the async pool's reset, so handing it the sync
+        # helper would raise on every connection return rather than at startup.
+        import inspect
+
+        from amfs_postgres.tenant_gucs import areset_tenant_gucs
+
+        assert inspect.iscoroutinefunction(areset_tenant_gucs)
+
+
 class TestThePoolSize:
     def test_it_follows_the_environment(self, monkeypatch):
         monkeypatch.setenv("AMFS_POSTGRES_POOL_MAX", "6")

--- a/tests/unit/test_backfill_embeddings.py
+++ b/tests/unit/test_backfill_embeddings.py
@@ -1,0 +1,210 @@
+"""Backfilling embeddings onto rows that were written without one.
+
+Two properties, neither of which held before, and both of which fail quietly
+rather than loudly:
+
+* It runs to completion. Reading a single batch and returning looks identical
+  to success from the caller's side — a number comes back — while most of the
+  store still has no vector and so is invisible to semantic search.
+* A row the embedder cannot handle does not block the rows behind it. Ordering
+  by written_at and skipping failures with `continue` left those rows NULL, so
+  they were re-read at the head of every subsequent batch, forever. One bad
+  value is then enough to stall the backfill permanently.
+
+Both come down to advancing a keyset cursor by id regardless of whether the
+row succeeded, which is what backfill_is_artifact already did.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from amfs_postgres.adapter import PostgresAdapter
+
+_ZERO_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+class _FakeCursor:
+    """Understands just the two statements backfill_embeddings issues."""
+
+    def __init__(self, db: _FakeDB) -> None:
+        self._db = db
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple = ()) -> None:
+        if sql.startswith("SELECT id, value"):
+            _namespace, last_id, limit = params
+            self._db.selects.append((last_id, limit))
+            pending = sorted(
+                row_id
+                for row_id, vector in self._db.embeddings.items()
+                if vector is None and row_id > last_id
+            )
+            self._rows = [
+                {"id": row_id, "value": json.dumps({"row": row_id})}
+                for row_id in pending[:limit]
+            ]
+        elif sql.startswith("UPDATE amfs_memory_entries SET embedding"):
+            vector, row_id = params
+            self._db.embeddings[row_id] = vector
+        else:  # pragma: no cover - would mean the query changed shape
+            raise AssertionError(f"unexpected statement: {sql}")
+
+    def fetchall(self) -> list[dict]:
+        return self._rows
+
+
+class _FakeDB:
+    def __init__(self, row_ids: list[str]) -> None:
+        self.embeddings: dict[str, str | None] = {r: None for r in row_ids}
+        self.selects: list[tuple[str, int]] = []
+
+    def connection(self) -> Any:
+        cursor = _FakeCursor(self)
+        pool_ctx = MagicMock()
+        pool_ctx.__enter__ = MagicMock(return_value=_conn_with(cursor))
+        pool_ctx.__exit__ = MagicMock(return_value=None)
+        return pool_ctx
+
+    @property
+    def embedded(self) -> set[str]:
+        return {r for r, v in self.embeddings.items() if v is not None}
+
+    @property
+    def missing(self) -> set[str]:
+        return {r for r, v in self.embeddings.items() if v is None}
+
+
+def _conn_with(cursor: _FakeCursor) -> MagicMock:
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=cursor)
+    return conn
+
+
+def _adapter(db: _FakeDB, *, failing: set[str] | None = None) -> PostgresAdapter:
+    """A PostgresAdapter with a fake pool, built without touching a database."""
+    failing = failing or set()
+
+    def embed_value(value: Any) -> list[float]:
+        row_id = value["row"] if isinstance(value, dict) else value
+        if row_id in failing:
+            raise ValueError(f"cannot embed {row_id}")
+        return [0.1, 0.2, 0.3]
+
+    adapter = object.__new__(PostgresAdapter)
+    adapter._pool = db
+    adapter._namespace = "default"
+    adapter._has_embedding_col = True
+    embedder = MagicMock()
+    embedder.embed_value = MagicMock(side_effect=embed_value)
+    adapter._embedder = embedder
+    return adapter
+
+
+def _ids(count: int) -> list[str]:
+    return [f"row-{n:03d}" for n in range(count)]
+
+
+class TestItRunsToCompletion:
+    def test_more_rows_than_one_batch_are_all_embedded(self):
+        db = _FakeDB(_ids(25))
+
+        updated = _adapter(db).backfill_embeddings(batch_size=10)
+
+        assert updated == 25
+        assert db.missing == set()
+
+    def test_the_cursor_advances_instead_of_re_reading_from_the_start(self):
+        db = _FakeDB(_ids(25))
+
+        _adapter(db).backfill_embeddings(batch_size=10)
+
+        # First read starts at the zero UUID, each later one resumes after the
+        # last id seen. Re-reading from the start is how the old version looped
+        # over the same rows.
+        starts = [start for start, _limit in db.selects]
+        assert starts[0] == _ZERO_UUID
+        assert starts == sorted(starts)
+        assert len(set(starts)) == len(starts)
+
+    def test_an_empty_store_reads_once_and_stops(self):
+        db = _FakeDB([])
+
+        assert _adapter(db).backfill_embeddings(batch_size=10) == 0
+        assert len(db.selects) == 1
+
+
+class TestAFailingRowCannotStarveTheOthers:
+    def test_rows_after_an_unembeddable_one_are_still_reached(self):
+        """The old version left the failure NULL and ordered by written_at, so
+        this row came back at the head of every batch and nothing behind it was
+        ever reached."""
+        db = _FakeDB(_ids(25))
+
+        updated = _adapter(db, failing={"row-000"}).backfill_embeddings(batch_size=10)
+
+        assert updated == 24
+        assert db.missing == {"row-000"}
+
+    def test_a_whole_first_batch_of_failures_does_not_stall_it(self):
+        db = _FakeDB(_ids(25))
+        doomed = set(_ids(25)[:10])
+
+        updated = _adapter(db, failing=doomed).backfill_embeddings(batch_size=10)
+
+        assert updated == 15
+        assert db.missing == doomed
+
+    def test_it_terminates_when_nothing_can_be_embedded(self):
+        # Every row fails, so no row's state ever changes. Only the cursor
+        # advancing ends this; without it the loop never finishes.
+        db = _FakeDB(_ids(12))
+        everything = set(_ids(12))
+
+        assert _adapter(db, failing=everything).backfill_embeddings(batch_size=5) == 0
+        assert db.missing == everything
+
+
+class TestBoundingTheWork:
+    def test_max_rows_stops_early(self):
+        db = _FakeDB(_ids(25))
+
+        updated = _adapter(db).backfill_embeddings(batch_size=10, max_rows=12)
+
+        assert updated == 12
+        assert len(db.embedded) == 12
+
+    def test_max_rows_never_reads_more_than_it_needs(self):
+        db = _FakeDB(_ids(25))
+
+        _adapter(db).backfill_embeddings(batch_size=10, max_rows=12)
+
+        # The final batch asks for 2, not 10.
+        assert [limit for _start, limit in db.selects] == [10, 2]
+
+    def test_max_rows_above_the_row_count_is_harmless(self):
+        db = _FakeDB(_ids(5))
+
+        assert _adapter(db).backfill_embeddings(batch_size=10, max_rows=99) == 5
+
+
+class TestWhenItCannotRunAtAll:
+    @pytest.mark.parametrize(
+        ("attribute", "value"),
+        [("_embedder", None), ("_has_embedding_col", False)],
+    )
+    def test_it_does_nothing_without_an_embedder_or_a_column(self, attribute, value):
+        db = _FakeDB(_ids(5))
+        adapter = _adapter(db)
+        setattr(adapter, attribute, value)
+
+        assert adapter.backfill_embeddings() == 0
+        assert db.selects == [], "must not query at all"

--- a/tests/unit/test_backfill_embeddings.py
+++ b/tests/unit/test_backfill_embeddings.py
@@ -195,6 +195,40 @@ class TestBoundingTheWork:
 
         assert _adapter(db).backfill_embeddings(batch_size=10, max_rows=99) == 5
 
+    def test_the_bound_counts_rows_examined_not_rows_embedded(self):
+        """A bound a bad row can lift is not a bound.
+
+        Counting successes meant failures were free: the loop kept fetching
+        batches until it found `max_rows` that worked, so a caller asking for 10
+        rows of work against 10 unembeddable rows walked the entire store
+        looking for successes that were never coming. The caller that asks for a
+        bound is the one on a time slice, which is exactly the one that cannot
+        afford that.
+        """
+        db = _FakeDB(_ids(25))
+        doomed = set(_ids(25)[:10])
+
+        updated = _adapter(db, failing=doomed).backfill_embeddings(
+            batch_size=10, max_rows=10
+        )
+
+        assert updated == 0, "none of the first ten can be embedded"
+        # One batch of ten, and then it stops. Not 25 rows read in pursuit of
+        # ten successes.
+        assert db.selects == [(_ZERO_UUID, 10)]
+        assert db.embedded == set()
+
+    def test_a_partly_failing_slice_still_stops_at_the_bound(self):
+        db = _FakeDB(_ids(40))
+        doomed = {"row-000", "row-003", "row-007"}
+
+        updated = _adapter(db, failing=doomed).backfill_embeddings(
+            batch_size=5, max_rows=10
+        )
+
+        assert updated == 7, "ten examined, three of them unembeddable"
+        assert sum(limit for _start, limit in db.selects) == 10
+
 
 class TestWhenItCannotRunAtAll:
     @pytest.mark.parametrize(

--- a/tests/unit/test_pool_bounds.py
+++ b/tests/unit/test_pool_bounds.py
@@ -13,6 +13,8 @@ import pytest
 from amfs_postgres.adapter import (
     _DEFAULT_POOL_MAX,
     _DEFAULT_POOL_MIN,
+    connection_options,
+    hnsw_iterative_scan_option,
     pool_bounds,
     statement_timeout_options,
 )
@@ -76,3 +78,57 @@ class TestTheStatementCeiling:
     def test_it_becomes_a_libpq_option(self, monkeypatch):
         monkeypatch.setenv("AMFS_POSTGRES_STATEMENT_TIMEOUT", "300s")
         assert statement_timeout_options() == "-c statement_timeout=300s"
+
+    def test_a_process_can_override_the_environment(self, monkeypatch):
+        """A bulk load, an index build and an embedding backfill are single
+        statements that outlast any request. Inheriting a request-shaped ceiling
+        from a shared environment variable aborts them partway through."""
+        monkeypatch.setenv("AMFS_POSTGRES_STATEMENT_TIMEOUT", "30s")
+        assert statement_timeout_options("15min") == "-c statement_timeout=15min"
+
+    def test_a_process_can_opt_out_entirely(self, monkeypatch):
+        from amfs_postgres.adapter import NO_STATEMENT_TIMEOUT
+
+        monkeypatch.setenv("AMFS_POSTGRES_STATEMENT_TIMEOUT", "30s")
+        assert (
+            statement_timeout_options(NO_STATEMENT_TIMEOUT)
+            == "-c statement_timeout=0"
+        )
+
+
+class TestIterativeHNSWScans:
+    """Without this, an HNSW index post-filters: it finds globally-near vectors
+    and then drops the ones failing the WHERE clause, so a search scoped to one
+    tenant or one dataset can come back short while the rows it wanted sit
+    unvisited. Missing results, not mis-ranked ones."""
+
+    def test_it_is_off_unless_asked_for(self, monkeypatch):
+        monkeypatch.delenv("AMFS_POSTGRES_HNSW_ITERATIVE_SCAN", raising=False)
+        assert hnsw_iterative_scan_option() is None
+
+    def test_it_becomes_a_libpq_option(self, monkeypatch):
+        monkeypatch.setenv("AMFS_POSTGRES_HNSW_ITERATIVE_SCAN", "relaxed_order")
+        assert hnsw_iterative_scan_option() == "-c hnsw.iterative_scan=relaxed_order"
+
+    def test_an_unknown_mode_is_refused(self, monkeypatch):
+        """Applied through libpq options, an unrecognised setting makes every
+        connection fail to open. Better to say why here than to have the pool
+        refuse to start with a libpq error."""
+        monkeypatch.setenv("AMFS_POSTGRES_HNSW_ITERATIVE_SCAN", "yes-please")
+        with pytest.raises(ValueError, match="must be one of"):
+            hnsw_iterative_scan_option()
+
+
+class TestComposingConnectionOptions:
+    def test_nothing_configured_means_no_options_at_all(self, monkeypatch):
+        monkeypatch.delenv("AMFS_POSTGRES_STATEMENT_TIMEOUT", raising=False)
+        monkeypatch.delenv("AMFS_POSTGRES_HNSW_ITERATIVE_SCAN", raising=False)
+        # None rather than "", so callers can leave `options` off the connection.
+        assert connection_options() is None
+
+    def test_both_fragments_compose(self, monkeypatch):
+        monkeypatch.setenv("AMFS_POSTGRES_STATEMENT_TIMEOUT", "30s")
+        monkeypatch.setenv("AMFS_POSTGRES_HNSW_ITERATIVE_SCAN", "strict_order")
+        assert connection_options() == (
+            "-c statement_timeout=30s -c hnsw.iterative_scan=strict_order"
+        )

--- a/tests/unit/test_tenant_gucs.py
+++ b/tests/unit/test_tenant_gucs.py
@@ -1,0 +1,197 @@
+"""The tenant settings module, and the transaction-scoped form of applying them.
+
+The session-scoped path is covered by test_tenant_rls_connection.py. What is
+tested here is the pooler-safe path and, mostly, the trap underneath it.
+
+``set_config(name, value, true)`` lasts until the end of the current
+transaction. Both adapters open their pools with ``autocommit=True``, so a
+statement that is not inside an explicit transaction *is* its own transaction
+and the setting is discarded before the next statement runs. The GUCs then read
+empty, ``NULLIF`` in the policies turns empty into NULL, and every RLS-protected
+read matches zero rows — without raising anything. An empty page that looks like
+an empty account is the worst failure available here, so ``tenant_transaction``
+checks it has a real transaction rather than trusting that it does.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from amfs_postgres import tenant_gucs
+
+
+def _cursor(recorder: list) -> MagicMock:
+    cur = MagicMock()
+    cur.execute = MagicMock(
+        side_effect=lambda sql, params=None: recorder.append((sql, params))
+    )
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=None)
+    return cur
+
+
+def _connection(recorder: list, *, status: str = "INTRANS") -> MagicMock:
+    """A connection whose ``transaction()`` reports ``status`` once entered."""
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=_cursor(recorder))
+    conn.info.transaction_status = MagicMock()
+    conn.info.transaction_status.name = status
+
+    txn = MagicMock()
+    txn.__enter__ = MagicMock(return_value=None)
+    txn.__exit__ = MagicMock(return_value=None)
+    conn.transaction = MagicMock(return_value=txn)
+    return conn
+
+
+def _pool(conn: MagicMock) -> MagicMock:
+    """An unwrapped pool.
+
+    ``spec`` matters: ``tenant_transaction`` unwraps with
+    ``getattr(pool, "_inner", pool)``, and a plain MagicMock would happily
+    invent a ``_inner`` attribute, so the function would unwrap to a phantom
+    mock instead of falling back to the pool. Restricting the spec makes the
+    mock behave like the real pools, only one of which has ``_inner``.
+    """
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=conn)
+    ctx.__exit__ = MagicMock(return_value=None)
+    pool = MagicMock(spec=["connection"])
+    pool.connection = MagicMock(return_value=ctx)
+    return pool
+
+
+def _context(*, account="acct-1", team=None, admin=False, user=None):
+    return (
+        patch(
+            "amfs_postgres.tenant_context.get_request_tenant_account_id",
+            return_value=account,
+        ),
+        patch(
+            "amfs_postgres.tenant_context.get_request_tenant_team_id",
+            return_value=team,
+        ),
+        patch(
+            "amfs_postgres.tenant_context.get_request_is_account_admin",
+            return_value=admin,
+        ),
+        patch(
+            "amfs_postgres.tenant_context.get_request_user_id", return_value=user
+        ),
+    )
+
+
+class TestOneDefinitionOfTheTenant:
+    def test_every_name_appears_in_both_statements(self):
+        """The two adapters used to carry a copy each of this SQL. A fifth
+        setting added to one and not the other is a silent policy hole, so the
+        names drive the SQL rather than being written out beside it."""
+        for name in tenant_gucs.TENANT_GUC_NAMES:
+            assert f"set_config('{name}'" in tenant_gucs.SET_TENANT_GUCS_SESSION
+            assert f"set_config('{name}'" in tenant_gucs.SET_TENANT_GUCS_LOCAL
+
+    def test_the_two_statements_differ_only_in_scope(self):
+        assert tenant_gucs.SET_TENANT_GUCS_SESSION.replace(
+            ", false)", ", true)"
+        ) == tenant_gucs.SET_TENANT_GUCS_LOCAL
+
+    def test_one_round_trip(self):
+        # This runs on every checkout, on every request.
+        assert tenant_gucs.SET_TENANT_GUCS_LOCAL.count("SELECT") == 1
+
+    def test_absent_values_become_empty_not_null(self):
+        """Empty string is what NULLIF turns into NULL, so a missing tenant
+        matches nothing. Saying it explicitly beats relying on how psycopg
+        happens to render None."""
+        with pytest.MonkeyPatch.context():
+            for p in _context(account=None, team=None, admin=False, user=None):
+                p.start()
+            try:
+                assert tenant_gucs.tenant_guc_values() == ("", "", "false", "")
+            finally:
+                patch.stopall()
+
+    def test_values_are_ordered_to_match_the_statement(self):
+        for p in _context(account="a", team="t", admin=True, user="u"):
+            p.start()
+        try:
+            assert tenant_gucs.tenant_guc_values() == ("a", "t", "true", "u")
+        finally:
+            patch.stopall()
+
+
+class TestTransactionScopedTenant:
+    def test_sets_all_four_locally_inside_the_transaction(self):
+        recorder: list = []
+        conn = _connection(recorder)
+
+        for p in _context(account="acct-9", team="team-3", admin=False, user="u-7"):
+            p.start()
+        try:
+            with tenant_gucs.tenant_transaction(_pool(conn)) as got:
+                assert got is conn
+        finally:
+            patch.stopall()
+
+        assert conn.transaction.called, "must open a real transaction"
+        assert len(recorder) == 1
+        sql, params = recorder[0]
+        assert sql == tenant_gucs.SET_TENANT_GUCS_LOCAL
+        assert params == ("acct-9", "team-3", "false", "u-7")
+
+    def test_refuses_to_run_without_an_open_transaction(self):
+        """The whole point. Outside a transaction the local set_config is
+        discarded immediately and every subsequent read silently returns
+        nothing, so this has to be an exception rather than an empty result."""
+        recorder: list = []
+        conn = _connection(recorder, status="IDLE")
+
+        for p in _context():
+            p.start()
+        try:
+            with pytest.raises(RuntimeError, match="no open transaction"):
+                with tenant_gucs.tenant_transaction(_pool(conn)):
+                    pass
+        finally:
+            patch.stopall()
+
+        assert recorder == [], "must not set anything it cannot scope"
+
+    def test_unwraps_the_session_scoped_pool_wrapper(self):
+        """Going through the wrapper would set the same four session-scoped at
+        checkout, and through a transaction pooler those land on an arbitrary
+        backend and stay there — the exact leak this function avoids."""
+        recorder: list = []
+        conn = _connection(recorder)
+        inner = _pool(conn)
+
+        wrapper = MagicMock()
+        wrapper._inner = inner
+        wrapper.connection = MagicMock(
+            side_effect=AssertionError("must not check out through the wrapper")
+        )
+
+        for p in _context():
+            p.start()
+        try:
+            with tenant_gucs.tenant_transaction(wrapper):
+                pass
+        finally:
+            patch.stopall()
+
+        assert inner.connection.called
+
+
+class TestReturningAConnectionToThePool:
+    def test_reset_blanks_all_four(self):
+        recorder: list = []
+        conn = MagicMock()
+        conn.cursor = MagicMock(return_value=_cursor(recorder))
+
+        tenant_gucs.reset_tenant_gucs(conn)
+
+        sql, params = recorder[0]
+        assert sql == tenant_gucs.SET_TENANT_GUCS_SESSION
+        assert params == ("", "", "false", "")
+        assert len(params) == len(tenant_gucs.TENANT_GUC_NAMES)

--- a/tests/unit/test_tenant_gucs.py
+++ b/tests/unit/test_tenant_gucs.py
@@ -15,6 +15,7 @@ checks it has a real transaction rather than trusting that it does.
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -29,6 +30,26 @@ def _cursor(recorder: list) -> MagicMock:
     cur.__enter__ = MagicMock(return_value=cur)
     cur.__exit__ = MagicMock(return_value=None)
     return cur
+
+
+class _AsyncCursor:
+    """An async cursor, written out rather than mocked.
+
+    MagicMock can be bent into supporting `async with` and an awaitable
+    execute, but the bending is longer than the class and reads worse.
+    """
+
+    def __init__(self, recorder: list) -> None:
+        self._recorder = recorder
+
+    async def __aenter__(self) -> _AsyncCursor:
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+    async def execute(self, sql: str, params: tuple | None = None) -> None:
+        self._recorder.append((sql, params))
 
 
 def _connection(recorder: list, *, status: str = "INTRANS") -> MagicMock:
@@ -195,3 +216,18 @@ class TestReturningAConnectionToThePool:
         assert sql == tenant_gucs.SET_TENANT_GUCS_SESSION
         assert params == ("", "", "false", "")
         assert len(params) == len(tenant_gucs.TENANT_GUC_NAMES)
+
+    async def test_the_async_reset_blanks_the_same_four(self):
+        """Both pools need this and only one callback can be awaited, so the
+        async twin exists. The request path is served by the async pool, which
+        makes it the one where a connection left holding a real
+        amfs.current_user_id matters most."""
+        recorder: list = []
+        conn = MagicMock()
+        conn.cursor = MagicMock(return_value=_AsyncCursor(recorder))
+
+        await tenant_gucs.areset_tenant_gucs(conn)
+
+        sql, params = recorder[0]
+        assert sql == tenant_gucs.SET_TENANT_GUCS_SESSION
+        assert params == ("", "", "false", "")


### PR DESCRIPTION
Foundation for Hugging Face dataset import (paired with amfs-internal `feat/hf-dataset-import-foundation`). Four changes to the Postgres adapter that are survivable at the current size and are not at hundreds of concurrent imports of hundreds of thousands of rows each.

**No behaviour change for existing callers.** The session-scoped tenant SQL this generates is byte-identical to what it replaced.

## One definition of the tenant, plus a pooler-safe way to apply it

RLS reads four settings, and `adapter.py` and `async_adapter.py` each carried their own copy of the same four-statement SQL — two places to remember when a fifth arrives, and drift between them is a security bug, not a formatting one. `amfs.current_user_id` is the setting that *widens* what a caller sees, since invited users reach rooms in other accounts through policies keyed on it and nothing else. The list now lives in `amfs_postgres/tenant_gucs.py` and the SQL is generated from it.

That module adds `tenant_transaction()`, which is the form that works behind a transaction-mode pooler: settings scoped to one explicit transaction, discarded at commit, nothing left on the backend for the next borrower.

**Why this is a new primitive and not a flag flip.** Both pools open with `autocommit=True`, so `set_config(..., true)` outside an explicit transaction applies to its own implicit single-statement transaction and is gone before the next statement. The settings then read empty, `NULLIF` turns empty into NULL, and every RLS-protected read matches zero rows — with nothing raised. `_apply_schema` already documents the same trap for `SET LOCAL`. So `tenant_transaction` asserts it has a real transaction rather than trusting it does, and the pool now blanks all four settings on connection return.

## `backfill_embeddings` could not finish, and one bad row stopped it

Two quiet failures:

- It read one batch and returned, so backfilling a store with more than `batch_size` missing embeddings returned `batch_size` and a number that looked like success.
- It ordered by `written_at` and skipped failures with `continue`, leaving them NULL — so the same permanently-failing rows came back at the head of every later batch and nothing behind them was ever reached. One value the embedder chokes on stalled the backfill forever, and the symptom is a store that quietly never becomes searchable.

Now a keyset cursor over `id` run to completion, in the shape `backfill_is_artifact` (directly below it) already used: progress no longer depends on any row succeeding. `max_rows` bounds the work for callers that want progress without running to the end.

## A statement ceiling a bulk process can opt out of

`AMFS_POSTGRES_STATEMENT_TIMEOUT` is applied through libpq `options`, making it a property of the connection and so of the whole pool. Right for a service, wrong for a process that also does bulk work: a copy, a per-partition index build and an embedding backfill are single statements that legitimately outlast any request. Both adapters now take an explicit `statement_timeout`, with `NO_STATEMENT_TIMEOUT` to opt out.

## HNSW searches that can be trusted on a filtered table

Without `hnsw.iterative_scan`, an HNSW index post-filters: it walks the global proximity graph for the nearest vectors and only then discards the ones failing the `WHERE` clause. A search scoped to one tenant, room or dataset can come back short while the rows it wanted sit unvisited — results missing rather than mis-ranked, which is the kind of wrong answer nobody notices.

Needs pgvector >= 0.8.0, so compose and Helm move off the floating `pg16` tag to `0.8.1-pg16`. The setting itself is opt-in via `AMFS_POSTGRES_HNSW_ITERATIVE_SCAN`, because it goes through libpq `options` and an unrecognised setting makes *every connection fail to open* — an installer who has not pinned their extension version should not lose the adapter over a flag they never set.

This is also what unblocks the ANN decision deferred in `amfs-internal` migration `050`, which said to revisit it "only with a pinned pgvector version and iterative scan enabled".

## Test plan

- [x] `pytest tests/unit` — 943 passed. One deselected: `test_mcp_server.py::TestAgentIdDetection::test_explicit_env_var`, pre-existing and environmental (`detect_agent_id` documents "IDE wins over env var" and I ran inside Cursor, so `VSCODE_PID` is set; passes in CI).
- [x] New `tests/unit/test_tenant_gucs.py` — the four names drive the SQL, transaction-local is applied inside a real transaction, and `tenant_transaction` **raises** rather than silently returning nothing when there is no transaction.
- [x] New `tests/unit/test_backfill_embeddings.py` — covers the loop, the starvation fix, and that it terminates when every row fails (that test does not terminate against the old code).
- [x] `test_tenant_rls_connection.py` and `test_pool_bounds.py` still pass unchanged, which is the check that the session-scoped path did not move.
- [x] `ruff check` clean on every file added or changed.
- [ ] Not covered by unit CI: the transaction-local path against a real PgBouncer in transaction mode. `tenant_transaction` has no callers yet — this PR adds the primitive; converting call sites is follow-up work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes tenant RLS GUC lifecycle and embedding backfill semantics; misconfiguration could leak tenant context or leave stores partially searchable, though session SQL is claimed byte-identical.
> 
> **Overview**
> Prepares the Postgres adapter for large dataset import by **centralizing RLS tenant settings** in `tenant_gucs.py` (shared sync/async checkout SQL, pool `reset` to blank all four GUCs on return, and exported `tenant_transaction()` for transaction-mode poolers). Session-scoped checkout behavior is intended to stay equivalent; tenant-less checkout warnings are throttled instead of logged on every connection.
> 
> **Fixes `backfill_embeddings`** so it runs to completion via a keyset cursor on `id`, advances past rows the embedder cannot handle, and adds optional `max_rows` that limits rows *examined* (not only successes) for time-sliced workers.
> 
> Adds **connection-level libpq options** composition: per-adapter `statement_timeout` override / `NO_STATEMENT_TIMEOUT` opt-out, and opt-in `AMFS_POSTGRES_HNSW_ITERATIVE_SCAN` for filtered HNSW recall on pgvector ≥ 0.8.0. **Docker Compose and Helm** pin `pgvector/pgvector:0.8.1-pg16` instead of the floating `pg16` tag.
> 
> Unit tests cover tenant GUC primitives, backfill loop/starvation/termination, async pool reset, and connection option composition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06a99603434c36327ffb5b66fec0c636e31b647d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->