### PR TITLE
Bound an embedding batch by what attention costs, not by row count

### DIFF
--- a/packages/adapters/http/pyproject.toml
+++ b/packages/adapters/http/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 dependencies = [
     # 0.3.14 adds the capture fields this adapter now sends on the outcome record,
     # including the tool_calls that carry the action half of a training example.
-    "amfs-core>=0.3.17",
+    "amfs-core>=0.3.18",
     "httpx>=0.27,<1",
 ]
 

--- a/packages/adapters/postgres/pyproject.toml
+++ b/packages/adapters/postgres/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 dependencies = [
     # 0.3.14 adds the capture fields this adapter now persists and selects back,
     # tool_calls among them.
-    "amfs-core>=0.3.17",
+    "amfs-core>=0.3.18",
     "psycopg[binary]>=3.1,<4",
     "psycopg-pool>=3.1",
 ]

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amfs-core"
-version = "0.3.17"
+version = "0.3.18"
 description = "AMFS core models, engine, and adapter ABC"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/core/src/amfs_core/default_embedder.py
+++ b/packages/core/src/amfs_core/default_embedder.py
@@ -19,6 +19,46 @@ logger = logging.getLogger(__name__)
 
 _HASH_DIM = 384
 
+#: How much attention a single model call may allocate, in units of
+#: ``rows x tokens^2``.
+#:
+#: A transformer's peak memory on a batch is dominated by the attention scores,
+#: which are shaped ``[rows, heads, tokens, tokens]`` -- quadratic in the length
+#: of the longest row in the batch, because every row is padded to it. For a
+#: 12-head fp32 model this budget is about ``12e6 * 12 * 4`` bytes, or 570MB of
+#: scores, leaving room for the weights and the runtime's arena inside a 4GB
+#: container.
+#:
+#: Why a budget rather than a row count: a fixed batch size has to be chosen for
+#: the worst case, and then short rows -- overwhelmingly the common case -- get
+#: embedded in batches far smaller than they could be, losing most of the speed
+#: this method exists for. Holding ``rows x tokens^2`` roughly constant instead
+#: gives hundreds of rows per call on short text and tens on long text, at
+#: roughly constant memory.
+#:
+#: This was not hypothetical. Importing `stanfordnlp/imdb` -- 25k movie reviews,
+#: long enough to pad near the model's limit -- at fastembed's default of 256
+#: rows per batch allocated over 3GB of scores and was killed by the kernel ten
+#: seconds in, on every retry, having written nothing.
+_ATTENTION_BUDGET = 12_000_000
+
+#: Never send more rows than this in one call, however short they are. Past a
+#: few hundred the attention tensors stop being what dominates and the
+#: tokenizer's own output starts to, which this budget does not model. Also
+#: fastembed's own default, so it is a well-trodden ceiling.
+_MAX_BATCH_ROWS = 256
+
+#: Tokens the longest row of a batch is assumed to occupy, at most. Sequences
+#: are truncated to the model's limit, so no row can cost more than this however
+#: long its text -- without the clamp, one enormous string would drive the
+#: estimate down to a single row per call and crawl.
+_MAX_TOKENS = 512
+
+#: Bytes of text per token, deliberately low so the estimate runs high.
+#: Over-estimating costs a little throughput; under-estimating costs the
+#: container.
+_BYTES_PER_TOKEN = 3
+
 
 class HashEmbedder(EmbedderABC):
     """Deterministic hash-based embedder as a zero-dependency fallback.
@@ -75,6 +115,40 @@ def create_default_embedder() -> EmbedderABC:
         return HashEmbedder()
 
 
+def _tokens(text: str) -> int:
+    """Roughly how many tokens `text` will occupy, never above the model's cap."""
+    return min(_MAX_TOKENS, max(1, len(text) // _BYTES_PER_TOKEN + 2))
+
+
+def _within_budget(texts: list[str]) -> list[list[str]]:
+    """`texts` split into consecutive runs each cheap enough for one model call.
+
+    Greedy and order-preserving, which both matter. Order, because `embed_batch`
+    promises one vector per text in input order and the caller matches them to
+    rows positionally -- sorting by length would embed the right texts and
+    attach them to the wrong content, the one failure worse than no embedding.
+    Greedy, because a run only has to be small enough, not optimal: the cost is
+    driven by the longest member, so packing short rows together and letting a
+    long one start a new run is most of what any smarter split would achieve.
+    """
+    runs: list[list[str]] = []
+    run: list[str] = []
+    widest = 0
+    for text in texts:
+        length = _tokens(text)
+        widest_with = max(widest, length)
+        too_big = (len(run) + 1) * widest_with * widest_with > _ATTENTION_BUDGET
+        if run and (too_big or len(run) >= _MAX_BATCH_ROWS):
+            runs.append(run)
+            run, widest = [text], length
+        else:
+            run.append(text)
+            widest = widest_with
+    if run:
+        runs.append(run)
+    return runs
+
+
 def _create_fastembed_embedder(model_name: str = DEFAULT_EMBED_MODEL) -> EmbedderABC:
     from fastembed import TextEmbedding  # type: ignore[import-untyped]
 
@@ -87,15 +161,22 @@ def _create_fastembed_embedder(model_name: str = DEFAULT_EMBED_MODEL) -> Embedde
             return [float(x) for x in next(iter(self._model.embed([text])))]
 
         def embed_batch(self, texts: list[str]) -> list[list[float]]:
-            # One ONNX session run over the whole list instead of one per
-            # text, which is where the order-of-magnitude on bulk imports
-            # comes from. `embed` returns a generator, so the list() is what
-            # actually runs the model.
+            # Batched, because one session run over many texts instead of one
+            # per text is where the order-of-magnitude on bulk imports comes
+            # from -- but bounded, because the batch fastembed would choose by
+            # default (256 rows, whatever their length) allocates gigabytes of
+            # attention on long text and gets the process killed. See
+            # `_ATTENTION_BUDGET`. `embed` is a generator, so iterating it is
+            # what actually runs the model.
             if not texts:
                 return []
-            return [
-                [float(x) for x in vector] for vector in self._model.embed(list(texts))
-            ]
+            vectors: list[list[float]] = []
+            for run in _within_budget(list(texts)):
+                vectors.extend(
+                    [float(x) for x in vector]
+                    for vector in self._model.embed(run, batch_size=len(run))
+                )
+            return vectors
 
     logger.info("Default embedder: fastembed %s", model_name)
     return FastEmbedEmbedder()
@@ -115,11 +196,21 @@ def _create_onnx_embedder() -> EmbedderABC:
             return self._model.encode(text, normalize_embeddings=True).tolist()
 
         def embed_batch(self, texts: list[str]) -> list[list[float]]:
+            # Bounded for the same reason as the fastembed path above:
+            # `encode` batches internally at 32 by default, but it accepts the
+            # whole list first and the attention cost still scales with the
+            # longest row, so a batch of long text is what gets the process
+            # killed. See `_ATTENTION_BUDGET`.
             if not texts:
                 return []
-            return self._model.encode(
-                list(texts), normalize_embeddings=True
-            ).tolist()
+            vectors: list[list[float]] = []
+            for run in _within_budget(list(texts)):
+                vectors.extend(
+                    self._model.encode(
+                        run, batch_size=len(run), normalize_embeddings=True
+                    ).tolist()
+                )
+            return vectors
 
         def embed_value(self, value: Any) -> list[float]:
             import json

--- a/packages/http-server/pyproject.toml
+++ b/packages/http-server/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     # The trace endpoints call amfs_core.capture and read/write task_input, and
     # 0.3.14 / 0.5.7 add the action half: scan_captured_arguments and ToolCall.
     "amfs>=0.5.10",
-    "amfs-core>=0.3.17",
+    "amfs-core>=0.3.18",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.32",
     "sse-starlette>=2.0",

--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     # EmbedderABC.embed_batch, which this server never calls. The floor rises
     # because a floor below the version in this tree is what
     # test_dependency_floors forbids, not because anything here would break.
-    "amfs-core>=0.3.17",
+    "amfs-core>=0.3.18",
     # 0.1.10 for the same reason, one layer down: this adapter builds the
     # /outcomes body field by field, and anything earlier does not copy
     # tool_calls into it. The floor was 0.1.2, which a cached 0.1.9 satisfies —

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     # 0.3.14 adds ToolCall, ReadTracker.record_action and
     # capture.scan_captured_arguments. record_action and commit_outcome below use
     # all three unconditionally, so an older core raises rather than degrading.
-    "amfs-core>=0.3.17",
+    "amfs-core>=0.3.18",
     "amfs-adapter-filesystem",
     "pyyaml>=6.0,<7",
 ]

--- a/tests/unit/test_embedder_batch.py
+++ b/tests/unit/test_embedder_batch.py
@@ -80,7 +80,12 @@ def _stub_sentence_transformers(monkeypatch: pytest.MonkeyPatch) -> type:
             self.batches: list[list[str]] = []
             FakeSentenceTransformer.instances.append(self)
 
-        def encode(self, text: object, normalize_embeddings: bool = False) -> _Array:
+        def encode(
+            self,
+            text: object,
+            normalize_embeddings: bool = False,
+            batch_size: int | None = None,
+        ) -> _Array:
             if isinstance(text, str):
                 self.batches.append([text])
                 return _Array([float(len(text)), 0.25])
@@ -216,3 +221,125 @@ class TestTheOverridesActuallyBatch:
         assert embedder.embed_batch([]) == []
 
         assert fake.instances[-1].batches == []
+
+
+class TestABatchIsBoundedByWhatAttentionCosts:
+    """Why a batch is split at all, and the invariant that makes it safe.
+
+    A transformer pads every row of a batch to the longest one and allocates
+    attention scores shaped `[rows, heads, tokens, tokens]`. So the cost is
+    quadratic in the longest row, and the batch size that is fine for short
+    text is fatal for long text. Handing fastembed its default of 256 rows of
+    movie review allocated over 3GB and the kernel killed the importer ten
+    seconds in, on every retry, having written nothing.
+
+    Splitting is only safe if it is invisible: same vectors, same order, one per
+    input. `assert_honours_the_contract` covers that for a small batch; these
+    cover it where a split actually happens.
+    """
+
+    def test_a_long_batch_is_split_rather_than_sent_whole(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        fake = _stub_fastembed(monkeypatch)
+        embedder = default_embedder._create_fastembed_embedder("stub/model")
+
+        # Long enough to reach the token clamp, so the budget allows tens of
+        # rows per call and 400 of them cannot be one batch.
+        long_text = "x" * (default_embedder._MAX_TOKENS * 10)
+        embedder.embed_batch([long_text] * 400)
+
+        batches = fake.instances[-1].batches
+        assert len(batches) > 1, "400 long rows must not be one model call"
+        assert sum(len(b) for b in batches) == 400, "every row embedded once"
+
+    def test_no_batch_exceeds_the_budget(self, monkeypatch: pytest.MonkeyPatch):
+        """The invariant, asserted over a deliberately mixed workload.
+
+        Mixed rather than uniform because the split is greedy over the running
+        maximum: one long row arriving late must close the run it would have
+        blown, not be absorbed into it.
+        """
+        fake = _stub_fastembed(monkeypatch)
+        embedder = default_embedder._create_fastembed_embedder("stub/model")
+
+        texts = [
+            "short",
+            "x" * 6000,
+            *["tiny"] * 300,
+            "y" * 40_000,
+            "medium " * 50,
+        ]
+        embedder.embed_batch(texts)
+
+        for batch in fake.instances[-1].batches:
+            widest = max(default_embedder._tokens(t) for t in batch)
+            assert len(batch) * widest * widest <= default_embedder._ATTENTION_BUDGET
+            assert len(batch) <= default_embedder._MAX_BATCH_ROWS
+
+    def test_short_text_still_batches_in_bulk(self, monkeypatch: pytest.MonkeyPatch):
+        """The budget must not have quietly become a per-row loop.
+
+        This is the regression that would make the fix worse than the bug: a
+        conservative fixed batch size would be safe and would also throw away
+        the order of magnitude `embed_batch` exists for. Short rows must still
+        go hundreds at a time.
+        """
+        fake = _stub_fastembed(monkeypatch)
+        embedder = default_embedder._create_fastembed_embedder("stub/model")
+
+        embedder.embed_batch(["a short row"] * 1000)
+
+        batches = fake.instances[-1].batches
+        assert max(len(b) for b in batches) == default_embedder._MAX_BATCH_ROWS
+        assert len(batches) == 4, "1000 short rows in 256-row calls"
+
+    def test_splitting_preserves_order_and_content(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Positional matching is how callers attach vectors to rows.
+
+        The fake encodes each text's length, so a reordered split shows up as
+        vectors in the wrong order rather than as an error -- which is exactly
+        how it would fail in production: embeddings attached to the wrong
+        content, silently.
+        """
+        _stub_fastembed(monkeypatch)
+        embedder = default_embedder._create_fastembed_embedder("stub/model")
+
+        texts = ["z" * (i * 200) for i in range(1, 60)]
+        vectors = embedder.embed_batch(texts)
+
+        assert len(vectors) == len(texts)
+        assert [v[0] for v in vectors] == [float(len(t)) for t in texts]
+
+    def test_one_enormous_row_is_still_embedded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A single row over the budget has nowhere smaller to go.
+
+        Without the token clamp the estimate for a megabyte of text would drive
+        the batch to zero rows and the split would either loop forever or drop
+        the row. It must come back as one batch of one.
+        """
+        fake = _stub_fastembed(monkeypatch)
+        embedder = default_embedder._create_fastembed_embedder("stub/model")
+
+        vectors = embedder.embed_batch(["q" * 1_000_000])
+
+        assert len(vectors) == 1
+        assert fake.instances[-1].batches == [["q" * 1_000_000]]
+
+    def test_sentence_transformers_is_bounded_too(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The same ceiling on the other backend, which had the same hole."""
+        fake = _stub_sentence_transformers(monkeypatch)
+        embedder = default_embedder._create_onnx_embedder()
+
+        long_text = "x" * (default_embedder._MAX_TOKENS * 10)
+        embedder.embed_batch([long_text] * 400)
+
+        batches = fake.instances[-1].batches
+        assert len(batches) > 1
+        assert sum(len(b) for b in batches) == 400

--- a/uv.lock
+++ b/uv.lock
@@ -330,7 +330,7 @@ provides-extras = ["cli"]
 
 [[package]]
 name = "amfs-core"
-version = "0.3.17"
+version = "0.3.18"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## The bug

`embed_batch` handed fastembed the whole list and let it choose the batch size. Its default is 256 rows **regardless of length**, and a transformer pads every row of a batch to the longest one, then allocates attention scores shaped `[rows, heads, tokens, tokens]` — quadratic in that longest row.

So the method was fine on short text and fatal on long text. Importing `stanfordnlp/imdb` (25k movie reviews, long enough to pad near the model's 512-token limit) put 300 rows in one batch:

```
300 rows x 12 heads x 512 x 512 x 4 bytes = 3.77 GB of attention scores
```

Observed in dev: `Memory limit of 4096 MiB exceeded with 4227 MiB used`, then signal 9 — about ten seconds after the loader logged `embedding ('text',)`, with `rows_written` still 0. That is 3.77 GB of scores plus the weights, the ONNX arena and the interpreter, and it matches the measurement to within a couple of percent.

It happened on every attempt of every job. Two separate jobs, four kills, nothing imported. The only symptom in the product was a progress bar that never moved.

## The fix

Split each call into consecutive runs that keep `rows x tokens^2` under a budget.

A fixed conservative batch size would also have been safe, and would have been the wrong fix: it has to be chosen for the worst case, which throws away most of the order of magnitude `embed_batch` exists for on the short text that is overwhelmingly the common case. A budget adapts instead:

| Row length | Rows per model call | Attention |
|---|---|---|
| short (`"a short row"`) | 256 (the ceiling) | negligible |
| long (4.3 KB, padded to 512 tokens) | 45 | 0.57 GB |
| one 1 MB row | 1 | bounded by the token clamp |

Same ceiling applied to the sentence-transformers path, which had the identical hole.

Three details that carry the correctness:

- **Order-preserving.** The split is greedy over a running maximum, never sorted. Callers match vectors to rows positionally, so a reordering split would attach embeddings to the wrong content — silent, and worse than no embeddings.
- **Running maximum, not current row.** A long row arriving late must close the run it would have blown rather than be absorbed into it.
- **Token clamp.** Sequences are truncated at the model's limit, so no row costs more than 512 tokens. Without the clamp a megabyte of text would drive the estimate to zero rows per call.

## Tests

New `TestABatchIsBoundedByWhatAttentionCosts`, seven cases: long batches split, no batch exceeds the budget under a deliberately mixed workload, **short text still batches in bulk** (the regression that would make the fix worse than the bug), order and content survive a split, one enormous row still gets embedded, and the sentence-transformers path is bounded too.

Four mutations verified to fail:

| Mutation | Caught by |
|---|---|
| budget linear in tokens instead of quadratic | `test_no_batch_exceeds_the_budget` |
| ignore the running maximum, use only the current row | `test_no_batch_exceeds_the_budget` |
| remove the token clamp | `test_no_batch_exceeds_the_budget` |
| drop the row ceiling | budget test + `test_short_text_still_batches_in_bulk` |

`990 passed` in unit tests. The one failure, `test_mcp_server.py::TestAgentIdDetection::test_explicit_env_var`, and the `test_framework_integrations` errors both reproduce identically with these changes stashed — a local environment quirk and missing optional framework deps.

## Release

`amfs-core` 0.3.17 to 0.3.18, with the five sibling floors moved to match so `test_dependency_floors` holds. `uv.lock` updated and verified with `uv lock --check`. Anyone installing `amfs-core[embedder]` from PyPI and embedding long documents hits this bug, so it wants publishing rather than just landing.

Made with [Cursor](https://cursor.com)