### PR TITLE
Report the server as SenseLab, not amfs

### DIFF
--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -218,23 +218,30 @@ def _getting_started() -> dict[str, str]:
 
 _toolset = os.environ.get("AMFS_TOOLSET", "all").lower()
 
+# Reported as serverInfo.name and shown to users by MCP clients, so it carries
+# the product name rather than the package name. Matches what the hosted
+# endpoint at mcp.sense-lab.ai already answers.
+_SERVER_NAME = "SenseLab Memory"
+
 
 def _create_server(toolset: str) -> FastMCP:
     """Build FastMCP with tag filtering, compatible with v2 and v3+."""
     instructions = _build_instructions()
     if toolset != "all":
         try:
-            server = FastMCP(name="amfs", instructions=instructions, include_tags={"core"})
+            server = FastMCP(
+                name=_SERVER_NAME, instructions=instructions, include_tags={"core"}
+            )
         except TypeError:
-            server = FastMCP(name="amfs", instructions=instructions)
+            server = FastMCP(name=_SERVER_NAME, instructions=instructions)
             server.enable(tags={"core"}, only=True)
         logger.info(
-            "AMFS toolset: core (essential tools incl. amfs_retrieve). "
-            "Set AMFS_TOOLSET=all to expose all 36 tools."
+            "SenseLab toolset: core (essential tools incl. amfs_retrieve). "
+            "Set AMFS_TOOLSET=all to expose every tool."
         )
     else:
-        server = FastMCP(name="amfs", instructions=instructions)
-        logger.info("AMFS toolset: all (36 tools)")
+        server = FastMCP(name=_SERVER_NAME, instructions=instructions)
+        logger.info("SenseLab toolset: all")
     return server
 
 

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -219,9 +219,8 @@ def _getting_started() -> dict[str, str]:
 _toolset = os.environ.get("AMFS_TOOLSET", "all").lower()
 
 # Reported as serverInfo.name and shown to users by MCP clients, so it carries
-# the product name rather than the package name. Matches what the hosted
-# endpoint at mcp.sense-lab.ai already answers.
-_SERVER_NAME = "SenseLab Memory"
+# the product name rather than the package name.
+_SERVER_NAME = "SenseLab"
 
 
 def _create_server(toolset: str) -> FastMCP:


### PR DESCRIPTION
## Why

`FastMCP(name="amfs")` becomes `serverInfo.name`, which MCP clients display. Connecting the published Pro server from Cursor reported:

```
serverInfo: {'name': 'amfs', 'version': '4.0.0'}
```

So the server introduced itself to users under the package name rather than the product name. Found while making the Cursor marketplace plugin consistently SenseLab-branded ([raia-live/cursor-plugin#4](https://github.com/raia-live/cursor-plugin/pull/4)); this is the one remaining leak the plugin cannot fix on its own, since Pro inherits the name from this server.

## What changed

- Name the server once in `_SERVER_NAME = "SenseLab"` and use it for all three construction paths, so the branches cannot drift apart again.
- The startup logs said `AMFS` for the same reason. They also claimed a fixed `36 tools`, which is stale — main defines 39 — so the count is dropped rather than left to drift.

`AMFS_TOOLSET` keeps its name; renaming an environment variable would break existing deployments.

## Verification

Running the patched server over stdio and calling `initialize`:

```
serverInfo: {'name': 'SenseLab', 'version': '3.2.0'}
```

No test asserts the server name. Clients key servers on the config entry name, not `serverInfo.name`, so existing configurations are unaffected.

