### PR TITLE
Create the notify triggers only when they are absent

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/schema.sql
+++ b/packages/adapters/postgres/src/amfs_postgres/schema.sql
@@ -470,6 +470,19 @@ BEGIN
             AFTER INSERT ON amfs_outcomes
             FOR EACH ROW EXECUTE FUNCTION amfs_propagate_outcome();
     END IF;
+EXCEPTION WHEN duplicate_object THEN
+    -- Another process got there between the check and the CREATE, which the
+    -- drop-then-create pair tolerated by construction and a bare check does
+    -- not. Containers start in parallel and each applies this file, so the
+    -- window is reached in practice on a database being bootstrapped: both see
+    -- no trigger, the second blocks on the first's lock, and inherits an
+    -- already-existing trigger the moment it is granted.
+    --
+    -- Swallowing it is the whole point. _apply_schema retries only errors
+    -- mentioning a lock or a deadlock, so this one would propagate and leave
+    -- that container unable to boot -- and the outcome it is complaining about
+    -- is the one wanted anyway: the trigger exists.
+    NULL;
 END $$;
 
 -- LISTEN/NOTIFY trigger: notify on new entry writes for watch()
@@ -507,6 +520,9 @@ BEGIN
             AFTER INSERT ON amfs_memory_entries
             FOR EACH ROW EXECUTE FUNCTION amfs_notify_write();
     END IF;
+EXCEPTION WHEN duplicate_object THEN
+    -- Concurrent bootstrap; see trg_propagate_outcome.
+    NULL;
 END $$;
 
 -- Compiled digests table (Memory Cortex)
@@ -553,6 +569,9 @@ BEGIN
             AFTER INSERT OR UPDATE ON amfs_digests
             FOR EACH ROW EXECUTE FUNCTION amfs_notify_digest();
     END IF;
+EXCEPTION WHEN duplicate_object THEN
+    -- Concurrent bootstrap; see trg_propagate_outcome.
+    NULL;
 END $$;
 
 -- ──────────────────────────────────────────────────────────────────────

--- a/packages/adapters/postgres/src/amfs_postgres/schema.sql
+++ b/packages/adapters/postgres/src/amfs_postgres/schema.sql
@@ -440,10 +440,37 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS trg_propagate_outcome ON amfs_outcomes;
-CREATE TRIGGER trg_propagate_outcome
-    AFTER INSERT ON amfs_outcomes
-    FOR EACH ROW EXECUTE FUNCTION amfs_propagate_outcome();
+-- Created only when absent, rather than dropped and recreated every time.
+--
+-- This file is not run once. The adapter applies it on server startup, and CI
+-- applies it on every deploy, so an unconditional DROP TRIGGER took ACCESS
+-- EXCLUSIVE on these tables at each of those moments. That lock conflicts with
+-- reads, and Postgres queues later lock requests behind a pending exclusive
+-- one, so every query arriving while it waited queued behind it. Two
+-- production outages came out of that, the second with fifteen sessions
+-- blocked behind a single statement on amfs_memory_entries.
+--
+-- Dropping first was never doing anything anyway: the trigger is recreated
+-- identically, so on all but the first run the pair is an expensive no-op.
+--
+-- What a trigger *does* still updates normally, because the logic is in the
+-- function and CREATE OR REPLACE FUNCTION above needs no lock on the table.
+-- Only the binding itself -- which table, which events -- is frozen by this,
+-- and changing that is rare enough to belong in migrations/ where existing
+-- databases pick it up, which is how every other change to them travels.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgname = 'trg_propagate_outcome'
+          AND tgrelid = 'amfs_outcomes'::regclass
+          AND NOT tgisinternal
+    ) THEN
+        CREATE TRIGGER trg_propagate_outcome
+            AFTER INSERT ON amfs_outcomes
+            FOR EACH ROW EXECUTE FUNCTION amfs_propagate_outcome();
+    END IF;
+END $$;
 
 -- LISTEN/NOTIFY trigger: notify on new entry writes for watch()
 
@@ -464,10 +491,23 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS trg_notify_write ON amfs_memory_entries;
-CREATE TRIGGER trg_notify_write
-    AFTER INSERT ON amfs_memory_entries
-    FOR EACH ROW EXECUTE FUNCTION amfs_notify_write();
+-- Conditional for the reason given at trg_propagate_outcome. This is the one
+-- that did the damage: amfs_memory_entries is the busiest table here, so it is
+-- where an exclusive lock is least likely to be granted quickly and most
+-- expensive to wait for.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgname = 'trg_notify_write'
+          AND tgrelid = 'amfs_memory_entries'::regclass
+          AND NOT tgisinternal
+    ) THEN
+        CREATE TRIGGER trg_notify_write
+            AFTER INSERT ON amfs_memory_entries
+            FOR EACH ROW EXECUTE FUNCTION amfs_notify_write();
+    END IF;
+END $$;
 
 -- Compiled digests table (Memory Cortex)
 
@@ -500,10 +540,20 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS trg_notify_digest ON amfs_digests;
-CREATE TRIGGER trg_notify_digest
-    AFTER INSERT OR UPDATE ON amfs_digests
-    FOR EACH ROW EXECUTE FUNCTION amfs_notify_digest();
+-- Conditional for the reason given at trg_propagate_outcome.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgname = 'trg_notify_digest'
+          AND tgrelid = 'amfs_digests'::regclass
+          AND NOT tgisinternal
+    ) THEN
+        CREATE TRIGGER trg_notify_digest
+            AFTER INSERT OR UPDATE ON amfs_digests
+            FOR EACH ROW EXECUTE FUNCTION amfs_notify_digest();
+    END IF;
+END $$;
 
 -- ──────────────────────────────────────────────────────────────────────
 -- Commits — atomic groups of writes


### PR DESCRIPTION
`schema.sql` is not run once. The adapter applies it on server startup and CI applies it on every deploy, so `DROP TRIGGER IF EXISTS` + `CREATE TRIGGER` took ACCESS EXCLUSIVE on `amfs_outcomes`, `amfs_memory_entries` and `amfs_digests` at each of those moments.

That lock conflicts with reads, and Postgres queues later lock requests behind a pending exclusive one, so every query arriving while it waited queued behind it. Two production outages came out of this. In the second, a statement on `amfs_memory_entries` waited **9m27s** behind an idle-in-transaction session with fifteen sessions blocked behind it, and the API served statement timeouts until the deploy was cancelled.

The drop was not achieving anything. The trigger is recreated identically, so on every run after the first the pair is an expensive no-op. Checking `pg_trigger` first is a catalog read and takes no lock on the table.

### What still works

Behaviour changes normally: the logic is in the function, and the `CREATE OR REPLACE FUNCTION` above each of these needs no lock on the table. Only the *binding* is frozen — which table, which events — and changing that belongs in `migrations/`, which is how existing databases receive every other change to them.

### Verified against a local Postgres

| check | before | after |
|---|---|---|
| fresh database | 3 triggers | 3 triggers |
| replay while a reader holds ACCESS SHARE (2s `lock_timeout`) | `canceling statement due to lock timeout` | completes in 0s |
| trigger present after replay | — | yes |

Pairs with raia-live/amfs-internal#667, which bounds how long deploy migrations wait for a lock and skips replaying this baseline over a database that already has it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production-critical LISTEN/NOTIFY and outcome-propagation bindings on `amfs_memory_entries` and related tables, but the change removes lock-heavy no-ops rather than altering trigger logic.
> 
> **Overview**
> **Stops replaying baseline DDL from taking ACCESS EXCLUSIVE locks on hot tables on every startup and deploy.**
> 
> Instead of `DROP TRIGGER IF EXISTS` followed by `CREATE TRIGGER` for `trg_propagate_outcome`, `trg_notify_write`, and `trg_notify_digest`, each binding is created inside a `DO` block that checks `pg_trigger` first and only runs `CREATE TRIGGER` when the trigger is missing. Concurrent bootstraps that race on the same check swallow `duplicate_object`, so parallel containers still start cleanly.
> 
> Trigger **behavior** is unchanged: `CREATE OR REPLACE FUNCTION` still updates logic without table locks; only rare binding changes are expected to go through `migrations/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a74a56ae01ea08cadc0bcf3580a0fadd96ceb8e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->