### PR TITLE
Pin CI Postgres to the pgvector image

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -15,7 +15,21 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        # pgvector's image, and a pinned version of it rather than the floating
+        # `pg16` tag — the same one docker-compose.yml and the Helm values use,
+        # for the reason spelled out there: `hnsw.iterative_scan` arrived in
+        # pgvector 0.8.0, and without it an HNSW index post-filters, walking the
+        # global proximity graph and then discarding rows that fail the WHERE
+        # clause. A query scoped to a small slice of a large table then returns
+        # results that are missing rather than merely mis-ranked. Local, CI and
+        # Cloud SQL agreeing on one version is the only thing that keeps that
+        # true, and CI was the one that did not.
+        #
+        # Plain `postgres:16` was not a smaller version of this. It ships no
+        # pgvector at all, and the adapter opens by running `CREATE EXTENSION IF
+        # NOT EXISTS vector` — so the vector paths could never have been
+        # exercised here, whatever the job reported.
+        image: pgvector/pgvector:0.8.1-pg16
         env:
           POSTGRES_DB: amfs_test
           POSTGRES_PASSWORD: test


### PR DESCRIPTION
## Summary

CI ran plain `postgres:16`, which has no pgvector, while `docker-compose.yml` and the Helm chart both pin `pgvector/pgvector:0.8.1-pg16` — and the adapter runs `CREATE EXTENSION vector`. So the three environments disagreed, and the vector integration tests could not run on the one that gates merges.

Pinned to the exact patch rather than a floating tag: an HNSW behaviour change arriving on its own would look like a bug in our code.

## Test plan

- [ ] CI green on this PR, with the vector-dependent integration tests actually executing rather than skipping.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes the CI Postgres service image and comments; no application or production runtime behavior.
> 
> **Overview**
> **CI Postgres now matches local and deploy Postgres** by switching the GitHub Actions service from plain `postgres:16` to **`pgvector/pgvector:0.8.1-pg16`**, the same patch pin used in `docker-compose.yml` and Helm.
> 
> Plain `postgres:16` does not ship pgvector, so integration tests that rely on `CREATE EXTENSION vector` could not exercise vector/HNSW paths in the merge gate even when the job looked green. The workflow comment documents why the exact **0.8.1** pin matters (e.g. `hnsw.iterative_scan` from pgvector 0.8.0) so CI behavior stays aligned with other environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ca3aec324c407fea391d57ccfda65ed2d566680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->