### PR TITLE
Fix critical security alerts: vitest, shell-quote, insecure session-id randomness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "amfs",
+  "name": "amfs-sec-fixes",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -7,10 +7,6 @@
       "workspaces": [
         "packages/sdk-typescript"
       ]
-    },
-    "node_modules/@amfs/sdk": {
-      "resolved": "packages/sdk-typescript",
-      "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.4",
@@ -455,9 +451,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -811,6 +807,10 @@
         "win32"
       ]
     },
+    "node_modules/@senselab-ai/amfs": {
+      "resolved": "packages/sdk-typescript",
+      "link": true
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -837,15 +837,15 @@
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -854,13 +854,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "3.2.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -881,9 +881,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -894,13 +894,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.7",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -909,13 +909,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.7",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -924,9 +924,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -937,13 +937,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.7",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -1385,9 +1385,9 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.6.tgz",
+      "integrity": "sha512-u8KszXvGfU68hVcZpRHKG28T0krMuv2G5nDhiHaMLen/gIuFEgIJhaJuO69qjnXg5paSrbPMFfx3brNuN8eVSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1507,20 +1507,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -1550,8 +1550,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -1597,12 +1597,12 @@
       }
     },
     "packages/sdk-typescript": {
-      "name": "@amfs/sdk",
-      "version": "0.1.0",
+      "name": "@senselab-ai/amfs",
+      "version": "0.4.0",
       "license": "BSL-1.1",
       "devDependencies": {
         "typescript": "^5.4",
-        "vitest": "^3.1"
+        "vitest": "^3.2.6"
       }
     }
   }

--- a/packages/browser-extension/package-lock.json
+++ b/packages/browser-extension/package-lock.json
@@ -956,9 +956,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -976,9 +973,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -996,9 +990,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1016,9 +1007,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1036,9 +1024,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1056,9 +1041,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3516,9 +3498,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3540,9 +3519,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3564,9 +3540,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3588,9 +3561,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4877,11 +4847,17 @@
       "license": "MIT"
     },
     "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/shellwords": {
       "version": "0.1.1",

--- a/packages/browser-extension/package.json
+++ b/packages/browser-extension/package.json
@@ -27,5 +27,8 @@
     "typescript": "^5.8.0",
     "wxt": "^0.20.27"
   },
+  "overrides": {
+    "shell-quote": "^1.9.0"
+  },
   "license": "BSL-1.1"
 }

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -19,7 +19,7 @@
   "dependencies": {},
   "devDependencies": {
     "typescript": "^5.4",
-    "vitest": "^3.1"
+    "vitest": "^3.2.6"
   },
   "files": ["dist"],
   "license": "BSL-1.1"

--- a/packages/sdk-typescript/src/engine.ts
+++ b/packages/sdk-typescript/src/engine.ts
@@ -6,14 +6,34 @@ import type { AmfsAdapter } from "./adapter.js";
 import type { MemoryEntry, Provenance } from "./models.js";
 import { ReadTracker } from "./tracker.js";
 
+type WebCrypto = {
+  getRandomValues<T extends ArrayBufferView>(array: T): T;
+};
+
+/**
+ * Mirrors the Python engine (`sess-` + 8 hex chars from a CSPRNG). Uses the
+ * Web Crypto API, which is a global in browsers and in Node.js >= 19, so the
+ * SDK stays runtime-agnostic without depending on `node:crypto` types.
+ */
+function newSessionId(): string {
+  const webCrypto = (globalThis as { crypto?: WebCrypto }).crypto;
+  if (!webCrypto?.getRandomValues) {
+    throw new Error(
+      "AMFS: Web Crypto API is unavailable in this runtime; pass an explicit sessionId to CausalTagger"
+    );
+  }
+  const bytes = webCrypto.getRandomValues(new Uint8Array(4));
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `sess-${hex}`;
+}
+
 export class CausalTagger {
   readonly agentId: string;
   readonly sessionId: string;
 
   constructor(agentId: string, sessionId?: string) {
     this.agentId = agentId;
-    this.sessionId =
-      sessionId ?? `sess-${Math.random().toString(36).substring(2, 10)}`;
+    this.sessionId = sessionId ?? newSessionId();
   }
 
   tag(patternRefs: string[] = []): Provenance {


### PR DESCRIPTION
## Summary

Closes the easiest-to-fix items from the repo's open security alerts. Targets `dev` first; promote to `main` afterwards.

| # | Alert | Severity | Fix |
|---|-------|----------|-----|
| 1 | Dependabot #6 — `vitest` < 3.2.6: arbitrary file read/execute when the Vitest UI server is listening | **Critical** | `packages/sdk-typescript` dev dep `^3.1` → `^3.2.6`; root `package-lock.json` now resolves `vitest` 3.2.7 (+ matching `@vitest/*`) |
| 2 | Dependabot #17 — `shell-quote` ≤ 1.8.3: `quote()` does not escape newlines (also closes **High** #20, quadratic DoS in `parse()`) | **Critical** | `packages/browser-extension`: `fx-runner` (via `wxt` → `web-ext-run`) pins `shell-quote` **exactly** at 1.7.3, so a plain update can't move it. Added an npm `overrides` entry forcing `^1.9.0`; lock resolves 1.10.0 |
| 3 | CodeQL #10 — `js/insecure-randomness` in `packages/sdk-typescript/src/engine.ts:16` (`Math.random()` for `sessionId`) | **High** | Generate `sess-` + 8 hex chars from `globalThis.crypto.getRandomValues` — same shape as the Python engine (`uuid4().hex[:8]`). Uses Web Crypto so the SDK stays runtime-agnostic (browsers, Node ≥ 19) without adding `@types/node` |

### Why only two of the four "critical" alerts are dependency bumps

The other two critical alerts (#39, #97) are both `chromadb` 1.1.1, pulled in **only transitively** via the optional `crewai` extra of `amfs-crewai`. There is **no patched release**: the latest `chromadb` (1.5.9) is still inside the vulnerable range, and the latest `crewai` (1.15.20) pins `chromadb~=1.1.0`. AMFS never imports `chromadb`. Those two are candidates for dismissal ("no fix available / vulnerable code not in use") rather than a code change, so #3 above picks up the highest-severity remaining alert in first-party code instead.

## Verification

- `packages/sdk-typescript`: `tsc --noEmit` clean, `vitest run` → 37/37 passing on vitest 3.2.7
- `packages/browser-extension`: `npm ci` resolves cleanly; `npm ls shell-quote` → `wxt → web-ext-run → fx-runner → shell-quote@1.10.0`
- Lockfile diffs are scoped to the bumped packages. The `libc` field removals in the extension lock are npm 11 normalisation of optional platform-package metadata, not dependency changes.

## Not touched (follow-ups)

- Dependabot **High** `json-repair` (fix 0.60.1) and `langchain-core` (fix 1.3.3) — not part of Dependabot PR #355; both transitive
- CodeQL **High** polynomial ReDoS in `amfs_core/content.py:129`, `amfs_core/query_norm.py:105`, `sdk-typescript/src/adapters/http.ts:39`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly dev-dependency and transitive dependency bumps plus a localized session-ID generation change with a clear fallback error path; no auth or payment flows touched.
> 
> **Overview**
> Addresses three open security alerts with targeted dependency and SDK changes.
> 
> **TypeScript SDK:** `CausalTagger` no longer defaults session IDs from `Math.random()`; it now builds `sess-` plus 8 hex characters via **`globalThis.crypto.getRandomValues`**, aligned with the Python engine, and throws if Web Crypto is missing so callers can pass an explicit `sessionId`. Dev dependency **`vitest`** is raised to **`^3.2.6`** (lock resolves 3.2.7) to close the Vitest UI server file-read/execute issue.
> 
> **Browser extension:** Adds an npm **`overrides`** entry forcing **`shell-quote`** to **`^1.9.0`** (lock resolves 1.10.0) because the transitive pin through `wxt`/`fx-runner` blocked a normal upgrade.
> 
> Root and workspace lockfiles reflect these bumps plus workspace package metadata updates (`@senselab-ai/amfs` at 0.4.0); extension lockfile `libc` field removals are npm normalization, not new dependency choices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45956043669883c10379fb365f8f755df3a72c72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->