### PR TITLE
Scope the four tenant RLS settings to a transaction

### DIFF
--- a/docs/adapters/postgres.md
+++ b/docs/adapters/postgres.md
@@ -200,6 +200,21 @@ When `depth=1`, the query uses the hot index; `depth=2` uses the warm index.
 
 The adapter uses `psycopg_pool.ConnectionPool` for efficient connection management. The pool size is configurable and defaults to sensible limits for most deployments.
 
+#### Running behind PgBouncer or another transaction pooler
+
+Supported, including in `pool_mode = transaction`. This is worth stating explicitly because it is the configuration where multi-tenant isolation is easiest to get wrong.
+
+Row-level security decides what a request can see by reading four Postgres settings — `amfs.current_account_id`, `amfs.current_team_id`, `amfs.is_account_admin`, and `amfs.current_user_id`. The adapter sets all four **inside the transaction** that reads, so Postgres discards them at commit and nothing is left on the server connection for whoever borrows it next.
+
+The alternative — setting them session-scoped, once per checkout — is safe with `psycopg_pool` on its own, because a checkout owns its backend for the whole block. It is **not** safe behind a transaction pooler, where one client connection maps to a different backend per transaction: the values land on whichever backend served the statement that set them, and the next query can be answered by a backend still carrying another tenant's. That is a cross-account read. AMFS does not do this, and `tests/integration/pgbouncer/` runs a real PgBouncer to prove both halves — that the old pattern leaks, and that the current one does not.
+
+Two consequences worth knowing about as an operator:
+
+- **Every checkout is a transaction.** Reads included. If you are watching for long-running transactions, expect one per request rather than none.
+- **Schema bootstrap and the backfills are exempt.** They run with the four settings blanked and no wrapping transaction: DDL because one transaction around the whole schema would hold `ACCESS EXCLUSIVE` on everything it touches until the last statement finished, and the backfills because they call an embedder between statements. Neither reads tenant data, and blanked settings match no rows under RLS, so they fail closed if that ever changes.
+
+No configuration is required to get this. There is no session-scoped mode to turn off.
+
 ---
 
 ## When to Use

--- a/packages/adapters/postgres/src/amfs_postgres/__init__.py
+++ b/packages/adapters/postgres/src/amfs_postgres/__init__.py
@@ -13,8 +13,10 @@ __all__ = [
     "AsyncPostgresAdapter",
     # Anything doing tenant-scoped work on its own connections needs these
     # rather than a private import: the four settings are one list in one place,
-    # and tenant_transaction is the only form that is safe behind a
-    # transaction-mode pooler. See amfs_postgres.tenant_gucs.
+    # and tenant_transaction is the transaction-scoped form that is safe behind
+    # a transaction-mode pooler. Both adapters' checkouts now do the same thing
+    # by default, so this is for callers holding a bare pool.
+    # See amfs_postgres.tenant_gucs.
     "TENANT_GUC_NAMES",
     "set_tenant_gucs",
     "tenant_transaction",

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -10,6 +10,7 @@ import os
 import re
 import threading
 import uuid
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
@@ -483,24 +484,61 @@ class PostgresAdapter(AdapterABC):
         self._watchers: dict[str, list[Callable[[MemoryEntry], None]]] = {}
 
     def _maintenance_connection(self) -> Any:
-        """A checkout with no transaction and no tenant, for DDL and backfills.
+        """A checkout with no transaction, for DDL and the backfills.
 
         Everything that touches tenant rows goes through the ordinary
-        ``self._pool.connection()``, which wraps the block in a transaction and
-        scopes the four settings to it. This is the documented exception, and it
-        is deliberately awkward to reach: the two callers that need it cannot be
-        wrapped in a transaction at all -- DDL because one transaction around
-        ``schema.sql`` would hold ACCESS EXCLUSIVE on every object for the whole
-        run, the backfills because they call an embedder between statements and
-        fall back to more SQL after a caught error.
+        ``self._pool.connection()``, which wraps the whole block in one
+        transaction and scopes the four settings to it. This is the documented
+        exception, and it is deliberately awkward to reach: the callers that
+        need it cannot live inside a single caller-imposed transaction at all --
+        DDL because one transaction around ``schema.sql`` would hold ACCESS
+        EXCLUSIVE on every object for the whole run, the backfills because they
+        call an embedder between statements and fall back to more SQL after a
+        caught error.
 
-        Both blank the four settings instead of setting them, so the connection
-        never inherits the previous borrower's tenant and never carries one of
-        its own. Under FORCE ROW LEVEL SECURITY that reads zero rows rather than
-        all of them, so a maintenance path that grew a tenant query by accident
-        fails closed and visibly.
+        The checkout blanks the four settings rather than setting them, so the
+        connection never inherits the previous borrower's tenant. For DDL that
+        is the whole story, and it fails closed: under FORCE ROW LEVEL SECURITY
+        empty reads zero rows rather than all of them, so DDL that grew a tenant
+        query by accident would return nothing rather than everything.
+
+        The backfills do touch tenant rows, so they cannot run on the blanked
+        settings this leaves behind -- they open a short transaction per
+        statement with :meth:`_tenant_statement` and set a real tenant inside
+        it. What they get from here is only the absence of an enclosing
+        transaction.
         """
         return self._pool.connection(transactional=False)
+
+    @contextlib.contextmanager
+    def _tenant_statement(self, conn: Any) -> Iterator[Any]:
+        """A short transaction on an existing checkout, carrying a real tenant.
+
+        For the backfills, which run on :meth:`_maintenance_connection` but --
+        unlike DDL -- read and update ``amfs_memory_entries``. That table has
+        FORCE ROW LEVEL SECURITY, so on the blanked settings a maintenance
+        checkout leaves behind, their ``SELECT`` matches no rows and the loops
+        examine and update nothing at all, silently. They need a tenant.
+
+        The tenant is still transaction-local, because a session-scoped one is
+        the leak :mod:`amfs_postgres.tenant_gucs` exists to remove. So it is set
+        per statement here rather than once per checkout, which costs a round
+        trip per transaction and buys back both of the properties the backfills
+        depend on: no embedder call happens inside a transaction, and each
+        statement commits on its own, so one row's failure leaves the rest of
+        the batch committed and a fallback issued after a caught error runs in a
+        new transaction rather than a failed one.
+        """
+        from amfs_postgres.tenant_gucs import (
+            require_open_transaction,
+            set_tenant_gucs,
+        )
+
+        with conn.transaction():
+            require_open_transaction(conn)
+            with conn.cursor() as cur:
+                set_tenant_gucs(cur, local=True)
+                yield cur
 
     def _migrations_source(self) -> str | None:
         """The text of _apply_migrations, or None if it cannot be read.
@@ -1547,11 +1585,14 @@ class PostgresAdapter(AdapterABC):
                 limit = min(limit, max_rows - examined)
             # Maintenance checkout: this block calls the embedder once per row,
             # so an ordinary one would hold a transaction open across a whole
-            # batch of network round trips. Per-statement commit is also what
+            # batch of network round trips. The tenant comes from the short
+            # per-statement transactions below rather than from the checkout,
+            # which blanks it -- these rows are tenant rows, and RLS matches
+            # none of them on a blank tenant. Per-statement commit is also what
             # lets one row's embedding failure leave the rest of the batch
             # committed, which is the documented behaviour above.
             with self._maintenance_connection() as conn:
-                with conn.cursor() as cur:
+                with self._tenant_statement(conn) as cur:
                     cur.execute(
                         "SELECT id, value FROM amfs_memory_entries "
                         "WHERE namespace = %s AND embedding IS NULL AND id > %s "
@@ -1559,41 +1600,45 @@ class PostgresAdapter(AdapterABC):
                         (self._namespace, last_id, limit),
                     )
                     rows = cur.fetchall()
-                    if not rows:
-                        break
-                    for r in rows:
-                        last_id = r["id"]
-                        examined += 1
-                        # Decoding is separate from embedding on purpose. Both
-                        # used to share one try, so a value that is a bare
-                        # string -- not JSON, and perfectly embeddable -- raised
-                        # JSONDecodeError and was counted as a row that could
-                        # not be embedded. It then kept its NULL embedding and
-                        # was re-read and re-failed by every later backfill.
-                        # backfill_is_artifact already falls back this way.
-                        raw = r["value"]
-                        if isinstance(raw, str):
-                            try:
-                                value = json.loads(raw)
-                            except (json.JSONDecodeError, ValueError):
-                                value = raw
-                        else:
-                            value = raw
+                if not rows:
+                    break
+                for r in rows:
+                    last_id = r["id"]
+                    examined += 1
+                    # Decoding is separate from embedding on purpose. Both
+                    # used to share one try, so a value that is a bare
+                    # string -- not JSON, and perfectly embeddable -- raised
+                    # JSONDecodeError and was counted as a row that could
+                    # not be embedded. It then kept its NULL embedding and
+                    # was re-read and re-failed by every later backfill.
+                    # backfill_is_artifact already falls back this way.
+                    raw = r["value"]
+                    if isinstance(raw, str):
                         try:
-                            vec = self._embedder.embed_value(value)
-                        except Exception:  # noqa: BLE001
-                            failed += 1
-                            logger.warning(
-                                "backfill embedding failed for row %s", r["id"],
-                                exc_info=True,
-                            )
-                            continue
+                            value = json.loads(raw)
+                        except (json.JSONDecodeError, ValueError):
+                            value = raw
+                    else:
+                        value = raw
+                    # Outside any transaction on purpose: this is the network
+                    # round trip the maintenance checkout exists to keep out
+                    # of one.
+                    try:
+                        vec = self._embedder.embed_value(value)
+                    except Exception:  # noqa: BLE001
+                        failed += 1
+                        logger.warning(
+                            "backfill embedding failed for row %s", r["id"],
+                            exc_info=True,
+                        )
+                        continue
+                    with self._tenant_statement(conn) as cur:
                         cur.execute(
                             "UPDATE amfs_memory_entries SET embedding = %s "
                             "WHERE id = %s",
                             (f"[{','.join(str(v) for v in vec)}]", r["id"]),
                         )
-                        updated += 1
+                    updated += 1
         if failed:
             logger.warning(
                 "backfill_embeddings: examined %d rows, updated %d, %d could not "
@@ -1627,10 +1672,13 @@ class PostgresAdapter(AdapterABC):
             # Maintenance checkout, for two reasons. It embeds per row, so an
             # ordinary transactional one would stay open across a batch of
             # network calls; and the re-embed fallback below issues an UPDATE
-            # from inside an ``except``, which after a failed statement in a
-            # transaction is InFailedSqlTransaction rather than a fallback.
+            # from inside an ``except``, which after a failed statement in the
+            # same transaction is InFailedSqlTransaction rather than a fallback.
+            # The tenant comes from the short per-statement transactions rather
+            # than the checkout, which blanks it: these are tenant rows, and RLS
+            # matches none of them on a blank tenant.
             with self._maintenance_connection() as conn:
-                with conn.cursor() as cur:
+                with self._tenant_statement(conn) as cur:
                     cur.execute(
                         "SELECT id, key, value, is_artifact FROM amfs_memory_entries "
                         "WHERE namespace = %s AND id > %s "
@@ -1638,47 +1686,50 @@ class PostgresAdapter(AdapterABC):
                         (self._namespace, last_id, batch_size),
                     )
                     rows = cur.fetchall()
-                    if not rows:
-                        break
-                    for r in rows:
-                        last_id = r["id"]
-                        stored = bool(r["is_artifact"])
+                if not rows:
+                    break
+                for r in rows:
+                    last_id = r["id"]
+                    stored = bool(r["is_artifact"])
+                    try:
+                        value = (
+                            json.loads(r["value"])
+                            if isinstance(r["value"], str)
+                            else r["value"]
+                        )
+                    except (json.JSONDecodeError, ValueError):
+                        value = r["value"]
+                    is_art = classify_artifact(r["key"], value)
+                    if is_art == stored:
+                        continue
+                    if is_art and can_embed:
                         try:
-                            value = (
-                                json.loads(r["value"])
-                                if isinstance(r["value"], str)
-                                else r["value"]
-                            )
-                        except (json.JSONDecodeError, ValueError):
-                            value = r["value"]
-                        is_art = classify_artifact(r["key"], value)
-                        if is_art == stored:
-                            continue
-                        if is_art and can_embed:
-                            try:
-                                _, text = embedding_input(r["key"], value)
-                                vec = self._embedder.embed(text)
+                            _, text = embedding_input(r["key"], value)
+                            vec = self._embedder.embed(text)
+                            with self._tenant_statement(conn) as cur:
                                 cur.execute(
                                     "UPDATE amfs_memory_entries "
                                     "SET is_artifact = %s, embedding = %s WHERE id = %s",
                                     (is_art, f"[{','.join(str(v) for v in vec)}]", r["id"]),
                                 )
-                            except Exception:  # noqa: BLE001
-                                logger.warning(
-                                    "backfill re-embed failed for row %s", r["id"],
-                                    exc_info=True,
-                                )
+                        except Exception:  # noqa: BLE001
+                            logger.warning(
+                                "backfill re-embed failed for row %s", r["id"],
+                                exc_info=True,
+                            )
+                            with self._tenant_statement(conn) as cur:
                                 cur.execute(
                                     "UPDATE amfs_memory_entries "
                                     "SET is_artifact = %s WHERE id = %s",
                                     (is_art, r["id"]),
                                 )
-                        else:
+                    else:
+                        with self._tenant_statement(conn) as cur:
                             cur.execute(
                                 "UPDATE amfs_memory_entries SET is_artifact = %s WHERE id = %s",
                                 (is_art, r["id"]),
                             )
-                        updated += 1
+                    updated += 1
         return updated
 
     # ------------------------------------------------------------------

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -295,7 +295,7 @@ class _SingleConnectionPool:
 
 
 class _TenantRLSConnection:
-    """Applies the four tenant settings on every checkout.
+    """Applies the four tenant settings on every checkout, inside a transaction.
 
     All four are set every time, whether or not a request tenant is present:
     with a tenant, to the real values; without one, to empty, which ``NULLIF``
@@ -304,23 +304,56 @@ class _TenantRLSConnection:
     would leave the previous borrower of this pooled connection in place, and
     ``amfs.current_user_id`` is the setting that grants reach across accounts.
 
-    Session-scoped, which is correct for ``psycopg_pool`` and not correct behind
-    a transaction-mode pooler. See :mod:`amfs_postgres.tenant_gucs` for why, and
-    :func:`~amfs_postgres.tenant_gucs.tenant_transaction` for the form that is.
+    The checkout opens an explicit transaction and sets them *inside* it, so
+    Postgres discards them at commit and nothing is left on the backend for the
+    next borrower. That is what makes it safe to put a transaction-mode pooler
+    in front: session-scoped settings would land on whichever backend served the
+    statement that set them, and the next query could be answered by a backend
+    still carrying another tenant. See :mod:`amfs_postgres.tenant_gucs`.
+
+    ``transactional=False`` is the maintenance path, for the two kinds of work
+    that cannot run in a caller-imposed transaction — DDL, and the backfills
+    that call an embedder between statements. Those get all four blanked instead
+    of set, which still overwrites the previous borrower but writes no tenant.
+
+    The whole checkout being one transaction is also why the methods below no
+    longer call ``conn.commit()``: psycopg forbids an explicit commit inside a
+    ``transaction()`` block, and the block commits on its own successful exit.
     """
 
     _tenantless_checkouts = 0
 
-    def __init__(self, inner_ctx: Any) -> None:
+    def __init__(self, inner_ctx: Any, *, transactional: bool = True) -> None:
         self._inner_ctx = inner_ctx
+        self._transactional = transactional
+        self._stack: contextlib.ExitStack | None = None
 
     def __enter__(self) -> Any:
-        from amfs_postgres.tenant_gucs import set_tenant_gucs
+        from amfs_postgres.tenant_gucs import (
+            blank_tenant_gucs,
+            require_open_transaction,
+            set_tenant_gucs,
+        )
 
-        conn = self._inner_ctx.__enter__()
-        with conn.cursor() as cur:
-            set_tenant_gucs(cur, local=False)
-        self._warn_if_tenantless()
+        # ExitStack rather than nested try/finally so that a failure while
+        # setting the tenant unwinds the transaction and returns the connection
+        # in the right order, without this class having to get that right twice.
+        stack = contextlib.ExitStack()
+        try:
+            conn = stack.enter_context(self._inner_ctx)
+            if self._transactional:
+                stack.enter_context(conn.transaction())
+                require_open_transaction(conn)
+                with conn.cursor() as cur:
+                    set_tenant_gucs(cur, local=True)
+                self._warn_if_tenantless()
+            else:
+                with conn.cursor() as cur:
+                    blank_tenant_gucs(cur)
+        except BaseException:
+            stack.close()
+            raise
+        self._stack = stack
         return conn
 
     @staticmethod
@@ -350,17 +383,21 @@ class _TenantRLSConnection:
         )
 
     def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Any:
-        return self._inner_ctx.__exit__(exc_type, exc, tb)
+        if self._stack is None:
+            return None
+        return self._stack.__exit__(exc_type, exc, tb)
 
 
 class _TenantRLSPoolWrapper:
-    """Wraps a psycopg pool so each checkout applies RLS session vars."""
+    """Wraps a psycopg pool so each checkout scopes RLS vars to a transaction."""
 
     def __init__(self, inner: Any) -> None:
         self._inner = inner
 
-    def connection(self) -> _TenantRLSConnection:
-        return _TenantRLSConnection(self._inner.connection())
+    def connection(self, *, transactional: bool = True) -> _TenantRLSConnection:
+        return _TenantRLSConnection(
+            self._inner.connection(), transactional=transactional
+        )
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)
@@ -445,6 +482,26 @@ class PostgresAdapter(AdapterABC):
         self._listen_stop = threading.Event()
         self._watchers: dict[str, list[Callable[[MemoryEntry], None]]] = {}
 
+    def _maintenance_connection(self) -> Any:
+        """A checkout with no transaction and no tenant, for DDL and backfills.
+
+        Everything that touches tenant rows goes through the ordinary
+        ``self._pool.connection()``, which wraps the block in a transaction and
+        scopes the four settings to it. This is the documented exception, and it
+        is deliberately awkward to reach: the two callers that need it cannot be
+        wrapped in a transaction at all -- DDL because one transaction around
+        ``schema.sql`` would hold ACCESS EXCLUSIVE on every object for the whole
+        run, the backfills because they call an embedder between statements and
+        fall back to more SQL after a caught error.
+
+        Both blank the four settings instead of setting them, so the connection
+        never inherits the previous borrower's tenant and never carries one of
+        its own. Under FORCE ROW LEVEL SECURITY that reads zero rows rather than
+        all of them, so a maintenance path that grew a tenant query by accident
+        fails closed and visibly.
+        """
+        return self._pool.connection(transactional=False)
+
     def _migrations_source(self) -> str | None:
         """The text of _apply_migrations, or None if it cannot be read.
 
@@ -507,6 +564,13 @@ class PostgresAdapter(AdapterABC):
         path refuses to queue: lock_timeout means a container that cannot get the
         lock promptly fails this attempt instead of joining the convoy it would
         otherwise extend.
+
+        Runs on ``_maintenance_connection`` rather than the ordinary checkout,
+        which is the one place that matters here: the ordinary one wraps the
+        block in a transaction, and one transaction around all of this DDL would
+        hold every ACCESS EXCLUSIVE lock it takes until the last statement
+        finished, turning the convoy above into a guaranteed one. It would also
+        undo the retry, which depends on partial progress being kept.
         """
         import time as _time
 
@@ -516,7 +580,7 @@ class PostgresAdapter(AdapterABC):
 
         for attempt in range(1, retries + 1):
             try:
-                with self._pool.connection() as conn:
+                with self._maintenance_connection() as conn:
                     with conn.cursor() as cur:
                         # Bounds the wait for a lock, not the work: a genuine
                         # first-run CREATE INDEX on a large table is allowed to
@@ -568,7 +632,10 @@ class PostgresAdapter(AdapterABC):
         """
         try:
             expected = self._expected_tables()
-            with self._pool.connection() as conn:
+            # Build metadata and pg_catalog, no tenant rows, and it runs before
+            # the schema it is checking for necessarily exists — so the
+            # maintenance checkout, same as the DDL it guards.
+            with self._maintenance_connection() as conn:
                 with conn.cursor() as cur:
                     cur.execute(
                         "SELECT 1 FROM amfs_schema_state WHERE fingerprint = %s",
@@ -1398,7 +1465,9 @@ class PostgresAdapter(AdapterABC):
         which requires AMFS_TEST_PG_DSN + pgvector; unvalidated in unit CI.
         """
         target = dim or self._embedding_dim
-        with self._pool.connection() as conn:
+        # DDL: CREATE INDEX ... hnsw on a populated table is long and takes
+        # ACCESS EXCLUSIVE, so it is not something to hold a transaction across.
+        with self._maintenance_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
                 cur.execute(
@@ -1476,7 +1545,12 @@ class PostgresAdapter(AdapterABC):
             limit = batch_size
             if max_rows is not None:
                 limit = min(limit, max_rows - examined)
-            with self._pool.connection() as conn:
+            # Maintenance checkout: this block calls the embedder once per row,
+            # so an ordinary one would hold a transaction open across a whole
+            # batch of network round trips. Per-statement commit is also what
+            # lets one row's embedding failure leave the rest of the batch
+            # committed, which is the documented behaviour above.
+            with self._maintenance_connection() as conn:
                 with conn.cursor() as cur:
                     cur.execute(
                         "SELECT id, value FROM amfs_memory_entries "
@@ -1490,12 +1564,22 @@ class PostgresAdapter(AdapterABC):
                     for r in rows:
                         last_id = r["id"]
                         examined += 1
+                        # Decoding is separate from embedding on purpose. Both
+                        # used to share one try, so a value that is a bare
+                        # string -- not JSON, and perfectly embeddable -- raised
+                        # JSONDecodeError and was counted as a row that could
+                        # not be embedded. It then kept its NULL embedding and
+                        # was re-read and re-failed by every later backfill.
+                        # backfill_is_artifact already falls back this way.
+                        raw = r["value"]
+                        if isinstance(raw, str):
+                            try:
+                                value = json.loads(raw)
+                            except (json.JSONDecodeError, ValueError):
+                                value = raw
+                        else:
+                            value = raw
                         try:
-                            value = (
-                                json.loads(r["value"])
-                                if isinstance(r["value"], str)
-                                else r["value"]
-                            )
                             vec = self._embedder.embed_value(value)
                         except Exception:  # noqa: BLE001
                             failed += 1
@@ -1540,7 +1624,12 @@ class PostgresAdapter(AdapterABC):
         updated = 0
         last_id = "00000000-0000-0000-0000-000000000000"
         while True:
-            with self._pool.connection() as conn:
+            # Maintenance checkout, for two reasons. It embeds per row, so an
+            # ordinary transactional one would stay open across a batch of
+            # network calls; and the re-embed fallback below issues an UPDATE
+            # from inside an ``except``, which after a failed statement in a
+            # transaction is InFailedSqlTransaction rather than a fallback.
+            with self._maintenance_connection() as conn:
                 with conn.cursor() as cur:
                     cur.execute(
                         "SELECT id, key, value, is_artifact FROM amfs_memory_entries "
@@ -3419,7 +3508,6 @@ class PostgresAdapter(AdapterABC):
                     ),
                 )
                 row = cur.fetchone()
-                conn.commit()
         return AgentGroup(
             id=str(row["id"]),
             namespace=namespace,
@@ -3595,8 +3683,6 @@ class PostgresAdapter(AdapterABC):
                     params,
                 )
                 row = cur.fetchone()
-                conn.commit()
-
         if not row:
             return None
         return AgentGroup(
@@ -3633,7 +3719,6 @@ class PostgresAdapter(AdapterABC):
                     (namespace, group_id, *acct_params),
                 )
                 deleted = cur.rowcount > 0
-                conn.commit()
         return deleted
 
     def add_agents_to_group(
@@ -3664,7 +3749,6 @@ class PostgresAdapter(AdapterABC):
                     values,
                 )
                 count = cur.rowcount
-                conn.commit()
         return count
 
     def remove_agents_from_group(
@@ -3685,7 +3769,6 @@ class PostgresAdapter(AdapterABC):
                     (group_id, namespace, agent_ids),
                 )
                 count = cur.rowcount
-                conn.commit()
         return count
 
     def reorder_agent_groups(
@@ -3713,7 +3796,6 @@ class PostgresAdapter(AdapterABC):
                         """,
                         params,
                     )
-                conn.commit()
 
     def list_agents_enriched(self, namespace: str = "default") -> list[dict[str, Any]]:
         account_id = self._get_current_account_id()
@@ -3887,7 +3969,6 @@ class PostgresAdapter(AdapterABC):
                     """,
                     (acct, cluster_id),
                 )
-                conn.commit()
 
     def list_dismissed_cluster_ids(self, account_id: str) -> list[str]:
         acct = self._get_current_account_id() or account_id

--- a/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
@@ -9,6 +9,7 @@ The sync PostgresAdapter, SDK, MCP, and Cortex are completely unaffected.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import uuid
@@ -54,21 +55,47 @@ class _AsyncTenantRLSConnection:
     """Async equivalent of _TenantRLSConnection.
 
     Replicates the exact same RLS behaviour:
-    1. Always set GUC on every checkout (even when tid is empty).
+    1. Always set all four GUCs on every checkout (even when the tenant is
+       empty), so a connection never inherits the previous borrower's.
     2. Empty string for no tenant (NULLIF handles it in RLS policies).
     3. Reads from the same contextvars used by the sync version.
+    4. Sets them *inside* an explicit transaction, so Postgres discards them at
+       commit and a transaction-mode pooler cannot hand them to another tenant.
+
+    Point 4 matters more here than on the sync side, because this pool serves
+    the HTTP request path: it is the most multi-tenant thing in the system, and
+    ``amfs.current_user_id`` is the setting that grants reach across accounts.
+
+    No ``transactional=False`` twin of the sync maintenance path, because this
+    adapter has no DDL and no backfills — the two things that need it.
     """
 
     def __init__(self, inner_ctx: Any) -> None:
         self._inner_ctx = inner_ctx
+        self._stack: contextlib.AsyncExitStack | None = None
 
     async def __aenter__(self) -> Any:
         from amfs_postgres.tenant_context import get_request_tenant_account_id
-        from amfs_postgres.tenant_gucs import aset_tenant_gucs
+        from amfs_postgres.tenant_gucs import (
+            aset_tenant_gucs,
+            require_open_transaction,
+        )
 
-        conn = await self._inner_ctx.__aenter__()
-        async with conn.cursor() as cur:
-            await aset_tenant_gucs(cur, local=False)
+        # AsyncExitStack for the same reason the sync side uses ExitStack: a
+        # failure while establishing the tenant has to unwind the transaction
+        # and hand the connection back, in that order, and getting that right
+        # by hand twice is how one of them ends up leaking a checkout.
+        stack = contextlib.AsyncExitStack()
+        try:
+            conn = await stack.enter_async_context(self._inner_ctx)
+            await stack.enter_async_context(conn.transaction())
+            require_open_transaction(conn)
+            async with conn.cursor() as cur:
+                await aset_tenant_gucs(cur, local=True)
+        except BaseException:
+            await stack.aclose()
+            raise
+        self._stack = stack
 
         if not get_request_tenant_account_id():
             logger.warning(
@@ -78,11 +105,13 @@ class _AsyncTenantRLSConnection:
         return conn
 
     async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> Any:
-        return await self._inner_ctx.__aexit__(exc_type, exc, tb)
+        if self._stack is None:
+            return None
+        return await self._stack.__aexit__(exc_type, exc, tb)
 
 
 class _AsyncTenantRLSPoolWrapper:
-    """Wraps an AsyncConnectionPool so each checkout applies RLS session vars."""
+    """Wraps an AsyncConnectionPool so each checkout scopes RLS vars to a txn."""
 
     def __init__(self, inner: AsyncConnectionPool) -> None:
         self._inner = inner

--- a/packages/adapters/postgres/src/amfs_postgres/tenant_gucs.py
+++ b/packages/adapters/postgres/src/amfs_postgres/tenant_gucs.py
@@ -62,11 +62,21 @@ Two kinds of work cannot run inside a caller-imposed transaction:
   embed-failed fallback issues more SQL after a caught error -- which inside a
   transaction is ``InFailedSqlTransaction`` instead of a fallback.
 
-Those use :func:`blank_tenant_gucs` instead: still one write of all four on
-every checkout, so nothing is inherited from the previous borrower, but to empty
-rather than to a tenant. Empty fails closed under RLS, and clearing is the one
-session-scoped write that cannot leak because there is nothing in it to leak.
-Both are ops- and startup-time paths that touch no tenant rows.
+Those check out with :func:`blank_tenant_gucs` instead: still one write of all
+four on every checkout, so nothing is inherited from the previous borrower, but
+to empty rather than to a tenant. Empty fails closed under RLS, and clearing is
+the one session-scoped write that cannot leak because there is nothing in it to
+leak.
+
+What that gives them is the absence of an enclosing transaction, and for DDL it
+is the whole story -- it touches no tenant rows, so blank settings are all it
+ever needs. The backfills are the other way round: they ``SELECT`` and
+``UPDATE`` ``amfs_memory_entries``, which is exactly the table the policies
+guard. Blank settings there are not a safe default but a silent no-op -- RLS
+matches no rows, so the loops examine nothing, update nothing, and report
+success. So they open a short transaction per statement and set a real tenant
+inside it, transaction-local like the data path, with the embedder calls falling
+between those transactions rather than inside one.
 """
 
 from __future__ import annotations

--- a/packages/adapters/postgres/src/amfs_postgres/tenant_gucs.py
+++ b/packages/adapters/postgres/src/amfs_postgres/tenant_gucs.py
@@ -22,26 +22,51 @@ bug rather than a formatting one.
 Session-scoped versus transaction-local
 ---------------------------------------
 ``set_config(name, value, is_local)`` takes a flag: false lasts for the session,
-true until the end of the current transaction. Both adapters use false today,
-set once per pool checkout, and with ``psycopg_pool`` that is sound — a checkout
-owns its backend for the whole block, and every checkout overwrites all four
-before running anything.
+true until the end of the current transaction. With ``psycopg_pool`` alone,
+false set once per checkout is sound — a checkout owns its backend for the whole
+block, and every checkout overwrites all four before running anything.
 
 It stops being sound the moment a transaction-mode pooler sits in front, because
 then one client connection maps to a different backend per transaction: the
 values set at checkout land on whichever backend served that statement, and the
 next query can be answered by a backend still carrying another tenant's session.
-Pooler-safe means setting them *inside* the transaction that reads, which is
-what :func:`tenant_transaction` is for.
+That is a cross-tenant read, and it was reproduced against a real PgBouncer
+before this was changed. Pooler-safe means setting them *inside* the transaction
+that reads.
 
-The trap, which is why this is not a one-line change: with ``autocommit=True``
+So the data path no longer sets them session-scoped at all: a checkout opens an
+explicit transaction and sets all four inside it, and Postgres discards them at
+commit. No tenant value is written session-scoped anywhere, which is what makes
+the leak structurally impossible rather than merely unlikely.
+
+The trap, which is why this was not a one-line change: with ``autocommit=True``
 -- what both adapters open their pools with -- ``set_config(..., true)`` applies
 to the implicit single-statement transaction it runs in and is gone before the
 next statement. The GUCs read empty, ``NULLIF`` turns that into NULL, and RLS
-matches nothing. It does not raise; it silently returns no rows. The same trap
-is already documented for ``SET LOCAL`` in ``_apply_schema``. So the local form
-is only ever used inside an explicit transaction, and
-:func:`tenant_transaction` asserts it has one rather than trusting the caller.
+matches nothing. It does not raise; it silently returns no rows. An empty page
+that looks like an empty account is the worst failure available here, so the
+local form is only ever used inside an explicit transaction and
+:func:`require_open_transaction` asserts there is one rather than trusting it.
+
+The maintenance exception
+-------------------------
+Two kinds of work cannot run inside a caller-imposed transaction:
+
+* **DDL.** ``_apply_schema`` deliberately does not wrap ``schema.sql`` in one --
+  a single transaction would hold ACCESS EXCLUSIVE on every object it touches
+  for the whole run, which is the lock convoy that took production down on
+  2026-08-12, only worse. It also sets ``lock_timeout`` session-scoped and
+  relies on statement-at-a-time commit to keep partial progress on retry.
+* **The backfills.** They call an embedder between statements, so a transaction
+  would stay open across a batch of network round trips, and their
+  embed-failed fallback issues more SQL after a caught error -- which inside a
+  transaction is ``InFailedSqlTransaction`` instead of a fallback.
+
+Those use :func:`blank_tenant_gucs` instead: still one write of all four on
+every checkout, so nothing is inherited from the previous borrower, but to empty
+rather than to a tenant. Empty fails closed under RLS, and clearing is the one
+session-scoped write that cannot leak because there is nothing in it to leak.
+Both are ops- and startup-time paths that touch no tenant rows.
 """
 
 from __future__ import annotations
@@ -109,29 +134,61 @@ CLEAR_TENANT_GUCS = SET_TENANT_GUCS_SESSION
 CLEARED_TENANT_GUC_VALUES: tuple[str, str, str, str] = ("", "", "false", "")
 
 
-def set_tenant_gucs(cur: Any, *, local: bool = False) -> None:
-    """Apply the current request's tenant to an open cursor."""
+def set_tenant_gucs(cur: Any, *, local: bool) -> None:
+    """Apply the current request's tenant to an open cursor.
+
+    ``local`` has no default on purpose. It used to default to False, and a
+    default here is the whole bug in one keyword: the unsafe scope was what you
+    got for not thinking about it, and the difference between the two is a
+    cross-tenant read rather than a style preference. Every caller now says
+    which it means, and ``local=False`` with a real tenant in it no longer
+    appears anywhere -- the session-scoped statement survives only to blank the
+    four, via :func:`blank_tenant_gucs`.
+    """
     sql = SET_TENANT_GUCS_LOCAL if local else SET_TENANT_GUCS_SESSION
     cur.execute(sql, tenant_guc_values())
 
 
-async def aset_tenant_gucs(cur: Any, *, local: bool = False) -> None:
-    """Async twin of :func:`set_tenant_gucs`."""
+async def aset_tenant_gucs(cur: Any, *, local: bool) -> None:
+    """Async twin of :func:`set_tenant_gucs`. ``local`` is required there too."""
     sql = SET_TENANT_GUCS_LOCAL if local else SET_TENANT_GUCS_SESSION
     await cur.execute(sql, tenant_guc_values())
+
+
+def blank_tenant_gucs(cur: Any) -> None:
+    """Set all four to empty on an open cursor, for the maintenance path.
+
+    The counterpart to :func:`set_tenant_gucs` for checkouts that cannot be
+    wrapped in a transaction (see "The maintenance exception" above). It is
+    session-scoped, like the old data path was, and that is safe here for a
+    reason that does not generalise: there is no tenant in it. Nothing that
+    could be leaked is written, and the previous borrower's tenant is still
+    overwritten, so the connection cannot inherit reach it should not have.
+
+    Under FORCE ROW LEVEL SECURITY -- which ``amfs_memory_entries`` has -- empty
+    matches no rows even for the table owner, so a maintenance path that
+    unexpectedly touched tenant data would read nothing rather than read
+    everything. Failing closed is the point.
+    """
+    cur.execute(CLEAR_TENANT_GUCS, CLEARED_TENANT_GUC_VALUES)
+
+
+async def ablank_tenant_gucs(cur: Any) -> None:
+    """Async twin of :func:`blank_tenant_gucs`."""
+    await cur.execute(CLEAR_TENANT_GUCS, CLEARED_TENANT_GUC_VALUES)
 
 
 def reset_tenant_gucs(conn: Any) -> None:
     """Blank all four. Suitable as a ``psycopg_pool`` ``reset`` callback.
 
-    Defence in depth for the session-scoped path. Every checkout already
-    overwrites all four before running anything, so this is not what stops a
-    leak today; it stops one from surviving a checkout that failed partway, or a
-    caller that reached the pool without going through the wrapper. Cheap enough
-    to be worth not having to reason about.
+    Defence in depth. The data path now scopes its tenant to a transaction, so
+    Postgres has already discarded it by the time a connection comes back and
+    there is normally nothing here to clear. This is what covers the paths that
+    do not go through that: a maintenance checkout, or a caller that reached the
+    pool directly. Cheap enough to be worth not having to reason about.
     """
     with conn.cursor() as cur:
-        cur.execute(CLEAR_TENANT_GUCS, CLEARED_TENANT_GUC_VALUES)
+        blank_tenant_gucs(cur)
 
 
 async def areset_tenant_gucs(conn: Any) -> None:
@@ -145,10 +202,10 @@ async def areset_tenant_gucs(conn: Any) -> None:
     one setting that grants reach across accounts.
     """
     async with conn.cursor() as cur:
-        await cur.execute(CLEAR_TENANT_GUCS, CLEARED_TENANT_GUC_VALUES)
+        await ablank_tenant_gucs(cur)
 
 
-def _assert_in_transaction(conn: Any) -> None:
+def require_open_transaction(conn: Any) -> None:
     """Refuse to proceed unless a transaction is genuinely open.
 
     This is the guard against the silent-empty-result failure described in the
@@ -156,6 +213,10 @@ def _assert_in_transaction(conn: Any) -> None:
     is discarded immediately and every following query reads an empty tenant, so
     the caller gets no rows and no error. Better to raise here, loudly, than to
     return an empty page that looks like an empty account.
+
+    Public because both adapters' checkout wrappers call it, not just
+    :func:`tenant_transaction`: the assertion is only worth having if it sits on
+    every path that sets the local form.
     """
     status = getattr(getattr(conn, "info", None), "transaction_status", None)
     if status is None:
@@ -163,7 +224,7 @@ def _assert_in_transaction(conn: Any) -> None:
     name = getattr(status, "name", str(status))
     if name not in ("INTRANS", "INERROR", "ACTIVE"):
         raise RuntimeError(
-            "tenant_transaction: no open transaction "
+            "tenant GUCs: no open transaction "
             f"(transaction_status={name}). Transaction-local tenant settings "
             "would be discarded before the next statement and every read would "
             "silently return zero rows."
@@ -179,15 +240,19 @@ def tenant_transaction(pool: Any) -> Iterator[Any]:
     them at commit. Nothing is left on the backend for the next borrower, which
     is what makes it safe to put a transaction-mode pooler in front.
 
-    Unwraps ``_TenantRLSPoolWrapper`` if handed one. The wrapper sets the same
-    four settings session-scoped at checkout, and here that is not merely
-    redundant: through a transaction pooler those writes land on an arbitrary
-    backend and stay there, which is the leak this function exists to avoid.
+    This is what ``_TenantRLSPoolWrapper`` now does on every checkout, so going
+    through the adapter's pool already gets you this. The function stays for
+    callers holding a bare pool, and for being the readable statement of the
+    invariant that the wrapper implements.
+
+    Unwraps the wrapper if handed one, purely to avoid doing the work twice: a
+    nested ``transaction()`` is a savepoint and a second write of the same four
+    values is a wasted round trip. Correct either way, which is the point.
     """
     inner = getattr(pool, "_inner", pool)
     with inner.connection() as conn:
         with conn.transaction():
-            _assert_in_transaction(conn)
+            require_open_transaction(conn)
             with conn.cursor() as cur:
                 set_tenant_gucs(cur, local=True)
             yield conn

--- a/tests/integration/pgbouncer/pgbouncer.ini
+++ b/tests/integration/pgbouncer/pgbouncer.ini
@@ -1,0 +1,43 @@
+; A transaction-mode pooler, configured the way the hazard actually appears.
+;
+; Two settings carry the whole point of the test:
+;
+;   pool_mode = transaction    one client connection maps to a DIFFERENT server
+;                              backend per transaction, so anything set outside
+;                              a transaction lands on an arbitrary backend and
+;                              stays there for whoever borrows it next.
+;
+;   default_pool_size = 1      one server connection shared by every client, so
+;                              the reuse the leak needs is guaranteed rather
+;                              than probabilistic. A larger pool hides the bug
+;                              behind luck, which is how it reaches production.
+;
+; server_reset_query is deliberately left at its default. PgBouncer's default is
+; `DISCARD ALL`, but `server_reset_query_always` defaults to 0, which means the
+; reset is NOT run in transaction mode -- so session state does survive between
+; clients. Setting it to 1 would paper over the bug being tested, and it is not
+; what a default deployment does.
+;
+; Started and stopped by the `pgbouncer` fixture in
+; test_tenant_guc_pooler_leak.py; the database line is rewritten there so the
+; test's own throwaway DSN is used rather than a name hardcoded here.
+
+[databases]
+* = host=/tmp port=5432
+
+[pgbouncer]
+listen_addr = 127.0.0.1
+listen_port = 6432
+pool_mode = transaction
+default_pool_size = 1
+max_client_conn = 20
+; Local trust auth, matching the pg_hba this runs against. Never a production
+; configuration; this file is test scaffolding and lives under tests/.
+auth_type = trust
+auth_file = /dev/null
+; psycopg sends both of these in its startup packet, and PgBouncer rejects
+; unknown startup parameters outright rather than ignoring them. `options` is
+; the one that matters here: the adapter puts statement_timeout there.
+ignore_startup_parameters = extra_float_digits,options
+; No logfile and no pidfile: the fixture runs this in the foreground as a child
+; process and kills it, so there is nothing to daemonise and nothing to clean up.

--- a/tests/integration/pgbouncer/test_tenant_guc_pooler_leak.py
+++ b/tests/integration/pgbouncer/test_tenant_guc_pooler_leak.py
@@ -1,0 +1,423 @@
+"""The tenant settings, against a real transaction-mode pooler.
+
+RLS on tenant tables reads four Postgres settings, and how long those settings
+last decides whether the isolation holds. They used to be set session-scoped,
+once per pool checkout. With ``psycopg_pool`` alone that is sound: a checkout
+owns its backend for the whole block.
+
+Put PgBouncer in ``pool_mode = transaction`` in front and it stops being sound,
+because one client connection then maps to a *different* server backend per
+transaction. A setting written outside a transaction lands on whichever backend
+happened to serve that statement and stays there, and the next query — a new
+transaction — can be answered by a backend still carrying another tenant's
+values. That is a cross-account read, and unit tests cannot see it: it lives
+entirely in the relationship between the pooler and the session.
+
+So this file runs a real PgBouncer. It has two halves, and the first matters as
+much as the second:
+
+``TestTheHarnessCanSeeTheLeak`` reproduces the bug with the old session-scoped
+pattern and asserts that the leak *happens*. Without it, a passing suite would
+be indistinguishable from a harness that cannot detect the problem — which is
+the failure mode that let this bug exist while tests were green.
+
+``TestTheAdapterDoesNotLeak`` then drives the real checkout wrapper through the
+same pooler and asserts it holds.
+
+Requires ``AMFS_TEST_PG_DSN`` and a ``pgbouncer`` binary on PATH; skipped
+otherwise, so the default unit run is unaffected.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+psycopg = pytest.importorskip("psycopg")
+
+from psycopg.conninfo import conninfo_to_dict  # noqa: E402
+
+DSN = os.environ.get("AMFS_TEST_PG_DSN")
+PGBOUNCER = shutil.which("pgbouncer")
+
+pytestmark = [
+    pytest.mark.skipif(not DSN, reason="AMFS_TEST_PG_DSN not set"),
+    pytest.mark.skipif(not PGBOUNCER, reason="pgbouncer not on PATH"),
+]
+
+#: The four settings, and the one the test reads back. Kept as a literal rather
+#: than imported so that a rename in the adapter cannot quietly make this test
+#: assert nothing.
+ACCOUNT_GUC = "amfs.current_account_id"
+
+#: Session-scoped, which is what this file exists to show is unsafe here.
+SET_SESSION = (
+    f"SELECT set_config('{ACCOUNT_GUC}', %s, false), "
+    "set_config('amfs.current_team_id', %s, false), "
+    "set_config('amfs.is_account_admin', %s, false), "
+    "set_config('amfs.current_user_id', %s, false)"
+)
+
+TABLE = "pooler_leak_rows"
+
+#: Every connection in this file is made as this role, not as the owner of the
+#: test database. That is not tidiness: superusers and BYPASSRLS roles ignore row
+#: level security entirely, even with FORCE, so running as the usual test
+#: superuser would make every isolation assertion here pass without RLS ever
+#: being consulted. ``TestTheHarnessCanSeeTheLeak`` checks this held.
+APP_ROLE = "amfs_pooler_leak_app"
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+@pytest.fixture(scope="module")
+def accounts() -> tuple[str, str]:
+    return str(uuid.uuid4()), str(uuid.uuid4())
+
+
+@pytest.fixture(scope="module")
+def table(accounts: tuple[str, str]) -> str:
+    """A table with the same RLS shape the real policies use, plus the app role.
+
+    Purpose-built rather than reusing ``amfs_memory_entries``, because what is
+    under test is the *scope* of the settings rather than any particular policy,
+    and a table of two rows makes a leak unambiguous. The predicate is copied in
+    form from the real ones: ``NULLIF(current_setting(..., true), '')``, so an
+    absent setting reads empty, becomes NULL, and matches nothing.
+
+    FORCE ROW LEVEL SECURITY as well as ENABLE, so that the table's owner is not
+    exempt either. Belt and braces given the app role below, but the combination
+    is what the real tenant tables use and the test should not be more permissive
+    than production.
+    """
+    a, b = accounts
+    with psycopg.connect(DSN, autocommit=True) as conn:
+        conn.execute(f"DROP TABLE IF EXISTS {TABLE}")
+        conn.execute(
+            f"CREATE TABLE {TABLE} (account_id uuid NOT NULL, label text NOT NULL)"
+        )
+        conn.execute(f"ALTER TABLE {TABLE} ENABLE ROW LEVEL SECURITY")
+        conn.execute(f"ALTER TABLE {TABLE} FORCE ROW LEVEL SECURITY")
+        conn.execute(
+            f"CREATE POLICY tenant_isolation ON {TABLE} USING ("
+            f"  account_id = NULLIF(current_setting('{ACCOUNT_GUC}', true), '')::uuid"
+            f")"
+        )
+        conn.execute(
+            f"INSERT INTO {TABLE} (account_id, label) VALUES (%s, %s), (%s, %s)",
+            (a, "belongs-to-a", b, "belongs-to-b"),
+        )
+        conn.execute(
+            f"DO $$ BEGIN "
+            f"  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{APP_ROLE}') "
+            f"  THEN CREATE ROLE {APP_ROLE} LOGIN NOSUPERUSER NOBYPASSRLS; END IF; "
+            f"END $$"
+        )
+        # NOSUPERUSER/NOBYPASSRLS again on the already-exists path, so a role
+        # left over from an earlier run cannot silently be the privileged one.
+        conn.execute(f"ALTER ROLE {APP_ROLE} NOSUPERUSER NOBYPASSRLS")
+        conn.execute(f"GRANT USAGE ON SCHEMA public TO {APP_ROLE}")
+        conn.execute(f"GRANT SELECT ON {TABLE} TO {APP_ROLE}")
+    yield TABLE
+    with psycopg.connect(DSN, autocommit=True) as conn:
+        conn.execute(f"REVOKE ALL ON {TABLE} FROM {APP_ROLE}")
+        conn.execute(f"DROP TABLE IF EXISTS {TABLE}")
+
+
+@pytest.fixture(scope="module")
+def pooled_dsn(tmp_path_factory, table: str) -> str:
+    """A DSN pointing at a PgBouncer in transaction mode, one server connection.
+
+    ``default_pool_size = 1`` is what makes the reuse deterministic instead of
+    lucky. A larger pool hides the bug behind timing, which is how it survives
+    review and reaches production.
+
+    The auth file is not optional even with ``auth_type = trust``: PgBouncer
+    still refuses a user it has never heard of, which is a confusing failure to
+    debug from a connection-refused error.
+    """
+    info = conninfo_to_dict(DSN)
+    dbname = info.get("dbname") or info.get("user") or "postgres"
+    host = info.get("host") or "/tmp"
+    port = info.get("port") or "5432"
+    user = APP_ROLE
+
+    workdir = tmp_path_factory.mktemp("pgbouncer")
+    listen_port = _free_port()
+
+    template = (Path(__file__).parent / "pgbouncer.ini").read_text()
+    ini = workdir / "pgbouncer.ini"
+    userlist = workdir / "userlist.txt"
+    userlist.write_text(f'"{user}" ""\n')
+    ini.write_text(
+        template.replace("* = host=/tmp port=5432", f"* = host={host} port={port}")
+        .replace("listen_port = 6432", f"listen_port = {listen_port}")
+        .replace("auth_file = /dev/null", f"auth_file = {userlist}")
+    )
+
+    proc = subprocess.Popen(
+        [PGBOUNCER, str(ini)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    pooled = f"host=127.0.0.1 port={listen_port} dbname={dbname} user={user}"
+    try:
+        deadline = time.monotonic() + 15
+        while True:
+            if proc.poll() is not None:
+                pytest.fail(f"pgbouncer exited early:\n{proc.stdout.read()}")
+            try:
+                with psycopg.connect(pooled, connect_timeout=2) as probe:
+                    probe.execute("SELECT 1")
+                break
+            except psycopg.OperationalError:
+                if time.monotonic() > deadline:
+                    proc.terminate()
+                    pytest.fail("pgbouncer did not accept connections in 15s")
+                time.sleep(0.2)
+        yield pooled
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def _first(row):
+    """The single column of a one-column row, whatever the row factory is.
+
+    Raw connections here use the default tuple rows; the adapter's pool is
+    opened with ``dict_row``, so the same query comes back as a mapping. Both
+    appear in this file and neither is worth changing to suit the other.
+    """
+    return next(iter(row.values())) if isinstance(row, dict) else row[0]
+
+
+def _labels(conn, table: str) -> list[str]:
+    return [_first(r) for r in conn.execute(f"SELECT label FROM {table}").fetchall()]
+
+
+def _setting(conn, name: str = ACCOUNT_GUC):
+    return _first(conn.execute(f"SELECT current_setting('{name}', true)").fetchone())
+
+
+class TestTheHarnessCanSeeTheLeak:
+    """The control. If these fail, nothing else in this file means anything.
+
+    A test that only asserts "no leak" is passed just as happily by a harness
+    that cannot produce one — the wrong pool mode, a pool big enough that
+    clients never share a backend, a policy that never applied. So the old
+    pattern is run through this exact harness first and the leak is asserted
+    as the expected outcome.
+    """
+
+    def test_the_connecting_role_is_actually_subject_to_rls(
+        self, pooled_dsn: str
+    ) -> None:
+        """The cheapest way for this whole file to become meaningless.
+
+        Superusers and BYPASSRLS roles skip row level security outright, FORCE or
+        not. Connect as the usual test superuser and every isolation assertion
+        below passes without a policy ever being evaluated — green, and blind.
+        """
+        with psycopg.connect(pooled_dsn, autocommit=True) as conn:
+            role, is_super, bypasses = conn.execute(
+                "SELECT current_user, rolsuper, rolbypassrls "
+                "FROM pg_roles WHERE rolname = current_user"
+            ).fetchone()
+
+        assert role == APP_ROLE
+        assert not is_super, "a superuser bypasses RLS; this test would prove nothing"
+        assert not bypasses, "BYPASSRLS set; this test would prove nothing"
+
+    def test_two_clients_share_one_backend(self, pooled_dsn: str) -> None:
+        """The precondition for everything below."""
+        with (
+            psycopg.connect(pooled_dsn, autocommit=True) as a,
+            psycopg.connect(pooled_dsn, autocommit=True) as b,
+        ):
+            pid_a = _first(a.execute("SELECT pg_backend_pid()").fetchone())
+            pid_b = _first(b.execute("SELECT pg_backend_pid()").fetchone())
+
+        assert pid_a == pid_b, (
+            "the pooler is not multiplexing these clients onto one backend, so "
+            "this file cannot observe the bug it exists to test"
+        )
+
+    def test_session_scoped_settings_leak_between_clients(
+        self, pooled_dsn: str, table: str, accounts: tuple[str, str]
+    ) -> None:
+        """The bug, reproduced.
+
+        Each statement below is its own transaction, because both connections
+        are in autocommit — which is how the adapter's pools are opened. So A's
+        settings land on a backend it does not keep, B's overwrite them, and A's
+        next query is answered by a backend carrying B's tenant.
+        """
+        account_a, account_b = accounts
+        with (
+            psycopg.connect(pooled_dsn, autocommit=True) as a,
+            psycopg.connect(pooled_dsn, autocommit=True) as b,
+        ):
+            a.execute(SET_SESSION, (account_a, "", "false", ""))
+            b.execute(SET_SESSION, (account_b, "", "false", ""))
+
+            seen_by_a = _labels(a, table)
+
+        assert seen_by_a == ["belongs-to-b"], (
+            f"expected A to be reading B's row through the shared backend, got "
+            f"{seen_by_a}. If this is A's own row, the harness has stopped "
+            f"reproducing the leak and the assertions below prove nothing."
+        )
+
+    def test_the_setting_outlives_the_client_that_wrote_it(
+        self, pooled_dsn: str
+    ) -> None:
+        """Residue is the mechanism. A session-scoped write is still on the
+        backend after the client that made it has gone away."""
+        leaked = str(uuid.uuid4())
+        with psycopg.connect(pooled_dsn, autocommit=True) as first:
+            first.execute(SET_SESSION, (leaked, "", "false", ""))
+
+        with psycopg.connect(pooled_dsn, autocommit=True) as second:
+            still_there = _setting(second)
+
+        assert still_there == leaked, (
+            "the pooler is resetting session state between clients, so this "
+            "harness cannot show the leak"
+        )
+
+
+class TestTheAdapterDoesNotLeak:
+    """The real checkout wrapper, through the same pooler that leaks above.
+
+    Of the three, ``test_each_checkout_sees_only_its_own_account`` is the one
+    that discriminates: revert the wrapper to session-scoped settings and it is
+    the only one that fails. The other two hold even on the broken version,
+    because ``psycopg_pool``'s ``reset`` callback blanks the four as a
+    connection goes back, so residue is gone by the time they look for it.
+
+    They are kept anyway, and it is worth being clear about why rather than
+    presenting them as proof they are not. That reset is defence in depth for a
+    path that no longer needs it, and both tests state a property that should
+    stay true independently of it — so if the reset callback is ever dropped as
+    redundant, these are what notice.
+    """
+
+    @pytest.fixture
+    def adapter(self, pooled_dsn: str):
+        from amfs_postgres.adapter import PostgresAdapter
+
+        # auto_schema=False: the bootstrap DDL is not what is under test, and
+        # running it through a transaction pooler on every test would be slow
+        # and beside the point.
+        return PostgresAdapter(pooled_dsn, namespace="pooler-leak", auto_schema=False)
+
+    @staticmethod
+    def _as(account: str):
+        """Enter a request context for one account, the way the server does."""
+        from amfs_postgres import tenant_context
+
+        tenant_context.set_tls_tenant_account_id(account)
+        tenant_context.set_tls_tenant_team_id(None)
+        tenant_context.set_tls_is_account_admin(False)
+        tenant_context.set_tls_user_id(None)
+
+    @staticmethod
+    def _clear():
+        from amfs_postgres import tenant_context
+
+        tenant_context.clear_tls_tenant_account_id()
+        tenant_context.clear_tls_tenant_team_id()
+        tenant_context.clear_tls_is_account_admin()
+        tenant_context.clear_tls_user_id()
+
+    def test_each_checkout_sees_only_its_own_account(
+        self, adapter, table: str, accounts: tuple[str, str]
+    ) -> None:
+        """Interleaved requests on one shared backend, which is the arrangement
+        that leaked in the control above."""
+        account_a, account_b = accounts
+        try:
+            self._as(account_a)
+            with adapter._pool.connection() as conn:
+                first_a = _labels(conn, table)
+
+            self._as(account_b)
+            with adapter._pool.connection() as conn:
+                seen_b = _labels(conn, table)
+
+            self._as(account_a)
+            with adapter._pool.connection() as conn:
+                second_a = _labels(conn, table)
+        finally:
+            self._clear()
+
+        assert first_a == ["belongs-to-a"]
+        assert seen_b == ["belongs-to-b"]
+        assert second_a == ["belongs-to-a"], (
+            "A's second request was answered by a backend still carrying B"
+        )
+
+    def test_nothing_is_left_on_the_backend_afterwards(
+        self, adapter, accounts: tuple[str, str]
+    ) -> None:
+        """The property that makes the pooler safe, asserted directly.
+
+        Transaction-local settings are discarded by Postgres at commit, so the
+        shared backend carries no tenant once the request is over. The first half
+        is the part only this test covers: that the tenant *is* visible inside
+        its own transaction. Getting the scope right and the placement wrong —
+        setting the four before the BEGIN, where autocommit throws them away —
+        produces a system that leaks nothing and also reads nothing.
+        """
+        account_a, _ = accounts
+        try:
+            self._as(account_a)
+            with adapter._pool.connection() as conn:
+                assert _setting(conn) == account_a, (
+                    "the tenant must be visible inside its own transaction"
+                )
+        finally:
+            self._clear()
+
+        with psycopg.connect(adapter._dsn, autocommit=True) as after:
+            residue = _setting(after)
+
+        assert residue in (None, ""), (
+            f"the backend is still carrying {residue!r} after the request "
+            f"finished; the next borrower would inherit it"
+        )
+
+    def test_a_request_with_no_tenant_reads_nothing(
+        self, adapter, table: str, accounts: tuple[str, str]
+    ) -> None:
+        """Fails closed. A checkout with no tenant must not inherit the previous
+        one — which, on a shared backend, is the difference between an empty
+        result and someone else's data."""
+        account_a, _ = accounts
+        try:
+            self._as(account_a)
+            with adapter._pool.connection() as conn:
+                assert _labels(conn, table) == ["belongs-to-a"]
+
+            self._clear()
+            with adapter._pool.connection() as conn:
+                seen = _labels(conn, table)
+        finally:
+            self._clear()
+
+        assert seen == [], f"a tenant-less request read {seen}"

--- a/tests/test_shared_path_scoping.py
+++ b/tests/test_shared_path_scoping.py
@@ -20,6 +20,7 @@ and nothing will notice.
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -71,9 +72,35 @@ class TestTheGuardIsDefinedOnce:
         )
 
     def test_the_async_adapter_shares_the_definition(self) -> None:
-        """Two copies of a security rule is one copy that gets forgotten."""
-        assert f"from amfs_postgres.adapter import {GUARD}" in ASYNC.read_text()
-        assert f'{GUARD} = ' not in ASYNC.read_text()
+        """Two copies of a security rule is one copy that gets forgotten.
+
+        Parsed rather than string-matched, because the substring version of this
+        test was a false negative for as long as the import stayed on one line
+        and then silently for as long as it did not: wrapping it in parentheses
+        -- which any formatter will do once a fourth name is added -- made the
+        assertion unsatisfiable while the code was still correct. A security
+        guard whose test fails for cosmetic reasons gets its test relaxed.
+        """
+        imported = {
+            alias.name
+            for node in ast.walk(ast.parse(ASYNC.read_text()))
+            if isinstance(node, ast.ImportFrom)
+            and node.module == "amfs_postgres.adapter"
+            for alias in node.names
+        }
+        assert GUARD in imported, (
+            f"{GUARD} is not imported from amfs_postgres.adapter; the async "
+            f"adapter has either lost the guard or grown its own copy"
+        )
+
+        assigned = {
+            target.id
+            for node in ast.walk(ast.parse(ASYNC.read_text()))
+            if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Name)
+        }
+        assert GUARD not in assigned, "a second definition of the guard"
 
 
 class TestUnscopedReadsExcludeSharedNamespaces:

--- a/tests/unit/test_async_adapter.py
+++ b/tests/unit/test_async_adapter.py
@@ -9,12 +9,51 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+class _AsyncTransaction:
+    """A stand-in for ``conn.transaction()`` that records its own lifecycle.
+
+    Written out rather than mocked so the ordering assertion below can see when
+    the transaction opened relative to the ``set_config`` call. An AsyncMock
+    would answer that with another mock.
+    """
+
+    def __init__(self, log: list) -> None:
+        self._log = log
+
+    async def __aenter__(self) -> _AsyncTransaction:
+        self._log.append(("BEGIN", None))
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        self._log.append(("COMMIT" if exc_type is None else "ROLLBACK", None))
+        return None
+
+
+def _async_sets(executed: list) -> list:
+    """Just the set_config statements, dropping the BEGIN/COMMIT markers."""
+    return [(sql, params) for sql, params in executed if "set_config" in str(sql)]
+
+
 class TestAsyncTenantRLSConnection:
-    """Verify _AsyncTenantRLSConnection sets the correct GUCs."""
+    """Verify _AsyncTenantRLSConnection sets the correct GUCs, transaction-local.
+
+    This pool serves the HTTP request path, so it is the most multi-tenant thing
+    in the system and the place where scope matters most: session-scoped
+    settings behind a transaction-mode pooler land on whichever backend served
+    the statement that set them, and the next request can be answered by a
+    backend still carrying them.
+    """
 
     @pytest.fixture
     def _make_conn(self):
-        """Build a mock async connection with a cursor that records SQL."""
+        """Build a mock async connection with a cursor that records SQL.
+
+        ``transaction_status.name`` has to be a real string and ``transaction``
+        a plain callable returning an async context manager: the wrapper refuses
+        to write transaction-local settings unless a transaction is genuinely
+        open, because outside one they are discarded and every read silently
+        returns nothing.
+        """
         executed = []
 
         mock_cur = AsyncMock()
@@ -24,6 +63,10 @@ class TestAsyncTenantRLSConnection:
 
         mock_conn = AsyncMock()
         mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_conn.info.transaction_status.name = "INTRANS"
+        mock_conn.transaction = MagicMock(
+            return_value=_AsyncTransaction(executed)
+        )
 
         mock_inner_ctx = AsyncMock()
         mock_inner_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
@@ -45,8 +88,8 @@ class TestAsyncTenantRLSConnection:
             rls = _AsyncTenantRLSConnection(inner_ctx)
             conn = await rls.__aenter__()
 
-        assert len(executed) == 1
-        sql, params = executed[0]
+        assert len(_async_sets(executed)) == 1
+        sql, params = _async_sets(executed)[0]
         assert "set_config('amfs.current_account_id'" in sql
         assert "set_config('amfs.current_team_id'" in sql
         assert "set_config('amfs.is_account_admin'" in sql
@@ -67,8 +110,8 @@ class TestAsyncTenantRLSConnection:
             rls = _AsyncTenantRLSConnection(inner_ctx)
             await rls.__aenter__()
 
-        assert len(executed) == 1
-        _, params = executed[0]
+        assert len(_async_sets(executed)) == 1
+        _, params = _async_sets(executed)[0]
         assert params == ("", "", "false", "")
 
     async def test_admin_false(self, _make_conn):
@@ -85,7 +128,7 @@ class TestAsyncTenantRLSConnection:
             rls = _AsyncTenantRLSConnection(inner_ctx)
             await rls.__aenter__()
 
-        _, params = executed[0]
+        _, params = _async_sets(executed)[0]
         assert params == ("acct-x", "team-y", "false", "")
 
     async def test_a_pooled_connection_never_inherits_the_last_users_identity(
@@ -111,7 +154,7 @@ class TestAsyncTenantRLSConnection:
         ):
             await _AsyncTenantRLSConnection(inner_ctx).__aenter__()
 
-        sql, params = executed[0]
+        sql, params = _async_sets(executed)[0]
         assert "set_config('amfs.current_user_id'" in sql, (
             "current_user_id is left untouched on checkout, so it keeps "
             "whatever the previous borrower of this pooled connection set"
@@ -132,6 +175,90 @@ class TestAsyncTenantRLSConnection:
             rls = _AsyncTenantRLSConnection(inner_ctx)
             await rls.__aenter__()
             await rls.__aexit__(None, None, None)
+
+        assert inner_ctx.__aexit__.called
+
+    async def test_the_settings_are_transaction_local(self, _make_conn):
+        """Session scope here is the leak: through a transaction pooler the
+        write lands on an arbitrary backend and outlives the request."""
+        from amfs_postgres import tenant_gucs
+        from amfs_postgres.async_adapter import _AsyncTenantRLSConnection
+
+        inner_ctx, executed = _make_conn
+
+        with (
+            patch("amfs_postgres.tenant_context.get_request_tenant_account_id", return_value="acct-1"),
+            patch("amfs_postgres.tenant_context.get_request_tenant_team_id", return_value=None),
+            patch("amfs_postgres.tenant_context.get_request_is_account_admin", return_value=False),
+            patch("amfs_postgres.tenant_context.get_request_user_id", return_value="u-1"),
+        ):
+            await _AsyncTenantRLSConnection(inner_ctx).__aenter__()
+
+        sql, _params = _async_sets(executed)[0]
+        assert sql == tenant_gucs.SET_TENANT_GUCS_LOCAL
+        assert sql != tenant_gucs.SET_TENANT_GUCS_SESSION
+
+    async def test_the_transaction_opens_before_the_settings_are_written(
+        self, _make_conn
+    ):
+        """Order decides whether this works at all. The pool runs autocommit, so
+        a local set_config issued before the BEGIN is its own transaction and is
+        discarded before the next statement — leaving every RLS-protected read
+        matching nothing, with no error to notice."""
+        from amfs_postgres.async_adapter import _AsyncTenantRLSConnection
+
+        inner_ctx, executed = _make_conn
+
+        with (
+            patch("amfs_postgres.tenant_context.get_request_tenant_account_id", return_value="acct-1"),
+            patch("amfs_postgres.tenant_context.get_request_tenant_team_id", return_value=None),
+            patch("amfs_postgres.tenant_context.get_request_is_account_admin", return_value=False),
+            patch("amfs_postgres.tenant_context.get_request_user_id", return_value=None),
+        ):
+            await _AsyncTenantRLSConnection(inner_ctx).__aenter__()
+
+        kinds = [sql if sql in ("BEGIN", "COMMIT") else "SET" for sql, _ in executed]
+        assert kinds[0] == "BEGIN", f"expected BEGIN first, got {kinds}"
+
+    async def test_the_transaction_commits_on_a_clean_exit(self, _make_conn):
+        from amfs_postgres.async_adapter import _AsyncTenantRLSConnection
+
+        inner_ctx, executed = _make_conn
+
+        with (
+            patch("amfs_postgres.tenant_context.get_request_tenant_account_id", return_value="acct-1"),
+            patch("amfs_postgres.tenant_context.get_request_tenant_team_id", return_value=None),
+            patch("amfs_postgres.tenant_context.get_request_is_account_admin", return_value=False),
+            patch("amfs_postgres.tenant_context.get_request_user_id", return_value=None),
+        ):
+            rls = _AsyncTenantRLSConnection(inner_ctx)
+            await rls.__aenter__()
+            await rls.__aexit__(None, None, None)
+
+        assert [sql for sql, _ in executed if sql in ("BEGIN", "COMMIT")] == [
+            "BEGIN",
+            "COMMIT",
+        ]
+
+    async def test_it_refuses_to_set_what_it_cannot_scope(self, _make_conn):
+        """An empty page that looks like an empty account is the worst available
+        failure, so this raises instead of returning one."""
+        from amfs_postgres.async_adapter import _AsyncTenantRLSConnection
+
+        inner_ctx, executed = _make_conn
+        inner_ctx.__aenter__.return_value.info.transaction_status.name = "IDLE"
+
+        with (
+            patch("amfs_postgres.tenant_context.get_request_tenant_account_id", return_value="acct-1"),
+            patch("amfs_postgres.tenant_context.get_request_tenant_team_id", return_value=None),
+            patch("amfs_postgres.tenant_context.get_request_is_account_admin", return_value=False),
+            patch("amfs_postgres.tenant_context.get_request_user_id", return_value="u-1"),
+        ):
+            with pytest.raises(RuntimeError, match="no open transaction"):
+                await _AsyncTenantRLSConnection(inner_ctx).__aenter__()
+
+        assert _async_sets(executed) == [], "must not write a tenant it cannot scope"
+        assert inner_ctx.__aexit__.called, "checkout leaked on the failure path"
 
         inner_ctx.__aexit__.assert_awaited_once()
 

--- a/tests/unit/test_backfill_embeddings.py
+++ b/tests/unit/test_backfill_embeddings.py
@@ -49,7 +49,7 @@ class _FakeCursor:
                 if vector is None and row_id > last_id
             )
             self._rows = [
-                {"id": row_id, "value": json.dumps({"row": row_id})}
+                {"id": row_id, "value": self._db.stored_value(row_id)}
                 for row_id in pending[:limit]
             ]
         elif sql.startswith("UPDATE amfs_memory_entries SET embedding"):
@@ -63,11 +63,28 @@ class _FakeCursor:
 
 
 class _FakeDB:
-    def __init__(self, row_ids: list[str]) -> None:
+    def __init__(
+        self, row_ids: list[str], *, values: dict[str, Any] | None = None
+    ) -> None:
         self.embeddings: dict[str, str | None] = {r: None for r in row_ids}
         self.selects: list[tuple[str, int]] = []
+        self.scopes: list[bool] = []
+        #: Overrides for what a row's ``value`` column holds. The default is a
+        #: JSON object, which is the common case; a bare string is the case that
+        #: used to be misread as an unembeddable row.
+        self.values: dict[str, Any] = values or {}
 
-    def connection(self) -> Any:
+    def stored_value(self, row_id: str) -> Any:
+        if row_id in self.values:
+            return self.values[row_id]
+        return json.dumps({"row": row_id})
+
+    def connection(self, *, transactional: bool = True) -> Any:
+        # The backfill checks out with transactional=False, because it calls the
+        # embedder between statements and would otherwise hold a transaction
+        # open across a batch of network round trips. Recorded rather than
+        # ignored so that the scope stays part of what these tests describe.
+        self.scopes.append(transactional)
         cursor = _FakeCursor(self)
         pool_ctx = MagicMock()
         pool_ctx.__enter__ = MagicMock(return_value=_conn_with(cursor))
@@ -242,3 +259,88 @@ class TestWhenItCannotRunAtAll:
 
         assert adapter.backfill_embeddings() == 0
         assert db.selects == [], "must not query at all"
+
+
+class TestValuesThatAreNotJson:
+    """A value can be a bare string, and a bare string is not JSON.
+
+    The decode and the embed used to share one ``try``, so ``json.loads`` on a
+    plain string raised JSONDecodeError and the row was counted as one the
+    embedder could not handle. It kept its NULL embedding, stayed invisible to
+    semantic search, and was re-read and re-failed by every later backfill —
+    reported only as a warning, so the store looked backfilled.
+    """
+
+    def test_a_plain_string_value_is_embedded_not_skipped(self):
+        db = _FakeDB(_ids(3), values={"row-001": "analytics runs on clickhouse"})
+
+        updated = _adapter(db).backfill_embeddings()
+
+        assert updated == 3, "the bare-string row must be embedded like the rest"
+        assert db.missing == set()
+
+    def test_it_is_the_raw_string_that_reaches_the_embedder(self):
+        """Not a JSON-quoted version of it, and not a repr."""
+        db = _FakeDB(["row-000"], values={"row-000": "analytics on clickhouse"})
+        adapter = _adapter(db)
+
+        adapter.backfill_embeddings()
+
+        adapter._embedder.embed_value.assert_called_once_with(
+            "analytics on clickhouse"
+        )
+
+    def test_a_json_value_is_still_decoded(self):
+        """The fallback must not stop real JSON being parsed into an object."""
+        db = _FakeDB(["row-000"], values={"row-000": json.dumps({"row": "row-000"})})
+        adapter = _adapter(db)
+
+        adapter.backfill_embeddings()
+
+        adapter._embedder.embed_value.assert_called_once_with({"row": "row-000"})
+
+    def test_a_genuine_embedder_failure_is_still_skipped(self):
+        """The fallback widens what counts as decodable, not what counts as
+        embeddable — a row the embedder rejects must still be left alone."""
+        db = _FakeDB(_ids(3), values={"row-001": "unembeddable"})
+
+        updated = _adapter(db, failing={"unembeddable"}).backfill_embeddings()
+
+        assert updated == 2
+        assert db.missing == {"row-001"}
+
+
+class TestItDoesNotHoldATransactionAcrossTheEmbedder:
+    """Why this checks out non-transactionally, and why that is not an oversight.
+
+    Ordinary checkouts wrap the block in a transaction so the tenant settings
+    can be scoped to it, which is what makes the adapter safe behind a
+    transaction-mode pooler. This loop cannot take that: it calls the embedder
+    once per row inside the block, so the transaction would stay open across a
+    whole batch of network round trips — holding a transaction id, blocking
+    vacuum, and stretching to however long the embedding service takes.
+
+    Per-statement commit is also load-bearing for the behaviour the tests above
+    describe: one row's failure leaves the rest of the batch committed.
+    """
+
+    def test_every_batch_checks_out_without_a_transaction(self):
+        db = _FakeDB(_ids(25))
+
+        _adapter(db).backfill_embeddings(batch_size=10)
+
+        assert db.scopes, "expected at least one checkout"
+        assert all(scope is False for scope in db.scopes), (
+            f"a transactional checkout would hold a transaction open across "
+            f"the embedder calls: {db.scopes}"
+        )
+
+    def test_the_batches_are_separate_checkouts(self):
+        """Each batch its own checkout, so the connection is handed back — and
+        the tenant settings blanked — between them rather than held for the
+        whole run."""
+        db = _FakeDB(_ids(25))
+
+        _adapter(db).backfill_embeddings(batch_size=10)
+
+        assert len(db.scopes) == len(db.selects) > 1

--- a/tests/unit/test_backfill_embeddings.py
+++ b/tests/unit/test_backfill_embeddings.py
@@ -18,20 +18,61 @@ row succeeded, which is what backfill_is_artifact already did.
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 from amfs_postgres.adapter import PostgresAdapter
+from amfs_postgres.tenant_context import (
+    clear_tls_tenant_account_id,
+    set_tls_tenant_account_id,
+)
+from amfs_postgres.tenant_gucs import CLEARED_TENANT_GUC_VALUES, blank_tenant_gucs
 
 _ZERO_UUID = "00000000-0000-0000-0000-000000000000"
+_BLANK = CLEARED_TENANT_GUC_VALUES
+_ACCOUNT = "acct-42"
+
+
+@dataclass(frozen=True)
+class _SettingWrite:
+    """One write of the four tenant settings, and the scope it was written in."""
+
+    values: tuple[str, ...]
+    local: bool
+    depth: int
+
+
+@pytest.fixture(autouse=True)
+def _tenant() -> Any:
+    """A tenant on the request, which is what an ops backfill runs under.
+
+    Without one there is nothing for the settings to carry and RLS correctly
+    hides everything, so every test here would pass for the wrong reason. The
+    interesting question is whether the tenant that *is* available reaches the
+    statements.
+    """
+    set_tls_tenant_account_id(_ACCOUNT)
+    yield
+    clear_tls_tenant_account_id()
 
 
 class _FakeCursor:
-    """Understands just the two statements backfill_embeddings issues."""
+    """The statements backfill_embeddings issues, under something like RLS.
 
-    def __init__(self, db: _FakeDB) -> None:
+    Enforcing the tenant here rather than ignoring it is what makes this file
+    able to see the bug it was previously blind to: ``amfs_memory_entries`` has
+    FORCE ROW LEVEL SECURITY, so a statement running with the four settings
+    blank matches no rows -- reads come back empty and updates hit nothing,
+    with no error either way.
+    """
+
+    def __init__(self, db: _FakeDB, conn: _FakeConnection) -> None:
         self._db = db
+        self._conn = conn
+        self._rows: list[dict] = []
 
     def __enter__(self) -> _FakeCursor:
         return self
@@ -40,9 +81,14 @@ class _FakeCursor:
         return None
 
     def execute(self, sql: str, params: tuple = ()) -> None:
-        if sql.startswith("SELECT id, value"):
+        if sql.startswith("SELECT set_config"):
+            self._conn.apply_settings(sql, params)
+        elif sql.startswith("SELECT id, value"):
             _namespace, last_id, limit = params
             self._db.selects.append((last_id, limit))
+            if not self._conn.can_see_tenant_rows:
+                self._rows = []
+                return
             pending = sorted(
                 row_id
                 for row_id, vector in self._db.embeddings.items()
@@ -53,6 +99,8 @@ class _FakeCursor:
                 for row_id in pending[:limit]
             ]
         elif sql.startswith("UPDATE amfs_memory_entries SET embedding"):
+            if not self._conn.can_see_tenant_rows:
+                return
             vector, row_id = params
             self._db.embeddings[row_id] = vector
         else:  # pragma: no cover - would mean the query changed shape
@@ -62,6 +110,57 @@ class _FakeCursor:
         return self._rows
 
 
+class _FakeTransaction:
+    """``conn.transaction()``: a scope the tenant settings do not outlive."""
+
+    def __init__(self, conn: _FakeConnection) -> None:
+        self._conn = conn
+
+    def __enter__(self) -> _FakeTransaction:
+        self._conn.depth += 1
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self._conn.depth -= 1
+        if self._conn.depth == 0:
+            # What Postgres does at commit with set_config(..., true): the
+            # values are discarded. A backfill that set its tenant once and
+            # expected it to persist would read nothing after the first commit.
+            self._conn.settings = _BLANK
+        return None
+
+
+class _FakeConnection:
+    def __init__(self, db: _FakeDB) -> None:
+        self._db = db
+        self.settings: tuple[str, ...] = _BLANK
+        self.depth = 0
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor(self._db, self)
+
+    def transaction(self) -> _FakeTransaction:
+        return _FakeTransaction(self)
+
+    @property
+    def info(self) -> Any:
+        return SimpleNamespace(
+            transaction_status=SimpleNamespace(
+                name="INTRANS" if self.depth else "IDLE"
+            )
+        )
+
+    def apply_settings(self, sql: str, params: tuple) -> None:
+        local = ", true)" in sql
+        self._db.setting_writes.append(_SettingWrite(tuple(params), local, self.depth))
+        self.settings = tuple(params)
+
+    @property
+    def can_see_tenant_rows(self) -> bool:
+        """RLS in one line: an account id is what the policies match on."""
+        return bool(self.settings and self.settings[0])
+
+
 class _FakeDB:
     def __init__(
         self, row_ids: list[str], *, values: dict[str, Any] | None = None
@@ -69,6 +168,7 @@ class _FakeDB:
         self.embeddings: dict[str, str | None] = {r: None for r in row_ids}
         self.selects: list[tuple[str, int]] = []
         self.scopes: list[bool] = []
+        self.setting_writes: list[_SettingWrite] = []
         #: Overrides for what a row's ``value`` column holds. The default is a
         #: JSON object, which is the common case; a bare string is the case that
         #: used to be misread as an unembeddable row.
@@ -84,10 +184,15 @@ class _FakeDB:
         # embedder between statements and would otherwise hold a transaction
         # open across a batch of network round trips. Recorded rather than
         # ignored so that the scope stays part of what these tests describe.
+        # The real wrapper blanks the four settings on such a checkout, so this
+        # one does too -- the backfill has to set its own tenant afterwards.
         self.scopes.append(transactional)
-        cursor = _FakeCursor(self)
+        conn = _FakeConnection(self)
+        if not transactional:
+            with conn.cursor() as cur:
+                blank_tenant_gucs(cur)
         pool_ctx = MagicMock()
-        pool_ctx.__enter__ = MagicMock(return_value=_conn_with(cursor))
+        pool_ctx.__enter__ = MagicMock(return_value=conn)
         pool_ctx.__exit__ = MagicMock(return_value=None)
         return pool_ctx
 
@@ -99,11 +204,10 @@ class _FakeDB:
     def missing(self) -> set[str]:
         return {r for r, v in self.embeddings.items() if v is None}
 
-
-def _conn_with(cursor: _FakeCursor) -> MagicMock:
-    conn = MagicMock()
-    conn.cursor = MagicMock(return_value=cursor)
-    return conn
+    @property
+    def tenanted_writes(self) -> list[_SettingWrite]:
+        """The writes that put a real tenant on the connection."""
+        return [w for w in self.setting_writes if w.values and w.values[0]]
 
 
 def _adapter(db: _FakeDB, *, failing: set[str] | None = None) -> PostgresAdapter:
@@ -344,3 +448,74 @@ class TestItDoesNotHoldATransactionAcrossTheEmbedder:
         _adapter(db).backfill_embeddings(batch_size=10)
 
         assert len(db.scopes) == len(db.selects) > 1
+
+    def test_no_statement_runs_inside_a_transaction_that_spans_the_embedder(self):
+        """The transactions exist, but each holds one statement.
+
+        A tenant has to be set inside a transaction to be scoped to it, so the
+        loop does open transactions — the property worth keeping is that none of
+        them is open while the embedder is being called. Every checkout ends
+        with its transaction closed, and each one wraps a single statement.
+        """
+        db = _FakeDB(_ids(6))
+
+        _adapter(db).backfill_embeddings(batch_size=3)
+
+        assert db.setting_writes, "expected the tenant to be set at all"
+        for write in db.tenanted_writes:
+            assert write.local, (
+                "a real tenant written session-scoped outlives the statement "
+                "and leaks to the next borrower of this pooled connection"
+            )
+            assert write.depth == 1, (
+                f"expected one transaction per statement, not nesting: {write}"
+            )
+
+
+class TestTheBackfillCanActuallySeeItsRows:
+    """A blank tenant is not a safe default here, it is a silent no-op.
+
+    The maintenance checkout blanks the four settings, which is right for DDL —
+    it touches no tenant rows, so blank fails closed. This loop is the opposite:
+    ``amfs_memory_entries`` is precisely the table the policies guard, and under
+    FORCE ROW LEVEL SECURITY blank settings match none of it. Run that way the
+    backfill selected nothing, embedded nothing, updated nothing, and returned 0
+    as though the store were already fully embedded.
+    """
+
+    def test_rows_are_visible_and_get_embedded(self):
+        db = _FakeDB(_ids(9))
+
+        updated = _adapter(db).backfill_embeddings(batch_size=4)
+
+        assert updated == 9, "the backfill saw no rows at all"
+        assert db.missing == set()
+
+    def test_the_select_runs_with_a_real_tenant_not_a_blank_one(self):
+        db = _FakeDB(_ids(3))
+
+        _adapter(db).backfill_embeddings()
+
+        assert db.tenanted_writes, (
+            "every statement ran on blanked settings, so RLS matched no rows"
+        )
+        assert all(w.values[0] == _ACCOUNT for w in db.tenanted_writes)
+
+    def test_the_update_runs_with_a_real_tenant_too(self):
+        """Reading with a tenant and updating without one is the same bug half
+        fixed: the UPDATE matches no row and the embedding is quietly dropped."""
+        db = _FakeDB(_ids(3))
+
+        _adapter(db).backfill_embeddings()
+
+        assert db.embedded == set(_ids(3))
+
+    def test_without_a_tenant_it_finds_nothing_and_says_so_by_returning_zero(self):
+        """The other side of the same coin, and correct: no tenant means no
+        rows. Worth pinning so the fix above cannot be mistaken for the adapter
+        having stopped enforcing RLS."""
+        clear_tls_tenant_account_id()
+        db = _FakeDB(_ids(5))
+
+        assert _adapter(db).backfill_embeddings() == 0
+        assert db.missing == set(_ids(5))

--- a/tests/unit/test_tenant_rls_connection.py
+++ b/tests/unit/test_tenant_rls_connection.py
@@ -10,26 +10,74 @@ let a user reach rooms in accounts that are not theirs, so a connection
 handed on with the previous borrower's user still set grants the next
 request that person's room access. Hence: set on every checkout, never
 conditionally.
+
+Scope is the other half, and it is what most of this file is about. The four
+used to be set session-scoped, which is sound with psycopg_pool alone and a
+cross-tenant read behind a transaction-mode pooler, because there one client
+connection maps to a different backend per transaction. So the checkout now
+opens an explicit transaction and sets them inside it, and Postgres discards
+them at commit. The tests below pin the parts of that which are easy to
+regress by accident: that a transaction is opened *before* the settings are
+written, that the statement is the local form, and that the two paths which
+cannot be transactional write no tenant at all.
 """
 
 from __future__ import annotations
 
+import contextlib
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 
+class _Transaction:
+    """A stand-in for ``conn.transaction()`` that records its own lifecycle.
+
+    Written out rather than mocked because the ordering assertions need to know
+    when it was entered relative to the ``set_config`` call, and a MagicMock
+    would answer that question with another MagicMock.
+    """
+
+    def __init__(self, log: list) -> None:
+        self._log = log
+        self.entered = False
+        self.exited_with: tuple | None = None
+
+    def __enter__(self) -> _Transaction:
+        self.entered = True
+        self._log.append(("BEGIN", None))
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        self.exited_with = (exc_type, exc, tb)
+        self._log.append(("COMMIT" if exc_type is None else "ROLLBACK", None))
+        return None
+
+
 @pytest.fixture
 def _make_conn():
+    """An inner checkout context whose connection looks like it is in a txn.
+
+    ``transaction_status.name`` has to be a real string: the wrapper asserts a
+    transaction is genuinely open before it writes anything transaction-local,
+    since a local ``set_config`` outside a transaction is discarded and turns
+    every subsequent read into a silent empty result.
+    """
     executed: list = []
 
     cur = MagicMock()
-    cur.execute = MagicMock(side_effect=lambda sql, params=None: executed.append((sql, params)))
+    cur.execute = MagicMock(
+        side_effect=lambda sql, params=None: executed.append((sql, params))
+    )
     cur.__enter__ = MagicMock(return_value=cur)
     cur.__exit__ = MagicMock(return_value=None)
 
     conn = MagicMock()
     conn.cursor = MagicMock(return_value=cur)
+    conn.info.transaction_status.name = "INTRANS"
+    txn = _Transaction(executed)
+    conn.transaction = MagicMock(return_value=txn)
 
     inner_ctx = MagicMock()
     inner_ctx.__enter__ = MagicMock(return_value=conn)
@@ -38,16 +86,47 @@ def _make_conn():
     return inner_ctx, executed
 
 
-def _checkout(inner_ctx, *, account="acct-1", team=None, admin=False, user=None):
+def _sets(executed: list) -> list:
+    """Just the set_config statements, dropping the BEGIN/COMMIT markers."""
+    return [(sql, params) for sql, params in executed if "set_config" in str(sql)]
+
+
+def _tenant(*, account="acct-1", team=None, admin=False, user=None):
+    return (
+        patch(
+            "amfs_postgres.tenant_context.get_request_tenant_account_id",
+            return_value=account,
+        ),
+        patch(
+            "amfs_postgres.tenant_context.get_request_tenant_team_id",
+            return_value=team,
+        ),
+        patch(
+            "amfs_postgres.tenant_context.get_request_is_account_admin",
+            return_value=admin,
+        ),
+        patch(
+            "amfs_postgres.tenant_context.get_request_user_id", return_value=user
+        ),
+    )
+
+
+def _checkout(
+    inner_ctx,
+    *,
+    account="acct-1",
+    team=None,
+    admin=False,
+    user=None,
+    transactional=True,
+):
     from amfs_postgres.adapter import _TenantRLSConnection
 
-    with (
-        patch("amfs_postgres.tenant_context.get_request_tenant_account_id", return_value=account),
-        patch("amfs_postgres.tenant_context.get_request_tenant_team_id", return_value=team),
-        patch("amfs_postgres.tenant_context.get_request_is_account_admin", return_value=admin),
-        patch("amfs_postgres.tenant_context.get_request_user_id", return_value=user),
-    ):
-        return _TenantRLSConnection(inner_ctx).__enter__()
+    with contextlib.ExitStack() as stack:
+        for p in _tenant(account=account, team=team, admin=admin, user=user):
+            stack.enter_context(p)
+        wrapper = _TenantRLSConnection(inner_ctx, transactional=transactional)
+        return wrapper, wrapper.__enter__()
 
 
 class TestTheActingUserReachesTheDatabase:
@@ -58,7 +137,7 @@ class TestTheActingUserReachesTheDatabase:
 
         _checkout(inner_ctx, account="acct-1", user="user-42")
 
-        sql, params = executed[0]
+        sql, params = _sets(executed)[0]
         assert "set_config('amfs.current_user_id'" in sql
         assert "user-42" in params
 
@@ -68,8 +147,8 @@ class TestTheActingUserReachesTheDatabase:
 
         _checkout(inner_ctx, account="a", team="t", admin=True, user="u")
 
-        assert len(executed) == 1
-        sql, params = executed[0]
+        assert len(_sets(executed)) == 1
+        sql, params = _sets(executed)[0]
         for guc in (
             "amfs.current_account_id",
             "amfs.current_team_id",
@@ -90,7 +169,7 @@ class TestAPooledConnectionCarriesNothingOver:
 
         _checkout(inner_ctx, account="acct-2", user=None)
 
-        sql, params = executed[0]
+        sql, params = _sets(executed)[0]
         assert "set_config('amfs.current_user_id'" in sql
         assert params[3] == "", "must clear, not leave the previous value"
 
@@ -99,7 +178,176 @@ class TestAPooledConnectionCarriesNothingOver:
 
         _checkout(inner_ctx, account=None, team=None, admin=False, user=None)
 
-        _sql, params = executed[0]
+        _sql, params = _sets(executed)[0]
         # NULLIF in the policies turns each empty string into NULL, which
         # matches no rows.
         assert params == ("", "", "false", "")
+
+
+class TestTheTenantIsScopedToATransaction:
+    """The pooler-safe property, and the three ways it is easy to lose."""
+
+    def test_the_statement_is_the_transaction_local_form(self, _make_conn):
+        from amfs_postgres import tenant_gucs
+
+        inner_ctx, executed = _make_conn
+
+        _checkout(inner_ctx, account="acct-1", user="u")
+
+        sql, _params = _sets(executed)[0]
+        assert sql == tenant_gucs.SET_TENANT_GUCS_LOCAL
+        assert sql != tenant_gucs.SET_TENANT_GUCS_SESSION
+
+    def test_a_transaction_is_opened_before_anything_is_set(self, _make_conn):
+        """Order is the whole thing. set_config(..., true) applied outside a
+        transaction is discarded before the next statement, and because the
+        pools run autocommit that is exactly what would happen if the BEGIN
+        came second — silently, with every read returning nothing."""
+        inner_ctx, executed = _make_conn
+
+        _checkout(inner_ctx)
+
+        kinds = [sql if sql in ("BEGIN", "COMMIT") else "SET" for sql, _ in executed]
+        assert kinds[0] == "BEGIN", f"expected BEGIN first, got {kinds}"
+        assert kinds.index("BEGIN") < kinds.index("SET")
+
+    def test_the_transaction_commits_and_the_connection_goes_back(self, _make_conn):
+        inner_ctx, executed = _make_conn
+
+        wrapper, _conn = _checkout(inner_ctx)
+        wrapper.__exit__(None, None, None)
+
+        assert [sql for sql, _ in executed if sql in ("BEGIN", "COMMIT")] == [
+            "BEGIN",
+            "COMMIT",
+        ]
+        assert inner_ctx.__exit__.called, "the checkout must be returned to the pool"
+
+    def test_an_error_rolls_the_transaction_back(self, _make_conn):
+        """Postgres would discard the settings either way. What matters is that
+        the caller's failed work does not commit on the way out."""
+        inner_ctx, executed = _make_conn
+
+        wrapper, _conn = _checkout(inner_ctx)
+        wrapper.__exit__(ValueError, ValueError("boom"), None)
+
+        assert ("ROLLBACK", None) in executed
+        assert inner_ctx.__exit__.called
+
+    def test_it_refuses_to_set_anything_it_cannot_scope(self, _make_conn):
+        """If the transaction did not actually open, the local settings would be
+        thrown away and every read would quietly return zero rows. Raising is
+        the only outcome that is not mistaken for an empty account."""
+        inner_ctx, executed = _make_conn
+        inner_ctx.__enter__.return_value.info.transaction_status.name = "IDLE"
+
+        with pytest.raises(RuntimeError, match="no open transaction"):
+            _checkout(inner_ctx)
+
+        assert _sets(executed) == [], "must not write a tenant it cannot scope"
+
+    def test_a_failure_while_setting_up_still_returns_the_connection(self, _make_conn):
+        """A leaked checkout on this path would drain the pool one failed
+        request at a time, which is a worse outage than the error itself."""
+        inner_ctx, _executed = _make_conn
+        inner_ctx.__enter__.return_value.info.transaction_status.name = "IDLE"
+
+        with pytest.raises(RuntimeError):
+            _checkout(inner_ctx)
+
+        assert inner_ctx.__exit__.called, "checkout leaked on the failure path"
+
+
+class TestTheMaintenancePath:
+    """DDL and the backfills, which cannot run inside a caller's transaction.
+
+    DDL because one transaction around schema.sql would hold every ACCESS
+    EXCLUSIVE lock it takes until the last statement finished; the backfills
+    because they call an embedder between statements and issue more SQL from
+    inside an except handler. Both get the four blanked instead of set.
+    """
+
+    def test_no_transaction_is_opened(self, _make_conn):
+        inner_ctx, executed = _make_conn
+
+        _checkout(inner_ctx, transactional=False)
+
+        assert [sql for sql, _ in executed if sql in ("BEGIN", "COMMIT")] == []
+
+    def test_all_four_are_blanked_even_with_a_tenant_in_context(self, _make_conn):
+        """The point of blanking rather than skipping: the connection cannot
+        inherit the previous borrower's tenant, and cannot carry one of its own
+        into a path that has no business reading tenant rows. Under FORCE ROW
+        LEVEL SECURITY empty reads nothing, so this fails closed."""
+        inner_ctx, executed = _make_conn
+
+        _checkout(
+            inner_ctx,
+            account="acct-7",
+            team="team-1",
+            admin=True,
+            user="user-9",
+            transactional=False,
+        )
+
+        sql, params = _sets(executed)[0]
+        assert params == ("", "", "false", "")
+        assert "acct-7" not in params and "user-9" not in params
+        assert len(params) == 4
+
+    def test_the_blanking_statement_covers_every_named_guc(self, _make_conn):
+        from amfs_postgres import tenant_gucs
+
+        inner_ctx, executed = _make_conn
+
+        _checkout(inner_ctx, transactional=False)
+
+        sql, _params = _sets(executed)[0]
+        for name in tenant_gucs.TENANT_GUC_NAMES:
+            assert f"set_config('{name}'" in sql
+
+
+class TestNoTenantValueIsEverSessionScoped:
+    """The invariant the whole change exists to establish, asserted directly.
+
+    Both scopes still exist as SQL, and the session-scoped one is still used —
+    but only ever with empty values, to clear. If a tenant value is ever paired
+    with the session-scoped statement again, the leak is back, so this checks
+    the pairing rather than trusting the call sites to stay right.
+    """
+
+    @pytest.mark.parametrize("transactional", [True, False])
+    def test_session_scoped_writes_carry_no_tenant(self, _make_conn, transactional):
+        from amfs_postgres import tenant_gucs
+
+        inner_ctx, executed = _make_conn
+
+        _checkout(
+            inner_ctx,
+            account="acct-1",
+            team="team-1",
+            admin=True,
+            user="user-1",
+            transactional=transactional,
+        )
+
+        for sql, params in _sets(executed):
+            if sql == tenant_gucs.SET_TENANT_GUCS_SESSION:
+                assert params == tenant_gucs.CLEARED_TENANT_GUC_VALUES, (
+                    "a session-scoped write with a real tenant in it is the "
+                    "cross-tenant leak this change removed"
+                )
+
+    def test_the_scope_argument_has_no_default(self):
+        """It used to default to the unsafe scope, which is the bug in one
+        keyword: session scope was what a caller got for not thinking about
+        it. Every caller now has to say which it means."""
+        import inspect
+
+        from amfs_postgres import tenant_gucs
+
+        for fn in (tenant_gucs.set_tenant_gucs, tenant_gucs.aset_tenant_gucs):
+            param = inspect.signature(fn).parameters["local"]
+            assert param.default is inspect.Parameter.empty, (
+                f"{fn.__name__}: 'local' must stay required"
+            )


### PR DESCRIPTION
Wrapping every checkout in a transaction has fallout, and all of it is in the one commit: seven `conn.commit()` removals, and five maintenance-path sites (DDL plus two backfills) that opt out explicitly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches multi-tenant RLS isolation on every Postgres checkout (sync HTTP path included); incorrect transaction/GUC scoping could leak tenants or silently return no rows.
> 
> **Overview**
> Fixes a **cross-tenant read** when Postgres sits behind **PgBouncer `pool_mode=transaction`**: tenant RLS settings are no longer applied session-scoped at checkout. Sync and async pool checkouts now **open an explicit transaction**, set all four `amfs.*` GUCs **transaction-local** (`local=True`), and rely on commit to clear backend state; **`require_open_transaction`** fails fast if that ordering breaks (silent empty reads otherwise).
> 
> **Maintenance** (schema DDL, embedding/artifact backfills) opts out via **`transactional=False`** checkouts that **`blank_tenant_gucs`** instead of setting a tenant; backfills use **`_tenant_statement`** for short per-row transactions so embedder calls stay outside a long-lived txn. Ordinary request paths drop redundant **`conn.commit()`** calls because the checkout transaction commits on exit.
> 
> Adds **PgBouncer integration tests** (harness proves the old pattern leaks), docs on running behind a transaction pooler, and backfill fix: **non-JSON string values** are embedded instead of being stuck in a retry loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6c55c9b45f3a5bc7895004d1a9ae4024a5f5f9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->