### PR TITLE
Trace scale fixes, seal gap, TS SDK trace fields (OSS side of agent evaluation)

### DIFF
--- a/docs/editions.md
+++ b/docs/editions.md
@@ -569,6 +569,10 @@ Extends the OSS MCP server with additional tools:
 | `amfs_graph_path` | Find shortest trust-weighted path between two entities in the knowledge graph |
 | `amfs_graph_query` | Flexible graph edge search by relation, entity type, or confidence range |
 
+### Agent evaluation surfaces (Pro, hosted only)
+
+Pro adds an evaluation layer on top of sealed traces: LLM **judges** (versioned rubrics with sampling, budgets and dry runs), **verdicts** with evidence, **behaviors** mined from or authored against traces, **incidents** when a behavior breaks from baseline, blast-radius and dimension **segmentation**, **attribution** of failures to the memory entries that caused them, a **fix loop** that hands a coding agent a reproduction-and-tests payload, and an **investigator** that answers questions across runs. All of it runs on the hosted `/api/v1/eval` service and is reached three ways — the Pro MCP server's `amfs_judge_*` / `amfs_verdicts` / `amfs_behavior*` / `amfs_incident` / `amfs_propose_fix` / `amfs_investigate` tools (which refuse with `"mode": "local"` without `AMFS_HTTP_URL`), the private `amfs_pro` Python client (`ProClient` / `AsyncProClient`, dist `amfs-sdk-pro`), and the `amfs-pro` CLI (`eval`, `behaviors`, `incidents`, `fixes`, `cases`, `traces`, `investigate`; `--json` everywhere, `--fail-on-fail` for CI). None of these are in the OSS SDKs; the column map lives in [SDK ↔ MCP Parity]({{ site.baseurl }}/reference/sdk-mcp-parity/#agent-evaluation-pro-hosted-only).
+
 ---
 
 ## Architecture

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -407,7 +407,8 @@ recorder = TraceRecorder(memory, store, account_id=acct.id)
 recorder.memory.read("svc", "retry-pattern")
 recorder.memory.record_context("pagerduty", "3 SEV-1", source="PagerDuty API")
 
-# Record LLM calls for token/cost tracking
+# Record LLM calls for token/cost tracking (Pro: amfs_traces / amfs_record_llm_call;
+# the OSS MCP server does not expose this tool)
 recorder.record_llm_call(
     model="gpt-4o", provider="openai",
     prompt_tokens=1200, completion_tokens=450,
@@ -564,7 +565,7 @@ Extends the OSS MCP server with additional tools:
 | `amfs_retrain` | Train the learned ranking model from outcome data |
 | `amfs_calibrate` | Learn optimal confidence multipliers from outcome history |
 | `amfs_export_training_data` | Export decision traces as SFT/DPO/reward model datasets |
-| `amfs_record_llm_call` | Record an LLM call with model, tokens, cost, and latency |
+| `amfs_record_llm_call` | Record an LLM call with model, tokens, cost, and latency. **Pro only** — not registered by the OSS MCP server |
 | `amfs_graph_path` | Find shortest trust-weighted path between two entities in the knowledge graph |
 | `amfs_graph_query` | Flexible graph edge search by relation, entity type, or confidence range |
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -860,7 +860,7 @@ Paginated list endpoints return the existing list key plus `next_cursor` (opaque
 
 | Method | Path | Description |
 |:-------|:-----|:------------|
-| `GET` | `/api/v1/traces` | List decision traces (supports `?outcome_type=`, `?agent_id=`, `?entity_path=`, `?limit=`, `?offset=`, `?cursor=`). Returns `traces`, `next_cursor`, `has_more` |
+| `GET` | `/api/v1/traces` | List decision traces (supports `?outcome_type=`, `?agent_id=`, `?entity_path=`, `?limit=`, `?offset=`, `?cursor=`, `?since=` (inclusive), `?until=` (exclusive), ISO-8601). Returns `traces`, `next_cursor`, `has_more` |
 | `GET` | `/api/v1/traces/{trace_id}` | Get full trace detail with causal entries, external contexts, query/error events, state diff |
 
 ### Observability

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -844,8 +844,10 @@ All entry endpoints accept a `branch` parameter (query param for GET, body field
 |:-------|:-----|:------------|
 | `GET` | `/api/v1/agents` | List agents with entry counts, entities touched, and last active time |
 | `GET` | `/api/v1/agents/{agent_id}/memory-graph` | Get agent's memory graph (entities and entries touched) |
-| `GET` | `/api/v1/agents/{agent_id}/activity` | Get agent's activity timeline (writes, outcomes, traces) |
-| `GET` | `/api/v1/agents/{agent_id}/timeline` | Git-like event log (every write, outcome, read, brief) |
+| `GET` | `/api/v1/agents/{agent_id}/activity` | Get agent's activity timeline (writes, outcomes, traces). Keyset-paginated: `?limit=`, `?cursor=`, `?since=`, `?until=` |
+| `GET` | `/api/v1/agents/{agent_id}/timeline` | Git-like event log (every write, outcome, read, brief). Keyset-paginated: `?limit=`, `?cursor=`, `?since=`, `?until=`, `?event_type=` |
+
+Paginated list endpoints return the existing list key plus `next_cursor` (opaque string, `null` on the last page) and `has_more`. Pass `next_cursor` back as `?cursor=` to fetch the next page; `offset` is still honoured when no cursor is given. Page size is capped at 1000.
 
 ### Outcomes
 
@@ -858,7 +860,7 @@ All entry endpoints accept a `branch` parameter (query param for GET, body field
 
 | Method | Path | Description |
 |:-------|:-----|:------------|
-| `GET` | `/api/v1/traces` | List decision traces (supports `?outcome_type=`, `?agent_id=`, `?limit=`) |
+| `GET` | `/api/v1/traces` | List decision traces (supports `?outcome_type=`, `?agent_id=`, `?entity_path=`, `?limit=`, `?offset=`, `?cursor=`). Returns `traces`, `next_cursor`, `has_more` |
 | `GET` | `/api/v1/traces/{trace_id}` | Get full trace detail with causal entries, external contexts, query/error events, state diff |
 
 ### Observability
@@ -1016,6 +1018,8 @@ amfs_export_training_data(
 Export decision traces as fine-tuning datasets. Format options: `"sft"` (supervised fine-tuning), `"dpo"` (direct preference optimization), `"reward_model"` (reward model training). See the [ML Layer guide](/amfs/guides/ml-layer/) for format details.
 
 ### amfs_record_llm_call
+
+> **Pro only.** This tool is implemented only in the private AMFS Pro MCP server. The OSS `amfs-mcp-server` package does not register it; calling it there returns an unknown-tool error.
 
 ```
 amfs_record_llm_call(

--- a/docs/reference/sdk-mcp-parity.md
+++ b/docs/reference/sdk-mcp-parity.md
@@ -49,6 +49,21 @@ AMFS exposes memory three ways: the **MCP server** (for agents), the **Python SD
 | List traces | `amfs_list_traces` | `list_traces` | `listTracesAsync` |
 | Get trace | `amfs_get_trace` | `get_trace` | `getTraceAsync` |
 
+### Spans & trace navigation (Pro)
+
+These ship in the **Pro MCP server** (`amfs-mcp-server-pro`) only. The recording tools write into the current session through the span recorder and are sealed by `amfs_commit_outcome`, so they work against any adapter — local or HTTP. The navigation tools read sealed traces: with `AMFS_HTTP_URL` set they proxy to `/api/v1/pro/traces/...` (indexed, semantic search); without it they fall back to the local adapter's `list_traces` plus the trace the process committed last (`trace_id="last"`), filter in Python, and answer with `"mode": "local"`.
+
+| Capability | MCP tool (Pro) | Python SDK | TypeScript SDK |
+|:--|:--|:--|:--|
+| Record a completed span | `amfs_record_span` | `SpanRecorder.record_span` (`amfs_traces`) | — |
+| Open / close a span | `amfs_start_span` / `amfs_end_span` | `SpanRecorder.start_span` / `end_span`, `with recorder.span(...)` | — |
+| Trace attribute bag | `amfs_set_trace_attributes` | `SpanRecorder.set_attributes` | — |
+| Record an LLM call (also emits an `llm` span) | `amfs_record_llm_call` | `SpanRecorder.record_llm_call` | — |
+| Search traces by content, attributes, span name/kind, errors | `amfs_trace_search` | — (HTTP `POST /api/v1/pro/traces/search`) | — |
+| Span tree with text outline | `amfs_trace_spans` | — (HTTP `GET /api/v1/pro/traces/{id}/spans`) | — |
+| One span's input/output payloads | `amfs_span_payload` | — (HTTP `GET /api/v1/pro/traces/{id}/spans/{span_id}`) | — |
+| Compare two traces span by span | `amfs_trace_compare` | — (HTTP `POST /api/v1/pro/traces/compare`) | — |
+
 {: .note }
 The TypeScript SDK's `*Async` methods route through the `HttpAdapter` to a remote AMFS server. The synchronous methods operate on the in-process adapter. Construct `AgentMemory` with an `HttpAdapter` to use the async surface — the intended path for a Node orchestrator or a disposable sandbox pointing at hosted SenseLab.
 
@@ -66,6 +81,8 @@ These MCP tools are **not** mirrored 1:1 in the SDKs, by design. They are either
 |:--|:--|:--|
 | `amfs_consolidate`, `amfs_consolidation_status/proposals/candidates` | Pro (HTTP-proxied) | Backed by the Cortex consolidation API, not the OSS adapter ABC. The TypeScript `HttpAdapter` exposes `consolidation*Async` passthroughs; the Python SDK reaches them via the HTTP API directly. See the caveat below. |
 | `amfs_export_training_data` | Pro (HTTP-proxied) | Calls `GET /api/v1/pro/export`. Exposed on the TS `HttpAdapter` as `exportTrainingDataAsync`; Python calls the endpoint directly. |
+| `amfs_record_span`, `amfs_start_span`, `amfs_end_span`, `amfs_set_trace_attributes`, `amfs_record_llm_call` | Pro (works locally and over HTTP) | Spans live on the Pro `ImmutableDecisionTrace`; the OSS `DecisionTrace` carries them only as `session_metadata` extras that the seal path lifts out. The Python side is the `amfs_traces.spans.SpanRecorder` in the private repo, not an `AgentMemory` method; the TS SDK has no span recorder yet. |
+| `amfs_trace_search`, `amfs_trace_spans`, `amfs_span_payload`, `amfs_trace_compare` | Pro (HTTP-proxied, local fallback) | Backed by the Pro traces API (`/api/v1/pro/traces/search`, `/{id}/spans`, `/{id}/spans/{span_id}`, `/compare`). The local fallback has no semantic search or paging and can only see traces the adapter persists plus the last one committed in-process. No SDK methods yet; call the endpoints through the `HttpAdapter`. |
 | `amfs_room_*`, `amfs_negotiate_*` | Pro (rooms backend) | Multi-agent rooms/negotiation require the Pro rooms service. The TS SDK has `room*`/`negotiate*` methods; `amfs_negotiate_cancel` has **no OSS backend endpoint**, so it's not added as an SDK method (it would be a broken stub). |
 | `amfs_verify`, `amfs_commit_batch`, `amfs_merge_base` | SDK-covered | Present in the Python SDK (`verify`, `transaction`, `common_ancestor`) and TS SDK (`verify`, `transaction`, `commonAncestor`). |
 | `amfs_export` | MCP-only | Spools full untruncated values to a **local file** on the MCP client's machine — a file-system convenience that only makes sense in-process. SDK callers already have `list`/`read` returning full values with no truncation, so there is nothing to mirror. |

--- a/docs/reference/sdk-mcp-parity.md
+++ b/docs/reference/sdk-mcp-parity.md
@@ -46,7 +46,7 @@ AMFS exposes memory three ways: the **MCP server** (for agents), the **Python SD
 | Record action | `amfs_record_action` | `record_action` | `recordAction` (tracker) |
 | Explain session | `amfs_explain` | `explain` | `explain` |
 | Timeline | `amfs_timeline` | `timeline` | `timelineAsync` |
-| List traces | `amfs_list_traces` | `list_traces` | `listTracesAsync` |
+| List traces | `amfs_list_traces` | `list_traces` (cursor / since / until) | `listTracesAsync`, `listTracesPageAsync` (`{traces, nextCursor, hasMore}`) |
 | Get trace | `amfs_get_trace` | `get_trace` | `getTraceAsync` |
 
 ### Spans & trace navigation (Pro)
@@ -67,6 +67,40 @@ These ship in the **Pro MCP server** (`amfs-mcp-server-pro`) only. The recording
 {: .note }
 The TypeScript SDK's `*Async` methods route through the `HttpAdapter` to a remote AMFS server. The synchronous methods operate on the in-process adapter. Construct `AgentMemory` with an `HttpAdapter` to use the async surface — the intended path for a Node orchestrator or a disposable sandbox pointing at hosted SenseLab.
 
+{: .note }
+**Paging traces in TypeScript.** `listTracesAsync` accepts `{ cursor, since, until, limit, offset, entityPath, agentId, outcomeType }` and still returns a flat array. `listTracesPageAsync` takes the same options and returns `{ traces, nextCursor, hasMore }`, matching the OSS server's `GET /api/v1/traces` page shape — follow `nextCursor` while `hasMore` is true. `DecisionTrace` now carries `taskInput`, `responseText`, `toolCalls[]` (with the caller's `arguments` keys left as-is) and `sessionMetadata`, mapped from the server's snake_case fields; the mappers are exported as `toDecisionTrace` / `toDecisionTracePage`.
+
+### Agent evaluation (Pro, hosted only)
+
+Judges, verdicts, behaviors, incidents, the fix loop and the investigator are **Pro, hosted-only** surfaces served by `/api/v1/eval` on SenseLab Cloud. They ship in three developer-facing forms, none of which live in the OSS SDKs:
+
+- **Pro MCP tools** (`amfs-mcp-server-pro`, `tags={"extended"}`): proxy to the hosted API when `AMFS_HTTP_URL` is set and refuse with `{"error": "...requires the hosted API (AMFS_HTTP_URL)...", "mode": "local"}` otherwise. They are excluded from the builder profile.
+- **`amfs_pro` Python client** (private dist `amfs-sdk-pro`): `ProClient(base_url=None, api_key=None)` reads `AMFS_HTTP_URL` / `AMFS_API_KEY`, sends `X-AMFS-API-Key`, and exposes `client.eval` and `client.traces`; `AsyncProClient` mirrors it on `httpx.AsyncClient`. List calls return `Page[...]` (`items`, `next_cursor`, `has_more`) and have `iter*` helpers that follow cursors.
+- **`amfs-pro` CLI** (installed with `amfs-sdk-pro`): every command takes `--json` for CI; `eval backfill` and `cases run` exit non-zero with `--fail-on-fail`.
+
+| Capability | MCP tool (Pro) | `amfs_pro` client | `amfs-pro` CLI |
+|:--|:--|:--|:--|
+| Grade one trace now | `amfs_judge_trace` | `eval.judge` | `eval judge <trace_id> <judge_id>` |
+| Define a judge (optionally dry-run first) | `amfs_judge_define` | `eval.judges.create` / `.update` / `.dry_run` / `.history` / `.diff` | `eval judges create --id --name --prompt [--dry-run]`, `eval judges dry-run <agent> <judge>` |
+| List judges | `amfs_judges` | `eval.judges.list` / `.get` / `.delete` / `.detection_rate` | `eval judges list <agent>` |
+| Install the starter pack | `amfs_seed_starter_judges` | `eval.judges.seed_starter_pack` | `eval judges seed <agent>` |
+| Browse verdicts | `amfs_verdicts` | `eval.verdicts.list` / `.iter` / `.get` / `.for_trace` | — (use `--json` on `eval judge` / `backfill`) |
+| Agent summary | `amfs_eval_summary` | `eval.summary` | `eval summary <agent> [--window]` |
+| Backfill past traces (spends budget) | `amfs_backfill` | `eval.backfill` / `eval.backfill_status` | `eval backfill <agent> <judge> [--since --until --limit --sampling-rate --wait --fail-on-fail]` |
+| Judge budget | — | `eval.budget.get` / `.set` | — |
+| Behaviors | `amfs_behaviors`, `amfs_behavior_define`, `amfs_behavior_from_trace` | `eval.behaviors.list` / `.create` / `.from_trace` / `.get` / `.update` / `.delete` / `.traces` | `behaviors list <agent>`, `behaviors from-trace <trace_id>` |
+| Blast radius of a behavior | `amfs_blast_radius` | `eval.behaviors.blast_radius` | — |
+| Incidents | `amfs_incident` (list / get / `action=acknowledge\|resolve\|mute`) | `eval.incidents.list` / `.get` / `.acknowledge` / `.resolve` / `.mute` | `incidents list [--agent --status]`, `incidents ack <id>`, `incidents mute <id> [--until]` |
+| Segment by dimension | `amfs_segment`, `amfs_dimensions` | `eval.segment`, `eval.dimensions` | — |
+| Attribute a failure to memory entries | `amfs_attribute_failure` | `eval.attribution` | — |
+| Fix loop | `amfs_propose_fix` (propose, then returns the handoff), `amfs_fixes`, `amfs_approve_fix_memory` | `eval.fixes.propose` / `.handoff` / `.list` / `.get` / `.approve_memory` / `.dismiss` / `.prevention` / `.prevention_for` | `fixes list <agent>`, `fixes propose <agent> --verdict\|--behavior`, `fixes handoff <fix_id>` (prints `instructions` markdown for piping into a coding agent) |
+| Regression cases | — | `eval.cases.sets` / `.create_set` / `.get_set` / `.cases` / `.run` (inline or queued) / `.get_run` / `.runs` / `.compare` | `cases run <set_id> --label [--since --compare-to --fail-on-fail]` |
+| Investigate a question across runs | `amfs_investigate` (non-streaming) | `eval.investigate`, `eval.investigate_stream` (SSE events) | `investigate <agent> "<question>" [--trace --max-steps --no-stream]` (streams steps) |
+| Alerts | `amfs_alerts` | `eval.alerts.list` / `.ack` / `.mute` / `.rules` | — |
+| Sealed traces | `amfs_trace_search`, `amfs_trace_spans`, `amfs_span_payload`, `amfs_trace_compare` | `traces.search` / `.iter_search` / `.get` / `.spans` / `.span` / `.compare` / `.otlp_export` | `traces search [--query --agent --since --until --has-error --outcome --limit --cursor]` |
+
+Where the Python SDK column above says "—", the same routes are reachable by any HTTP client with the `X-AMFS-API-Key` header; the `amfs_pro` client is the supported wrapper.
+
 ## Identity
 
 Agent identity in the SDKs is set via the `AgentMemory` constructor (`agent_id`). **Sticky identity** (`amfs_set_identity` / `amfs_whoami` / `amfs_reset_identity`) is an MCP-server concept: it persists the last identity to `~/.amfs/.identity-<client>` so a fresh MCP process auto-restores it. The SDKs don't own that on-disk state, so they intentionally don't expose set/whoami/reset — pass `agent_id` explicitly instead.
@@ -83,6 +117,7 @@ These MCP tools are **not** mirrored 1:1 in the SDKs, by design. They are either
 | `amfs_export_training_data` | Pro (HTTP-proxied) | Calls `GET /api/v1/pro/export`. Exposed on the TS `HttpAdapter` as `exportTrainingDataAsync`; Python calls the endpoint directly. |
 | `amfs_record_span`, `amfs_start_span`, `amfs_end_span`, `amfs_set_trace_attributes`, `amfs_record_llm_call` | Pro (works locally and over HTTP) | Spans live on the Pro `ImmutableDecisionTrace`; the OSS `DecisionTrace` carries them only as `session_metadata` extras that the seal path lifts out. The Python side is the `amfs_traces.spans.SpanRecorder` in the private repo, not an `AgentMemory` method; the TS SDK has no span recorder yet. |
 | `amfs_trace_search`, `amfs_trace_spans`, `amfs_span_payload`, `amfs_trace_compare` | Pro (HTTP-proxied, local fallback) | Backed by the Pro traces API (`/api/v1/pro/traces/search`, `/{id}/spans`, `/{id}/spans/{span_id}`, `/compare`). The local fallback has no semantic search or paging and can only see traces the adapter persists plus the last one committed in-process. No SDK methods yet; call the endpoints through the `HttpAdapter`. |
+| `amfs_judge_trace`, `amfs_judge_define`, `amfs_judges`, `amfs_seed_starter_judges`, `amfs_verdicts`, `amfs_eval_summary`, `amfs_backfill`, `amfs_behaviors`, `amfs_behavior_define`, `amfs_behavior_from_trace`, `amfs_blast_radius`, `amfs_incident`, `amfs_segment`, `amfs_dimensions`, `amfs_attribute_failure`, `amfs_propose_fix`, `amfs_fixes`, `amfs_approve_fix_memory`, `amfs_investigate`, `amfs_alerts` | Pro (HTTP-proxied, **no local mode**) | Agent evaluation runs on the hosted `/api/v1/eval` service (LLM judges, budgets, behavior mining). Without `AMFS_HTTP_URL` the tools answer `{"mode": "local"}` and do nothing. The OSS SDKs have no methods for these; use the private `amfs_pro` client or the `amfs-pro` CLI (see *Agent evaluation* above). |
 | `amfs_room_*`, `amfs_negotiate_*` | Pro (rooms backend) | Multi-agent rooms/negotiation require the Pro rooms service. The TS SDK has `room*`/`negotiate*` methods; `amfs_negotiate_cancel` has **no OSS backend endpoint**, so it's not added as an SDK method (it would be a broken stub). |
 | `amfs_verify`, `amfs_commit_batch`, `amfs_merge_base` | SDK-covered | Present in the Python SDK (`verify`, `transaction`, `common_ancestor`) and TS SDK (`verify`, `transaction`, `commonAncestor`). |
 | `amfs_export` | MCP-only | Spools full untruncated values to a **local file** on the MCP client's machine — a file-system convenience that only makes sense in-process. SDK callers already have `list`/`read` returning full values with no truncation, so there is nothing to mirror. |

--- a/packages/adapters/filesystem/src/amfs_filesystem/adapter.py
+++ b/packages/adapters/filesystem/src/amfs_filesystem/adapter.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import heapq
 import json
 import os
 import logging
+from collections.abc import Iterator
+from datetime import datetime, timezone, UTC
 from pathlib import Path
 from typing import Callable
 
@@ -237,6 +240,71 @@ class FilesystemAdapter(AdapterABC):
                     except Exception:
                         logger.warning("Skipping unreadable file: %s", f)
         return entries
+
+    def _iter_current_entries(self) -> Iterator[MemoryEntry]:
+        """Yield current entries one file at a time, never holding them all."""
+        layout = self._layout
+        for ep in layout.all_entity_paths():
+            for key in layout.all_keys(ep):
+                for f in layout.all_version_files(ep, key, include_superseded=False):
+                    try:
+                        yield self._read_entry(f)
+                    except Exception:
+                        logger.warning("Skipping unreadable file: %s", f)
+
+    def list_entries_for_agent(
+        self,
+        agent_id: str,
+        *,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        cursor: str | None = None,
+        limit: int = 100,
+        exclude_prefixes: tuple[str, ...] = ("_system/",),
+    ) -> list[MemoryEntry]:
+        """Stream the store once and keep only the ``limit`` newest matches.
+
+        The base implementation materialises ``list()`` first; here a bounded
+        heap holds at most *limit* entries at any point, so the memory cost
+        is the page, not the store. Ordering and the cursor tiebreak match
+        the base implementation exactly.
+        """
+        from amfs_core.pagination import decode_cursor, entry_tiebreak
+
+        limit = max(1, int(limit))
+        cursor_key: tuple[datetime, str] | None = None
+        if cursor:
+            ts, tiebreak = decode_cursor(cursor)
+            cursor_key = (ts, json.dumps(tiebreak, default=str, sort_keys=True))
+
+        def sort_key(e: MemoryEntry) -> tuple[datetime, str]:
+            ts = e.provenance.written_at
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=UTC)
+            return ts, json.dumps(entry_tiebreak(e), default=str, sort_keys=True)
+
+        heap: list[tuple[tuple[datetime, str], int, MemoryEntry]] = []
+        seq = 0
+        for e in self._iter_current_entries():
+            if e.provenance.agent_id != agent_id:
+                continue
+            if any(e.entity_path.startswith(p) for p in exclude_prefixes):
+                continue
+            written = e.provenance.written_at
+            if since is not None and written < since:
+                continue
+            if until is not None and written >= until:
+                continue
+            key = sort_key(e)
+            if cursor_key is not None and key >= cursor_key:
+                continue
+            seq += 1
+            if len(heap) < limit:
+                heapq.heappush(heap, (key, seq, e))
+            elif key > heap[0][0]:
+                heapq.heapreplace(heap, (key, seq, e))
+
+        return [e for _, _, e in sorted(heap, key=lambda h: h[0], reverse=True)]
 
     # ------------------------------------------------------------------
     # watch

--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -406,17 +406,16 @@ class HttpAdapter(AdapterABC):
             params["cursor"] = cursor
         elif offset:
             params["offset"] = offset
-        # since/until are not query parameters on the server; applied here
-        # so the contract matches the other adapters.
+        # The window is applied by the server's query, not to the page after
+        # the fact: filtering a page here would empty it whenever the window
+        # excludes the newest traces, and the cursor walk in _iter_traces
+        # stops on an empty page — so older matches would never be reached.
+        if since is not None:
+            params["since"] = since.isoformat()
+        if until is not None:
+            params["until"] = until.isoformat()
         data = self._get("/api/v1/traces", **params)
         traces = [DecisionTrace.model_validate(t) for t in data.get("traces", [])]
-        if since is not None or until is not None:
-            traces = [
-                t
-                for t in traces
-                if (since is None or t.created_at >= since)
-                and (until is None or t.created_at < until)
-            ]
         return traces, data.get("next_cursor"), bool(data.get("has_more", False))
 
     def _iter_traces(self, *, max_rows: int, **filters: Any) -> list[DecisionTrace]:

--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -345,12 +345,15 @@ class HttpAdapter(AdapterABC):
         entity_path: str | None = None,
         since: datetime | None = None,
         limit: int = 1000,
+        outcome_ref: str | None = None,
     ) -> list[OutcomeRecord]:
         params: dict[str, Any] = {"limit": limit}
         if entity_path:
             params["entity_path"] = entity_path
         if since:
             params["since"] = since.isoformat()
+        if outcome_ref:
+            params["outcome_ref"] = outcome_ref
         data = self._get("/api/v1/outcomes", **params)
         return [OutcomeRecord.model_validate(o) for o in data.get("outcomes", [])]
 
@@ -361,15 +364,105 @@ class HttpAdapter(AdapterABC):
         agent_id: str | None = None,
         outcome_type: str | None = None,
         limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
     ) -> list[DecisionTrace]:
-        data = self._get(
-            "/api/v1/traces",
+        """One page of traces. The server caps a page at 1,000 rows; callers
+        that need more than that follow cursors (see :meth:`_iter_traces`)."""
+        data = self.list_traces_page(
             entity_path=entity_path,
             agent_id=agent_id,
             outcome_type=outcome_type,
             limit=limit,
+            offset=offset,
+            cursor=cursor,
+            since=since,
+            until=until,
         )
-        return [DecisionTrace.model_validate(t) for t in data.get("traces", [])]
+        return data[0]
+
+    def list_traces_page(
+        self,
+        *,
+        entity_path: str | None = None,
+        agent_id: str | None = None,
+        outcome_type: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> tuple[list[DecisionTrace], str | None, bool]:
+        """``(traces, next_cursor, has_more)`` straight from the server's page."""
+        params: dict[str, Any] = {
+            "entity_path": entity_path,
+            "agent_id": agent_id,
+            "outcome_type": outcome_type,
+            "limit": limit,
+        }
+        if cursor:
+            params["cursor"] = cursor
+        elif offset:
+            params["offset"] = offset
+        # since/until are not query parameters on the server; applied here
+        # so the contract matches the other adapters.
+        data = self._get("/api/v1/traces", **params)
+        traces = [DecisionTrace.model_validate(t) for t in data.get("traces", [])]
+        if since is not None or until is not None:
+            traces = [
+                t
+                for t in traces
+                if (since is None or t.created_at >= since)
+                and (until is None or t.created_at < until)
+            ]
+        return traces, data.get("next_cursor"), bool(data.get("has_more", False))
+
+    def _iter_traces(self, *, max_rows: int, **filters: Any) -> list[DecisionTrace]:
+        """Follow cursors until *max_rows* traces have been read or the list ends."""
+        out: list[DecisionTrace] = []
+        cursor: str | None = None
+        while len(out) < max_rows:
+            page, cursor, has_more = self.list_traces_page(
+                limit=min(1000, max_rows - len(out)), cursor=cursor, **filters
+            )
+            out.extend(page)
+            if not has_more or not cursor or not page:
+                break
+        return out
+
+    def count_traces(
+        self,
+        *,
+        entity_path: str | None = None,
+        agent_id: str | None = None,
+        outcome_type: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> int:
+        from amfs_core.pagination import max_scan_rows
+
+        return len(
+            self._iter_traces(
+                max_rows=max_scan_rows(),
+                entity_path=entity_path,
+                agent_id=agent_id,
+                outcome_type=outcome_type,
+                since=since,
+                until=until,
+            )
+        )
+
+    def trace_read_counts(self, agent_id: str) -> dict[str, dict[str, int]]:
+        from amfs_core.pagination import max_scan_rows
+
+        counts: dict[str, dict[str, int]] = {}
+        for t in self._iter_traces(max_rows=max_scan_rows(), agent_id=agent_id):
+            for ce in t.causal_entries:
+                per_entity = counts.setdefault(ce.entity_path, {})
+                per_entity[ce.key] = per_entity.get(ce.key, 0) + 1
+        return counts
 
     def save_trace(self, trace: DecisionTrace) -> DecisionTrace:
         data = self._post("/api/v1/traces", trace.model_dump(mode="json"))
@@ -559,6 +652,9 @@ class HttpAdapter(AdapterABC):
         event_type: str | None = None,
         since: datetime | None = None,
         limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        until: datetime | None = None,
     ) -> list[Event]:
         params: dict[str, Any] = {"limit": limit}
         if branch:
@@ -567,8 +663,18 @@ class HttpAdapter(AdapterABC):
             params["event_type"] = event_type
         if since:
             params["since"] = since.isoformat()
+        if until:
+            params["until"] = until.isoformat()
+        if cursor:
+            params["cursor"] = cursor
+        elif offset:
+            params["offset"] = offset
         data = self._get(f"/api/v1/agents/{agent_id}/timeline", **params)
-        return [Event.model_validate(e) for e in data.get("events", [])]
+        events = [Event.model_validate(e) for e in data.get("events", [])]
+        if until is not None:
+            # Older servers ignore the parameter; keep the bound exact locally.
+            events = [e for e in events if e.created_at < until]
+        return events
 
     def upsert_graph_edge(
         self,

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -252,9 +252,14 @@ def _tables_created_by(sql: str) -> frozenset[str]:
     bootstrap runs is covered without anyone remembering to update a second
     place — which is the kind of upkeep that silently stops happening.
     """
+    # Partitions (``CREATE TABLE x PARTITION OF parent``) are excluded: they
+    # exist only once the parent is partitioned, which on a database where the
+    # partitioning migration was deliberately skipped is never, and a table
+    # that can never be present would make the schema never "current" and
+    # re-run the DDL on every start — the convoy this check exists to stop.
     return frozenset(
         re.findall(
-            r"CREATE TABLE IF NOT EXISTS\s+([A-Za-z_][A-Za-z0-9_]*)",
+            r"CREATE TABLE IF NOT EXISTS\s+([A-Za-z_][A-Za-z0-9_]*)\b(?!\s+PARTITION\s+OF\b)",
             sql,
             re.IGNORECASE,
         )
@@ -478,6 +483,13 @@ class PostgresAdapter(AdapterABC):
         self._pool = _TenantRLSPoolWrapper(self._pool)
         if auto_schema:
             self._apply_schema()
+            # Every start, not only when the schema changes: the partitions
+            # that need to exist move forward one month at a time and the
+            # schema marker does not. One catalog query on a warm database.
+            try:
+                self.ensure_trace_partitions()
+            except Exception:  # noqa: BLE001
+                logger.warning("trace partitioning: partition upkeep skipped", exc_info=True)
         self._detect_optional_columns()
         self._listen_thread: threading.Thread | None = None
         self._listen_stop = threading.Event()
@@ -551,7 +563,13 @@ class PostgresAdapter(AdapterABC):
         try:
             import inspect
 
-            return inspect.getsource(type(self)._apply_migrations)
+            from amfs_postgres import trace_partitions
+
+            # The partitioning and retention DDL lives in its own module, and a
+            # change there is a schema change just as much as one in here.
+            return inspect.getsource(type(self)._apply_migrations) + inspect.getsource(
+                trace_partitions
+            )
         except Exception:  # noqa: BLE001
             return None
 
@@ -634,8 +652,11 @@ class PostgresAdapter(AdapterABC):
                         cur.execute("SET lock_timeout = '5s'")
                         try:
                             cur.execute(_SCHEMA_SQL)
-                            self._apply_migrations(cur)
-                            if fingerprint:
+                            complete = self._apply_migrations(cur)
+                            # A migration that failed for a transient reason
+                            # reports False so the marker is withheld and the
+                            # next start tries again; everything else is done.
+                            if fingerprint and complete is not False:
                                 self._record_schema_fingerprint(cur, fingerprint)
                         finally:
                             cur.execute("SET lock_timeout = DEFAULT")
@@ -686,7 +707,7 @@ class PostgresAdapter(AdapterABC):
                         SELECT count(*) AS present
                         FROM pg_catalog.pg_class c
                         JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-                        WHERE c.relkind = 'r'
+                        WHERE c.relkind IN ('r', 'p')
                           AND n.nspname = ANY (current_schemas(false))
                           AND c.relname = ANY (%s)
                         """,
@@ -745,8 +766,14 @@ class PostgresAdapter(AdapterABC):
         )
 
     @staticmethod
-    def _apply_migrations(cur: psycopg.Cursor) -> None:
-        """Additive migrations for columns added after initial schema."""
+    def _apply_migrations(cur: psycopg.Cursor) -> bool:
+        """Additive migrations for columns added after initial schema.
+
+        Returns False when a migration could not be applied for a reason that
+        may clear on its own, so ``_apply_schema`` withholds the schema marker
+        and the next start retries. True (or None, from older code paths)
+        means the database is at this build's schema.
+        """
         cur.execute("""
             ALTER TABLE amfs_memory_entries
             ADD COLUMN IF NOT EXISTS shared BOOLEAN NOT NULL DEFAULT TRUE
@@ -1209,6 +1236,14 @@ class PostgresAdapter(AdapterABC):
             ON amfs_memory_entries (namespace, branch, entity_path, key)
             WHERE superseded_at IS NULL
         """)
+        # The per-agent activity listing: current entries by one agent, newest
+        # first, keyset-paged on written_at. Without this it is a scan of every
+        # current entry in the namespace filtered by agent afterwards.
+        cur.execute("""
+            CREATE INDEX IF NOT EXISTS idx_entries_agent_written
+            ON amfs_memory_entries (namespace, agent_id, written_at DESC)
+            WHERE superseded_at IS NULL
+        """)
 
         cur.execute("""
             ALTER TABLE amfs_api_keys
@@ -1258,6 +1293,91 @@ class PostgresAdapter(AdapterABC):
                 PRIMARY KEY (account_id, cluster_id)
             )
         """)
+
+        # Decision traces at volume: monthly range partitioning by created_at,
+        # then the GIN index the entity_path filter needs. The partitioning
+        # step is a one-time table rebuild inside its own transaction (see
+        # trace_partitions.migrate_to_partitioned for the approach and its
+        # rollback). It comes after every ALTER above so the parent is built
+        # from a table that already has every column; the index comes after
+        # the partitioning so it is created once, on the parent, rather than
+        # on a table about to be rebuilt.
+        from amfs_postgres import trace_partitions
+
+        complete = True
+        try:
+            trace_partitions.migrate_to_partitioned(cur)
+        except Exception:  # noqa: BLE001
+            # Already rolled back and logged. Not re-raised: a failed rebuild
+            # must not stop the process booting, since the flat table still
+            # works. Reported as incomplete so the next start tries again.
+            complete = False
+        trace_partitions.create_causal_entries_index(cur)
+        try:
+            trace_partitions.ensure_partitions(cur)
+        except Exception:  # noqa: BLE001
+            logger.warning("trace partitioning: could not create partitions ahead", exc_info=True)
+        return complete
+
+    # ------------------------------------------------------------------
+    # decision-trace partition upkeep and retention
+    # ------------------------------------------------------------------
+
+    def ensure_trace_partitions(self, months_ahead: int = 2) -> list[str]:
+        """Create trace partitions for this month and *months_ahead* more.
+
+        Runs at adapter start and is safe to call any time: it reads the
+        catalog and creates only what is missing, so on a warm database it is
+        one query and no DDL. Returns the partition names it created. A no-op
+        when the table is not partitioned.
+        """
+        from amfs_postgres import trace_partitions
+
+        with self._maintenance_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SET lock_timeout = '5s'")
+                try:
+                    return trace_partitions.ensure_partitions(cur, months_ahead=months_ahead)
+                finally:
+                    cur.execute("SET lock_timeout = DEFAULT")
+
+    def apply_trace_retention(
+        self,
+        *,
+        hot_days: int = 30,
+        strip_payloads: bool = True,
+        drop_after_days: int | None = None,
+    ) -> dict[str, Any]:
+        """Age decision traces out of the hot tier; see ``trace_partitions.apply_retention``.
+
+        Payload stripping is scoped to this adapter's namespace and keeps every
+        trace, its causal entries, contexts and metadata; only ``task_input``,
+        ``response_text``, ``tool_calls``, ``query_events`` and ``error_events``
+        are cleared for traces older than *hot_days*. *drop_after_days*, when
+        set, drops whole monthly partitions older than that — across every
+        namespace, since a partition is a month, not a tenant — so it is off
+        by default. Nothing schedules this; call it from a job or the
+        ``python -m amfs_postgres.retention`` entry point.
+
+        Runs on the maintenance checkout, which carries no tenant, so on a
+        deployment that scopes traces with row-level security it runs as the
+        table owner or not at all.
+        """
+        from amfs_postgres import trace_partitions
+
+        with self._maintenance_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SET lock_timeout = '5s'")
+                try:
+                    return trace_partitions.apply_retention(
+                        cur,
+                        namespace=self._namespace,
+                        hot_days=hot_days,
+                        strip_payloads=strip_payloads,
+                        drop_after_days=drop_after_days,
+                    )
+                finally:
+                    cur.execute("SET lock_timeout = DEFAULT")
 
     def _detect_optional_columns(self) -> None:
         """Check whether optional columns (embedding, search_tsv) exist.
@@ -2772,13 +2892,13 @@ class PostgresAdapter(AdapterABC):
     # list_outcomes
     # ------------------------------------------------------------------
 
-    def list_outcomes(
+    def _outcome_conditions(
         self,
         *,
-        entity_path: str | None = None,
-        since: datetime | None = None,
-        limit: int = 1000,
-    ) -> list[OutcomeRecord]:
+        entity_path: str | None,
+        since: datetime | None,
+        outcome_ref: str | None = None,
+    ) -> tuple[str, list[Any]]:
         conditions = ["namespace = %s"]
         params: list[Any] = [self._namespace]
 
@@ -2792,7 +2912,37 @@ class PostgresAdapter(AdapterABC):
             conditions.append("committed_at >= %s")
             params.append(since)
 
-        where = " AND ".join(conditions)
+        if outcome_ref is not None:
+            conditions.append("outcome_ref = %s")
+            params.append(outcome_ref)
+
+        return " AND ".join(conditions), params
+
+    def count_outcomes(
+        self,
+        *,
+        entity_path: str | None = None,
+        since: datetime | None = None,
+    ) -> int:
+        """``COUNT(*)`` over outcomes, so the number is right past any page cap."""
+        where, params = self._outcome_conditions(entity_path=entity_path, since=since)
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(f"SELECT count(*) AS cnt FROM amfs_outcomes WHERE {where}", params)
+                row = cur.fetchone()
+        return int(row["cnt"]) if row else 0
+
+    def list_outcomes(
+        self,
+        *,
+        entity_path: str | None = None,
+        since: datetime | None = None,
+        limit: int = 1000,
+        outcome_ref: str | None = None,
+    ) -> list[OutcomeRecord]:
+        where, params = self._outcome_conditions(
+            entity_path=entity_path, since=since, outcome_ref=outcome_ref
+        )
         sql = f"""
             SELECT outcome_ref, outcome_type, causal_confidence,
                    committed_at, causal_entry_keys, agent_id
@@ -2906,6 +3056,69 @@ class PostgresAdapter(AdapterABC):
                 row = cur.fetchone()
         return trace.model_copy(update={"id": str(row["id"]), "created_at": row["created_at"]})
 
+    @staticmethod
+    def _trace_conditions(
+        namespace: str,
+        *,
+        entity_path: str | None = None,
+        agent_id: str | None = None,
+        outcome_type: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        cursor: str | None = None,
+    ) -> tuple[str, list[Any]]:
+        """WHERE clause shared by the trace list and count queries.
+
+        Shared between the sync and async adapters, which is why it is static:
+        the two must agree on what a page contains or a cursor issued by one
+        would mean something else to the other.
+        """
+        conditions = ["namespace = %s"]
+        params: list[Any] = [namespace]
+
+        if entity_path is not None:
+            # Containment rather than ``jsonb_array_elements``: ``@>`` is what
+            # the jsonb_path_ops GIN index on causal_entries can serve, and it
+            # asks the same question — is there an element whose entity_path
+            # is this string.
+            conditions.append("causal_entries @> %s::jsonb")
+            params.append(json.dumps([{"entity_path": entity_path}]))
+        if agent_id is not None:
+            conditions.append("agent_id = %s")
+            params.append(agent_id)
+        if outcome_type is not None:
+            conditions.append("outcome_type = %s")
+            params.append(outcome_type)
+        if since is not None:
+            conditions.append("created_at >= %s")
+            params.append(since)
+        if until is not None:
+            conditions.append("created_at < %s")
+            params.append(until)
+        if cursor:
+            from amfs_core.pagination import decode_cursor
+
+            cursor_ts, cursor_id = decode_cursor(cursor)
+            # The row comparison is the keyset step; the plain ``created_at <=``
+            # beside it is redundant for correctness but is a single-column
+            # predicate the planner can use to prune partitions, which the
+            # row comparison is not.
+            conditions.append("created_at <= %s")
+            params.append(cursor_ts)
+            conditions.append("(created_at, id) < (%s, %s::uuid)")
+            params.extend([cursor_ts, str(cursor_id)])
+
+        return " AND ".join(conditions), params
+
+    _TRACE_COLUMNS = """
+        id, agent_id, session_id, outcome_ref, outcome_type,
+        decision_summary, task_input, response_text, tool_calls,
+        causal_entries, external_contexts,
+        query_events, session_started_at, session_ended_at,
+        session_duration_ms,
+        error_events, state_diff, session_metadata, created_at
+    """
+
     def list_traces(
         self,
         *,
@@ -2913,37 +3126,31 @@ class PostgresAdapter(AdapterABC):
         agent_id: str | None = None,
         outcome_type: str | None = None,
         limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
     ) -> list[DecisionTrace]:
-        conditions = ["namespace = %s"]
-        params: list[Any] = [self._namespace]
-
-        if entity_path is not None:
-            conditions.append(
-                "EXISTS (SELECT 1 FROM jsonb_array_elements(causal_entries) AS ce "
-                "WHERE ce->>'entity_path' = %s)"
-            )
-            params.append(entity_path)
-        if agent_id is not None:
-            conditions.append("agent_id = %s")
-            params.append(agent_id)
-        if outcome_type is not None:
-            conditions.append("outcome_type = %s")
-            params.append(outcome_type)
-
-        where = " AND ".join(conditions)
+        where, params = self._trace_conditions(
+            self._namespace,
+            entity_path=entity_path,
+            agent_id=agent_id,
+            outcome_type=outcome_type,
+            since=since,
+            until=until,
+            cursor=cursor,
+        )
         sql = f"""
-            SELECT id, agent_id, session_id, outcome_ref, outcome_type,
-                   decision_summary, task_input, response_text, tool_calls,
-                   causal_entries, external_contexts,
-                   query_events, session_started_at, session_ended_at,
-                   session_duration_ms,
-                   error_events, state_diff, session_metadata, created_at
+            SELECT {self._TRACE_COLUMNS}
             FROM amfs_decision_traces
             WHERE {where}
-            ORDER BY created_at DESC
+            ORDER BY created_at DESC, id DESC
             LIMIT %s
         """
         params.append(limit)
+        if not cursor and offset > 0:
+            sql += " OFFSET %s"
+            params.append(offset)
 
         with self._pool.connection() as conn:
             with conn.cursor() as cur:
@@ -2951,6 +3158,132 @@ class PostgresAdapter(AdapterABC):
                 rows = cur.fetchall()
 
         return [self._row_to_trace(row) for row in rows]
+
+    def count_traces(
+        self,
+        *,
+        entity_path: str | None = None,
+        agent_id: str | None = None,
+        outcome_type: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> int:
+        where, params = self._trace_conditions(
+            self._namespace,
+            entity_path=entity_path,
+            agent_id=agent_id,
+            outcome_type=outcome_type,
+            since=since,
+            until=until,
+        )
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"SELECT count(*) AS cnt FROM amfs_decision_traces WHERE {where}", params
+                )
+                row = cur.fetchone()
+        return int(row["cnt"]) if row else 0
+
+    _TRACE_READ_COUNTS_SQL = """
+        SELECT ce->>'entity_path' AS entity_path, ce->>'key' AS key, COUNT(*) AS cnt
+        FROM amfs_decision_traces t
+        CROSS JOIN LATERAL jsonb_array_elements(t.causal_entries) AS ce
+        WHERE t.namespace = %s AND t.agent_id = %s
+        GROUP BY ce->>'entity_path', ce->>'key'
+    """
+
+    @staticmethod
+    def _read_counts_from_rows(rows: list[dict[str, Any]]) -> dict[str, dict[str, int]]:
+        counts: dict[str, dict[str, int]] = {}
+        for r in rows:
+            ep, key = r["entity_path"], r["key"]
+            if ep is None or key is None:
+                continue
+            counts.setdefault(ep, {})[key] = int(r["cnt"])
+        return counts
+
+    def trace_read_counts(self, agent_id: str) -> dict[str, dict[str, int]]:
+        """Per-entry read counts across an agent's traces, aggregated in SQL."""
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(self._TRACE_READ_COUNTS_SQL, (self._namespace, agent_id))
+                rows = cur.fetchall()
+        return self._read_counts_from_rows(rows)
+
+    _ENTRIES_FOR_AGENT_ORDER = "ORDER BY written_at DESC, entity_path DESC, key DESC, version DESC"
+
+    @staticmethod
+    def _entries_for_agent_conditions(
+        namespace: str,
+        agent_id: str,
+        *,
+        since: datetime | None,
+        until: datetime | None,
+        cursor: str | None,
+        exclude_prefixes: tuple[str, ...],
+    ) -> tuple[str, list[Any]]:
+        conditions = [
+            "namespace = %s",
+            "agent_id = %s",
+            "superseded_at IS NULL",
+            "branch = 'main'",
+        ]
+        params: list[Any] = [namespace, agent_id]
+        for prefix in exclude_prefixes:
+            conditions.append("entity_path NOT LIKE %s")
+            params.append(prefix.replace("%", r"\%").replace("_", r"\_") + "%")
+        if since is not None:
+            conditions.append("written_at >= %s")
+            params.append(since)
+        if until is not None:
+            conditions.append("written_at < %s")
+            params.append(until)
+        if cursor:
+            from amfs_core.pagination import decode_cursor
+
+            cursor_ts, tiebreak = decode_cursor(cursor)
+            try:
+                ep, key, version = tiebreak
+            except (TypeError, ValueError) as exc:
+                from amfs_core.pagination import InvalidCursorError
+
+                raise InvalidCursorError("cursor does not belong to this listing") from exc
+            conditions.append(
+                "(written_at, entity_path, key, version) < (%s, %s, %s, %s)"
+            )
+            params.extend([cursor_ts, ep, key, int(version)])
+        return " AND ".join(conditions), params
+
+    def list_entries_for_agent(
+        self,
+        agent_id: str,
+        *,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        cursor: str | None = None,
+        limit: int = 100,
+        exclude_prefixes: tuple[str, ...] = ("_system/",),
+    ) -> list[MemoryEntry]:
+        where, params = self._entries_for_agent_conditions(
+            self._namespace,
+            agent_id,
+            since=since,
+            until=until,
+            cursor=cursor,
+            exclude_prefixes=exclude_prefixes,
+        )
+        sql = f"""
+            SELECT * FROM amfs_memory_entries
+            WHERE {where}
+            {self._ENTRIES_FOR_AGENT_ORDER}
+            LIMIT %s
+        """
+        params.append(limit)
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+                rows = cur.fetchall()
+        return [self._row_to_entry(r) for r in rows]
 
     def list_traces_for_entry(
         self,
@@ -4074,15 +4407,59 @@ class PostgresAdapter(AdapterABC):
         event_type: str | None = None,
         since: datetime | None = None,
         limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        until: datetime | None = None,
     ) -> list[Event]:
+        where, params = self._event_conditions(
+            namespace,
+            agent_id,
+            account_id=self._get_current_account_id(),
+            branch=branch,
+            event_type=event_type,
+            since=since,
+            until=until,
+            cursor=cursor,
+        )
+        sql = f"""
+            SELECT id, namespace, agent_id, branch, event_type,
+                   summary, details, actor_agent_id, created_at
+            FROM amfs_events
+            WHERE {where}
+            ORDER BY created_at DESC, id DESC
+            LIMIT %s
+        """
+        params.append(limit)
+        if not cursor and offset > 0:
+            sql += " OFFSET %s"
+            params.append(offset)
+
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+                rows = cur.fetchall()
+
+        return [self._row_to_event(r) for r in rows]
+
+    @staticmethod
+    def _event_conditions(
+        namespace: str,
+        agent_id: str,
+        *,
+        account_id: str | None,
+        branch: str | None,
+        event_type: str | None,
+        since: datetime | None,
+        until: datetime | None,
+        cursor: str | None,
+    ) -> tuple[str, list[Any]]:
+        """WHERE clause for the timeline, shared with the async adapter."""
         conditions = ["namespace = %s", "agent_id = %s"]
         params: list[Any] = [namespace, agent_id]
 
-        account_id = self._get_current_account_id()
         if account_id:
             conditions.append("account_id = %s")
             params.append(account_id)
-
         if branch is not None:
             conditions.append("branch = %s")
             params.append(branch)
@@ -4092,24 +4469,16 @@ class PostgresAdapter(AdapterABC):
         if since is not None:
             conditions.append("created_at >= %s")
             params.append(since)
+        if until is not None:
+            conditions.append("created_at < %s")
+            params.append(until)
+        if cursor:
+            from amfs_core.pagination import decode_cursor
 
-        where = " AND ".join(conditions)
-        sql = f"""
-            SELECT id, namespace, agent_id, branch, event_type,
-                   summary, details, actor_agent_id, created_at
-            FROM amfs_events
-            WHERE {where}
-            ORDER BY created_at DESC
-            LIMIT %s
-        """
-        params.append(limit)
-
-        with self._pool.connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(sql, params)
-                rows = cur.fetchall()
-
-        return [self._row_to_event(r) for r in rows]
+            cursor_ts, cursor_id = decode_cursor(cursor)
+            conditions.append("(created_at, id) < (%s, %s::uuid)")
+            params.extend([cursor_ts, str(cursor_id)])
+        return " AND ".join(conditions), params
 
     def get_event(self, event_id: str, namespace: str = "default") -> Event | None:
         """Fetch one event by id, scoped to the caller's account.

--- a/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
@@ -25,6 +25,7 @@ from amfs_core.exceptions import VersionConflictError
 from amfs_core.models import (
     Agent,
     ArtifactRef,
+    DecisionTrace,
     Event,
     EventType,
     GraphEdge,
@@ -739,6 +740,179 @@ class AsyncPostgresAdapter:
             last_seen=row["last_seen"],
             provenance=row["provenance"],
         )
+
+    # ──────────────────────────────────────────────────────────────
+    # 7b. decision traces, agent activity, timeline
+    # ──────────────────────────────────────────────────────────────
+    #
+    # The trace list, trace detail, activity and timeline routes used to call
+    # the sync adapter from inside the event loop, so every page of traces
+    # was a blocking round-trip that stalled every other request. These share
+    # the WHERE builders and row mappers with the sync adapter, so a cursor
+    # issued by one is honoured identically by the other.
+
+    def _row_to_trace(self, row: dict[str, Any]) -> DecisionTrace:
+        # The sync mapper reads only ``self._namespace`` from its instance,
+        # which this adapter also carries under the same name.
+        return PostgresAdapter._row_to_trace(self, row)  # type: ignore[arg-type]
+
+    async def get_trace(self, trace_id: str) -> DecisionTrace | None:
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    f"""
+                    SELECT {PostgresAdapter._TRACE_COLUMNS}
+                    FROM amfs_decision_traces
+                    WHERE id = %s AND namespace = %s
+                    """,
+                    (trace_id, self._namespace),
+                )
+                row = await cur.fetchone()
+        return self._row_to_trace(row) if row is not None else None
+
+    async def list_traces(
+        self,
+        *,
+        entity_path: str | None = None,
+        agent_id: str | None = None,
+        outcome_type: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> list[DecisionTrace]:
+        where, params = PostgresAdapter._trace_conditions(
+            self._namespace,
+            entity_path=entity_path,
+            agent_id=agent_id,
+            outcome_type=outcome_type,
+            since=since,
+            until=until,
+            cursor=cursor,
+        )
+        sql = f"""
+            SELECT {PostgresAdapter._TRACE_COLUMNS}
+            FROM amfs_decision_traces
+            WHERE {where}
+            ORDER BY created_at DESC, id DESC
+            LIMIT %s
+        """
+        params.append(limit)
+        if not cursor and offset > 0:
+            sql += " OFFSET %s"
+            params.append(offset)
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(sql, params)
+                rows = await cur.fetchall()
+        return [self._row_to_trace(r) for r in rows]
+
+    async def count_traces(
+        self,
+        *,
+        entity_path: str | None = None,
+        agent_id: str | None = None,
+        outcome_type: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> int:
+        where, params = PostgresAdapter._trace_conditions(
+            self._namespace,
+            entity_path=entity_path,
+            agent_id=agent_id,
+            outcome_type=outcome_type,
+            since=since,
+            until=until,
+        )
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    f"SELECT count(*) AS cnt FROM amfs_decision_traces WHERE {where}", params
+                )
+                row = await cur.fetchone()
+        return int(row["cnt"]) if row else 0
+
+    async def trace_read_counts(self, agent_id: str) -> dict[str, dict[str, int]]:
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    PostgresAdapter._TRACE_READ_COUNTS_SQL, (self._namespace, agent_id)
+                )
+                rows = await cur.fetchall()
+        return PostgresAdapter._read_counts_from_rows(rows)
+
+    async def list_entries_for_agent(
+        self,
+        agent_id: str,
+        *,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        cursor: str | None = None,
+        limit: int = 100,
+        exclude_prefixes: tuple[str, ...] = ("_system/",),
+    ) -> list[MemoryEntry]:
+        where, params = PostgresAdapter._entries_for_agent_conditions(
+            self._namespace,
+            agent_id,
+            since=since,
+            until=until,
+            cursor=cursor,
+            exclude_prefixes=exclude_prefixes,
+        )
+        sql = f"""
+            SELECT * FROM amfs_memory_entries
+            WHERE {where}
+            {PostgresAdapter._ENTRIES_FOR_AGENT_ORDER}
+            LIMIT %s
+        """
+        params.append(limit)
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(sql, params)
+                rows = await cur.fetchall()
+        return [self._row_to_entry(r) for r in rows]
+
+    async def list_events(
+        self,
+        agent_id: str,
+        namespace: str = "default",
+        *,
+        branch: str | None = None,
+        event_type: str | None = None,
+        since: datetime | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        until: datetime | None = None,
+    ) -> list[Event]:
+        where, params = PostgresAdapter._event_conditions(
+            namespace,
+            agent_id,
+            account_id=self._get_current_account_id(),
+            branch=branch,
+            event_type=event_type,
+            since=since,
+            until=until,
+            cursor=cursor,
+        )
+        sql = f"""
+            SELECT id, namespace, agent_id, branch, event_type,
+                   summary, details, actor_agent_id, created_at
+            FROM amfs_events
+            WHERE {where}
+            ORDER BY created_at DESC, id DESC
+            LIMIT %s
+        """
+        params.append(limit)
+        if not cursor and offset > 0:
+            sql += " OFFSET %s"
+            params.append(offset)
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(sql, params)
+                rows = await cur.fetchall()
+        return [PostgresAdapter._row_to_event(r) for r in rows]
 
     # ──────────────────────────────────────────────────────────────
     # 8. increment_recall_count

--- a/packages/adapters/postgres/src/amfs_postgres/retention.py
+++ b/packages/adapters/postgres/src/amfs_postgres/retention.py
@@ -1,0 +1,93 @@
+"""Operator entry point for decision-trace retention.
+
+Nothing schedules retention on its own; run this from a cron job, a Kubernetes
+CronJob or by hand::
+
+    python -m amfs_postgres.retention --hot-days 30
+    python -m amfs_postgres.retention --hot-days 30 --drop-after-days 365
+    python -m amfs_postgres.retention --ensure-partitions --dry-run
+
+The DSN comes from ``--dsn`` or ``AMFS_POSTGRES_DSN``; the namespace from
+``--namespace`` or ``AMFS_NAMESPACE``. See
+:meth:`amfs_postgres.adapter.PostgresAdapter.apply_trace_retention` for what
+each tier does and the row-level-security caveat.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m amfs_postgres.retention",
+        description="Strip old decision-trace payloads and drop old partitions.",
+    )
+    parser.add_argument("--dsn", default=os.environ.get("AMFS_POSTGRES_DSN"))
+    parser.add_argument("--namespace", default=os.environ.get("AMFS_NAMESPACE", "default"))
+    parser.add_argument(
+        "--hot-days", type=int, default=30,
+        help="Traces older than this lose task_input, response_text, tool_calls, "
+             "query_events and error_events (default 30).",
+    )
+    parser.add_argument(
+        "--no-strip", action="store_true",
+        help="Do not strip payloads; only drop partitions if --drop-after-days is set.",
+    )
+    parser.add_argument(
+        "--drop-after-days", type=int, default=None,
+        help="Drop whole monthly partitions older than this many days. Off by default; "
+             "a partition holds every namespace's traces for its month.",
+    )
+    parser.add_argument(
+        "--ensure-partitions", action="store_true",
+        help="Also create partitions for the current month and the next two.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print what would run and exit without touching the database.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    if not args.dsn:
+        parser.error("--dsn or AMFS_POSTGRES_DSN is required")
+
+    plan = {
+        "namespace": args.namespace,
+        "hot_days": args.hot_days,
+        "strip_payloads": not args.no_strip,
+        "drop_after_days": args.drop_after_days,
+        "ensure_partitions": args.ensure_partitions,
+    }
+    if args.dry_run:
+        print(json.dumps({"dry_run": True, **plan}, indent=2))
+        return 0
+
+    from amfs_postgres.adapter import PostgresAdapter
+
+    adapter = PostgresAdapter(args.dsn, namespace=args.namespace, auto_schema=False)
+    try:
+        result: dict = {}
+        if args.ensure_partitions:
+            result["partitions_created"] = adapter.ensure_trace_partitions()
+        result.update(
+            adapter.apply_trace_retention(
+                hot_days=args.hot_days,
+                strip_payloads=not args.no_strip,
+                drop_after_days=args.drop_after_days,
+            )
+        )
+        print(json.dumps(result, indent=2, default=str))
+    finally:
+        adapter.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/adapters/postgres/src/amfs_postgres/schema.sql
+++ b/packages/adapters/postgres/src/amfs_postgres/schema.sql
@@ -50,8 +50,19 @@ CREATE TABLE IF NOT EXISTS amfs_outcomes (
     account_id UUID
 );
 
+-- Range-partitioned by month on created_at. Traces are append-only and read by
+-- recency, so a page of recent traces touches one or two partitions, retention
+-- drops a month instead of deleting rows, and payload stripping runs per
+-- partition. The primary key carries created_at because a partitioned table's
+-- key must include the partition column; id is still unique per row and
+-- get_trace(id) still resolves by id alone.
+--
+-- Databases created before this was partitioned are rebuilt in place by
+-- _apply_migrations (see trace_partitions.migrate_to_partitioned). Monthly
+-- partitions are created by ensure_partitions at adapter start; the DEFAULT
+-- partition below catches anything created_at outside them.
 CREATE TABLE IF NOT EXISTS amfs_decision_traces (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    id UUID NOT NULL DEFAULT gen_random_uuid(),
     namespace TEXT NOT NULL,
     agent_id TEXT NOT NULL,
     session_id TEXT NOT NULL,
@@ -69,14 +80,41 @@ CREATE TABLE IF NOT EXISTS amfs_decision_traces (
     session_started_at TIMESTAMPTZ,
     session_ended_at TIMESTAMPTZ,
     session_duration_ms NUMERIC,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (id, created_at)
+) PARTITION BY RANGE (created_at);
+
+-- Guarded so this file stays runnable against a database whose traces table
+-- is still flat and about to be rebuilt by _apply_migrations: PARTITION OF a
+-- non-partitioned table is an error, not a no-op.
+DO $$ BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relname = 'amfs_decision_traces' AND c.relkind = 'p'
+          AND n.nspname = ANY (current_schemas(false))
+    ) THEN
+        CREATE TABLE IF NOT EXISTS amfs_decision_traces_default
+            PARTITION OF amfs_decision_traces DEFAULT;
+    END IF;
+END $$;
 
 CREATE INDEX IF NOT EXISTS idx_traces_namespace
     ON amfs_decision_traces (namespace, created_at DESC);
 
 CREATE INDEX IF NOT EXISTS idx_traces_agent
     ON amfs_decision_traces (namespace, agent_id);
+
+-- Keyset pages per agent: ORDER BY created_at DESC, id DESC under an agent
+-- filter is answered by this index alone.
+CREATE INDEX IF NOT EXISTS idx_traces_agent_created
+    ON amfs_decision_traces (namespace, agent_id, created_at DESC, id DESC);
+
+-- Serves the entity_path filter, causal_entries @> '[{"entity_path": ...}]'.
+-- jsonb_path_ops supports only containment, which is the only operator used,
+-- and is smaller and faster for it than the default opclass.
+CREATE INDEX IF NOT EXISTS idx_traces_causal_entries_gin
+    ON amfs_decision_traces USING gin (causal_entries jsonb_path_ops);
 
 CREATE INDEX IF NOT EXISTS idx_traces_outcome
     ON amfs_decision_traces (namespace, outcome_type)

--- a/packages/adapters/postgres/src/amfs_postgres/trace_partitions.py
+++ b/packages/adapters/postgres/src/amfs_postgres/trace_partitions.py
@@ -1,0 +1,669 @@
+"""Monthly range partitioning and retention for ``amfs_decision_traces``.
+
+Traces are append-only and queried almost entirely by recency, which is the
+shape range partitioning on ``created_at`` was made for: a page of recent
+traces touches one or two partitions instead of an index over the whole
+history, retention becomes ``DROP TABLE`` on a month instead of a
+``DELETE`` that bloats the table it is meant to shrink, and payload stripping
+runs one partition at a time rather than as a single table-wide ``UPDATE``.
+
+Three entry points, all taking a cursor on an *autocommit* connection (the
+adapter's maintenance checkout) because each manages its own transactions:
+
+- :func:`migrate_to_partitioned` turns a flat table into a partitioned one,
+  once, in a single transaction. Idempotent: a partitioned table is left alone.
+- :func:`ensure_partitions` creates the partitions for the current month and
+  the next few, so inserts never have to fall back to the DEFAULT partition.
+  Cheap enough to run on every adapter start.
+- :func:`apply_retention` strips captured payloads from traces past the hot
+  window and optionally drops partitions past a longer one. Nothing schedules
+  it; the adapter exposes it and an operator or a job calls it.
+
+Why copy rather than attach
+---------------------------
+The migration builds the partitioned parent beside the old table, copies the
+rows into it, and drops the old table — instead of attaching the old table as
+the DEFAULT partition, which would avoid the copy. Attaching was rejected
+because it leaves every existing row in the default partition forever:
+Postgres refuses to create a monthly partition for any range the default
+partition already holds rows in, so the current month could never get its own
+partition without moving rows anyway, and every query would keep scanning one
+large unpruned child. Copying yields real monthly partitions from the first
+day, and it costs one ``INSERT ... SELECT`` over a table the plan sizes at
+thousands of rows per tenant. The whole thing is one transaction, so a failure
+at any step leaves the flat table exactly as it was.
+
+Rolling back after the fact is a plain table rebuild, because the parent has
+the same columns in the same order::
+
+    BEGIN;
+    CREATE TABLE amfs_decision_traces_flat (LIKE amfs_decision_traces
+        INCLUDING DEFAULTS INCLUDING CONSTRAINTS);
+    INSERT INTO amfs_decision_traces_flat SELECT * FROM amfs_decision_traces;
+    ALTER TABLE amfs_decision_traces_flat ADD PRIMARY KEY (id);
+    DROP TABLE amfs_decision_traces;
+    ALTER TABLE amfs_decision_traces_flat RENAME TO amfs_decision_traces;
+    COMMIT;
+
+followed by recreating the indexes in ``schema.sql`` and any policies.
+
+Primary key
+-----------
+A partitioned table's primary key must include the partition column, so the
+key becomes ``(id, created_at)``. ``id`` is still a uuid generated per row and
+``get_trace(id)`` still resolves by id alone; the lookup probes the id index of
+each partition rather than one index, which at a few dozen partitions is a
+handful of index probes.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+TABLE = "amfs_decision_traces"
+LEGACY_TABLE = "amfs_decision_traces_legacy"
+DEFAULT_PARTITION = "amfs_decision_traces_default"
+
+_PARTITION_NAME_RE = re.compile(rf"^{TABLE}_y(\d{{4}})m(\d{{2}})$")
+
+_PAYLOAD_COLUMNS_NONNULL = ("task_input", "response_text")
+_PAYLOAD_COLUMNS_JSON_ARRAY = ("tool_calls", "query_events", "error_events")
+
+
+def partition_name(year: int, month: int) -> str:
+    return f"{TABLE}_y{year:04d}m{month:02d}"
+
+
+def month_start(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    dt = dt.astimezone(UTC)
+    return dt.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+def next_month(dt: datetime) -> datetime:
+    start = month_start(dt)
+    if start.month == 12:
+        return start.replace(year=start.year + 1, month=1)
+    return start.replace(month=start.month + 1)
+
+
+def partition_bounds(name: str) -> tuple[datetime, datetime] | None:
+    """``(start, end)`` for a partition we named, or None for anything else."""
+    m = _PARTITION_NAME_RE.match(name)
+    if not m:
+        return None
+    start = datetime(int(m.group(1)), int(m.group(2)), 1, tzinfo=UTC)
+    return start, next_month(start)
+
+
+def _relkind(cur: Any, table: str) -> str | None:
+    cur.execute(
+        """
+        SELECT c.relkind
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relname = %s AND n.nspname = ANY (current_schemas(false))
+        """,
+        (table,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    kind = row["relkind"] if isinstance(row, dict) else row[0]
+    return kind if isinstance(kind, str) else kind.decode()
+
+
+def is_partitioned(cur: Any) -> bool:
+    return _relkind(cur, TABLE) == "p"
+
+
+def list_partitions(cur: Any) -> list[str]:
+    cur.execute(
+        """
+        SELECT c.relname
+        FROM pg_catalog.pg_inherits i
+        JOIN pg_catalog.pg_class c ON c.oid = i.inhrelid
+        WHERE i.inhparent = %s::regclass
+        ORDER BY c.relname
+        """,
+        (TABLE,),
+    )
+    return [r["relname"] if isinstance(r, dict) else r[0] for r in cur.fetchall()]
+
+
+def _one(row: Any, key: str, idx: int = 0) -> Any:
+    return row[key] if isinstance(row, dict) else row[idx]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Migration
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _external_dependents(cur: Any) -> list[str]:
+    """Objects that would stop the flat table from being dropped.
+
+    Foreign keys from other tables and views over this one both follow the
+    table through a rename and then block the drop; worse, a foreign key to a
+    partitioned table must reference the whole partition key, which an
+    existing ``REFERENCES amfs_decision_traces(id)`` cannot. When any exist the
+    migration is skipped and reported rather than attempted and rolled back
+    on every start.
+    """
+    cur.execute(
+        """
+        SELECT conrelid::regclass::text AS dep
+        FROM pg_catalog.pg_constraint
+        WHERE contype = 'f' AND confrelid = %s::regclass
+        UNION ALL
+        SELECT DISTINCT dependent.relname::text
+        FROM pg_catalog.pg_depend d
+        JOIN pg_catalog.pg_rewrite r ON r.oid = d.objid
+        JOIN pg_catalog.pg_class dependent ON dependent.oid = r.ev_class
+        WHERE d.refobjid = %s::regclass
+          AND d.refclassid = 'pg_class'::regclass
+          AND dependent.oid <> %s::regclass
+        """,
+        (TABLE, TABLE, TABLE),
+    )
+    return [_one(r, "dep") for r in cur.fetchall()]
+
+
+def _capture_extras(cur: Any, table: str) -> dict[str, Any]:
+    """Everything attached to the table that ``CREATE TABLE ... LIKE`` does not copy.
+
+    Policies, the row-security flags, triggers, grants, owner and indexes all
+    live on the *relation*, so they would follow the old table into the drop.
+    They are read here and replayed onto the parent inside the same
+    transaction. Policies matter most: the hosted deployment scopes tenants
+    with row-level security, and a parent without them would answer every
+    tenant's query with every tenant's rows.
+    """
+    cur.execute(
+        """
+        SELECT policyname, permissive, roles, cmd, qual, with_check
+        FROM pg_catalog.pg_policies
+        WHERE tablename = %s
+        """,
+        (table,),
+    )
+    policies = [dict(r) if isinstance(r, dict) else r for r in cur.fetchall()]
+
+    cur.execute(
+        "SELECT relrowsecurity, relforcerowsecurity "
+        "FROM pg_catalog.pg_class WHERE oid = %s::regclass",
+        (table,),
+    )
+    flags = cur.fetchone()
+
+    cur.execute(
+        """
+        SELECT tgname, pg_get_triggerdef(oid) AS def
+        FROM pg_catalog.pg_trigger
+        WHERE tgrelid = %s::regclass AND NOT tgisinternal
+        """,
+        (table,),
+    )
+    triggers = [_one(r, "def", 1) for r in cur.fetchall()]
+
+    cur.execute(
+        """
+        SELECT grantee, privilege_type, is_grantable
+        FROM information_schema.role_table_grants
+        WHERE table_name = %s AND grantee <> current_user
+        """,
+        (table,),
+    )
+    grants = [dict(r) if isinstance(r, dict) else r for r in cur.fetchall()]
+
+    cur.execute("SELECT tableowner FROM pg_catalog.pg_tables WHERE tablename = %s", (table,))
+    owner_row = cur.fetchone()
+
+    cur.execute(
+        """
+        SELECT i.indexname, i.indexdef, x.indisunique, x.indisprimary
+        FROM pg_catalog.pg_indexes i
+        JOIN pg_catalog.pg_class c ON c.relname = i.indexname
+        JOIN pg_catalog.pg_index x ON x.indexrelid = c.oid
+        WHERE i.tablename = %s
+        """,
+        (table,),
+    )
+    indexes = [dict(r) if isinstance(r, dict) else r for r in cur.fetchall()]
+
+    return {
+        "policies": policies,
+        "rls": bool(_one(flags, "relrowsecurity")) if flags else False,
+        "force_rls": bool(_one(flags, "relforcerowsecurity", 1)) if flags else False,
+        "triggers": triggers,
+        "grants": grants,
+        "owner": _one(owner_row, "tableowner") if owner_row else None,
+        "indexes": indexes,
+    }
+
+
+def _quote_ident(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+def _role_list(roles: Any) -> str:
+    names = list(roles) if roles is not None else []
+    if not names:
+        return "PUBLIC"
+    out = []
+    for r in names:
+        r = str(r)
+        if r.lower() in ("public", "current_user", "session_user"):
+            out.append(r.upper())
+        else:
+            out.append(_quote_ident(r))
+    return ", ".join(out)
+
+
+def _replay_extras(cur: Any, extras: dict[str, Any], new: str) -> None:
+    """Recreate what :func:`_capture_extras` read, on the new parent.
+
+    The definitions were captured before the rename, so they already name
+    ``amfs_decision_traces`` — the name the parent now holds.
+    """
+    for idx in extras["indexes"]:
+        if idx["indisprimary"]:
+            continue  # replaced by PRIMARY KEY (id, created_at)
+        definition: str = idx["indexdef"]
+        if idx["indisunique"] and "created_at" not in definition:
+            logger.warning(
+                "trace partitioning: unique index %s cannot exist on a partitioned "
+                "table without created_at — not recreated",
+                idx["indexname"],
+            )
+            continue
+        definition = re.sub(
+            r"^CREATE (UNIQUE )?INDEX (?!IF NOT EXISTS)",
+            lambda m: f"CREATE {m.group(1) or ''}INDEX IF NOT EXISTS ",
+            definition,
+        )
+        cur.execute(definition)
+
+    for trig in extras["triggers"]:
+        cur.execute(trig)
+
+    for pol in extras["policies"]:
+        is_permissive = str(pol["permissive"]).upper().startswith("PERM")
+        permissive = "PERMISSIVE" if is_permissive else "RESTRICTIVE"
+        parts = [
+            f"CREATE POLICY {_quote_ident(pol['policyname'])} ON {new}",
+            f"AS {permissive}",
+            f"FOR {pol['cmd'] or 'ALL'}",
+            f"TO {_role_list(pol['roles'])}",
+        ]
+        if pol.get("qual"):
+            parts.append(f"USING ({pol['qual']})")
+        if pol.get("with_check"):
+            parts.append(f"WITH CHECK ({pol['with_check']})")
+        cur.execute(" ".join(parts))
+
+    if extras["rls"]:
+        cur.execute(f"ALTER TABLE {new} ENABLE ROW LEVEL SECURITY")
+    if extras["force_rls"]:
+        cur.execute(f"ALTER TABLE {new} FORCE ROW LEVEL SECURITY")
+
+    # Grants and ownership are best-effort: a role that can rebuild the table
+    # is not necessarily one that can grant to, or hand it to, another role.
+    # A savepoint keeps a refusal here from undoing the migration.
+    for g in extras["grants"]:
+        grantee = g["grantee"]
+        target = "PUBLIC" if str(grantee).upper() == "PUBLIC" else _quote_ident(str(grantee))
+        suffix = " WITH GRANT OPTION" if str(g.get("is_grantable", "NO")).upper() == "YES" else ""
+        cur.execute("SAVEPOINT amfs_grant")
+        try:
+            cur.execute(f"GRANT {g['privilege_type']} ON {new} TO {target}{suffix}")
+            cur.execute("RELEASE SAVEPOINT amfs_grant")
+        except Exception as exc:  # noqa: BLE001
+            cur.execute("ROLLBACK TO SAVEPOINT amfs_grant")
+            logger.warning("trace partitioning: could not replay grant to %s: %s", grantee, exc)
+
+    owner = extras.get("owner")
+    if owner:
+        cur.execute("SAVEPOINT amfs_owner")
+        try:
+            cur.execute(f"ALTER TABLE {new} OWNER TO {_quote_ident(owner)}")
+            cur.execute("RELEASE SAVEPOINT amfs_owner")
+        except Exception as exc:  # noqa: BLE001
+            cur.execute("ROLLBACK TO SAVEPOINT amfs_owner")
+            logger.warning("trace partitioning: could not set owner %s: %s", owner, exc)
+
+
+def _months_between(first: datetime, last: datetime) -> list[datetime]:
+    months: list[datetime] = []
+    m = month_start(first)
+    stop = month_start(last)
+    while m <= stop:
+        months.append(m)
+        m = next_month(m)
+    return months
+
+
+def _create_partition_sql(name: str, start: datetime, end: datetime) -> str:
+    return (
+        f"CREATE TABLE IF NOT EXISTS {name} PARTITION OF {TABLE} "
+        f"FOR VALUES FROM ('{start.isoformat()}') TO ('{end.isoformat()}')"
+    )
+
+
+def migrate_to_partitioned(cur: Any, *, months_ahead: int = 2, now: datetime | None = None) -> bool:
+    """Convert a flat ``amfs_decision_traces`` into a partitioned one, once.
+
+    Returns True when the table is partitioned on return — whether it already
+    was or this call did it — or when partitioning is deliberately skipped for
+    a permanent reason (foreign keys or views over the table), so the caller
+    records the schema as applied and does not retry on every start. Raises on
+    a transient failure after rolling back, so the caller can leave the schema
+    marker unset and try again next start.
+    """
+    kind = _relkind(cur, TABLE)
+    if kind is None:
+        return False
+    if kind == "p":
+        return True
+    if kind != "r":
+        logger.warning("trace partitioning: %s has relkind %r — leaving it alone", TABLE, kind)
+        return True
+
+    dependents = _external_dependents(cur)
+    if dependents:
+        logger.error(
+            "trace partitioning: %s has dependents %s (foreign keys or views) — "
+            "cannot be partitioned in place; leaving the flat table. Remove or "
+            "recreate the dependents against (id, created_at) and restart.",
+            TABLE, dependents,
+        )
+        return True
+
+    now = now or datetime.now(UTC)
+    try:
+        cur.execute("BEGIN")
+        extras = _capture_extras(cur, TABLE)
+
+        cur.execute(f"ALTER TABLE {TABLE} RENAME TO {LEGACY_TABLE}")
+        # Index names are schema-wide: the new primary key wants the name the
+        # old one holds, and the schema.sql indexes are recreated under their
+        # own names after the drop below.
+        cur.execute(f"ALTER INDEX IF EXISTS {TABLE}_pkey RENAME TO {LEGACY_TABLE}_pkey")
+        # The copy has to see every row. Under FORCE ROW LEVEL SECURITY a
+        # maintenance connection with no tenant sees none, and would copy an
+        # empty table and drop the full one; disabling RLS on the doomed table
+        # is what makes the count check below meaningful. Only the owner may
+        # do this, and a role that is not the owner fails here, rolls back, and
+        # leaves the flat table in place.
+        cur.execute(f"ALTER TABLE {LEGACY_TABLE} DISABLE ROW LEVEL SECURITY")
+
+        cur.execute(
+            f"""
+            CREATE TABLE {TABLE} (
+                LIKE {LEGACY_TABLE} INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING GENERATED,
+                PRIMARY KEY (id, created_at)
+            ) PARTITION BY RANGE (created_at)
+            """
+        )
+        cur.execute(f"CREATE TABLE {DEFAULT_PARTITION} PARTITION OF {TABLE} DEFAULT")
+
+        cur.execute(
+            f"SELECT min(created_at) AS lo, max(created_at) AS hi, count(*) AS n "
+            f"FROM {LEGACY_TABLE}"
+        )
+        span = cur.fetchone()
+        lo, hi, legacy_count = _one(span, "lo", 0), _one(span, "hi", 1), int(_one(span, "n", 2))
+
+        wanted: dict[str, tuple[datetime, datetime]] = {}
+        horizon = month_start(now)
+        for _ in range(months_ahead):
+            horizon = next_month(horizon)
+        for m in _months_between(lo or now, max(hi or now, horizon)):
+            wanted[partition_name(m.year, m.month)] = (m, next_month(m))
+        for name, (start, end) in wanted.items():
+            cur.execute(_create_partition_sql(name, start, end))
+
+        cur.execute(f"INSERT INTO {TABLE} SELECT * FROM {LEGACY_TABLE}")
+        cur.execute(f"SELECT count(*) AS n FROM {TABLE}")
+        copied = int(_one(cur.fetchone(), "n"))
+        if copied != legacy_count:
+            raise RuntimeError(
+                f"trace partitioning: copied {copied} rows but the flat table held "
+                f"{legacy_count}; refusing to drop it"
+            )
+
+        cur.execute(f"DROP TABLE {LEGACY_TABLE}")
+        _replay_extras(cur, extras, TABLE)
+        cur.execute("COMMIT")
+    except Exception:
+        try:
+            cur.execute("ROLLBACK")
+        except Exception:  # noqa: BLE001
+            pass
+        logger.exception("trace partitioning: migration rolled back; flat table left in place")
+        raise
+
+    logger.info(
+        "trace partitioning: %s is now range-partitioned by month (%d rows moved, %d partitions)",
+        TABLE, legacy_count, len(wanted),
+    )
+    return True
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Partition upkeep
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _default_partition_months(cur: Any) -> list[datetime]:
+    """Months for which the DEFAULT partition is holding rows.
+
+    Rows land there only when no partition covered their ``created_at`` — a
+    backdated trace, or a deployment that was not restarted for longer than
+    the partitions created ahead. Each such month is given a partition of its
+    own by :func:`ensure_partitions`.
+    """
+    cur.execute(
+        f"""
+        SELECT DISTINCT date_trunc('month', created_at AT TIME ZONE 'UTC') AS m
+        FROM {DEFAULT_PARTITION}
+        """
+    )
+    months = []
+    for r in cur.fetchall():
+        m = _one(r, "m")
+        if m is None:
+            continue
+        if m.tzinfo is None:
+            m = m.replace(tzinfo=UTC)
+        months.append(month_start(m))
+    return months
+
+
+def _create_partition(cur: Any, name: str, start: datetime, end: datetime) -> None:
+    """Create one monthly partition, moving any rows the default partition holds for it.
+
+    Postgres refuses ``CREATE TABLE ... PARTITION OF`` for a range the default
+    partition has rows in, so those rows are moved into a standalone table
+    first and the table attached afterwards, all in one transaction.
+    """
+    cur.execute("BEGIN")
+    try:
+        cur.execute(
+            f"SELECT 1 FROM {DEFAULT_PARTITION} WHERE created_at >= %s AND created_at < %s LIMIT 1",
+            (start, end),
+        )
+        if cur.fetchone() is None:
+            cur.execute(_create_partition_sql(name, start, end))
+        else:
+            cur.execute(
+                f"CREATE TABLE {name} (LIKE {TABLE} INCLUDING DEFAULTS INCLUDING CONSTRAINTS)"
+            )
+            cur.execute(
+                f"INSERT INTO {name} SELECT * FROM {DEFAULT_PARTITION} "
+                f"WHERE created_at >= %s AND created_at < %s",
+                (start, end),
+            )
+            cur.execute(
+                f"DELETE FROM {DEFAULT_PARTITION} WHERE created_at >= %s AND created_at < %s",
+                (start, end),
+            )
+            cur.execute(
+                f"ALTER TABLE {TABLE} ATTACH PARTITION {name} "
+                f"FOR VALUES FROM ('{start.isoformat()}') TO ('{end.isoformat()}')"
+            )
+        cur.execute("COMMIT")
+    except Exception:
+        try:
+            cur.execute("ROLLBACK")
+        except Exception:  # noqa: BLE001
+            pass
+        raise
+
+
+def ensure_partitions(cur: Any, *, months_ahead: int = 2, now: datetime | None = None) -> list[str]:
+    """Create partitions for this month and *months_ahead* more. Returns the names created.
+
+    A no-op on a table that is not partitioned. Also gives a partition to any
+    month the DEFAULT partition is holding rows for, so the default partition
+    stays empty and every query can prune.
+    """
+    if not is_partitioned(cur):
+        return []
+    existing = set(list_partitions(cur))
+    now = now or datetime.now(UTC)
+
+    wanted: dict[str, tuple[datetime, datetime]] = {}
+    m = month_start(now)
+    for _ in range(months_ahead + 1):
+        wanted[partition_name(m.year, m.month)] = (m, next_month(m))
+        m = next_month(m)
+    if DEFAULT_PARTITION in existing:
+        for m in _default_partition_months(cur):
+            wanted.setdefault(partition_name(m.year, m.month), (m, next_month(m)))
+    else:
+        cur.execute(f"CREATE TABLE IF NOT EXISTS {DEFAULT_PARTITION} PARTITION OF {TABLE} DEFAULT")
+
+    created: list[str] = []
+    for name, (start, end) in sorted(wanted.items()):
+        if name in existing:
+            continue
+        _create_partition(cur, name, start, end)
+        created.append(name)
+    if created:
+        logger.info("trace partitioning: created %s", ", ".join(created))
+    return created
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Retention
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _strip_sql(target: str, *, bounded: bool) -> str:
+    sets = ", ".join(
+        [f"{c} = NULL" for c in _PAYLOAD_COLUMNS_NONNULL]
+        + [f"{c} = '[]'::jsonb" for c in _PAYLOAD_COLUMNS_JSON_ARRAY]
+    )
+    has_payload = " OR ".join(
+        [f"{c} IS NOT NULL" for c in _PAYLOAD_COLUMNS_NONNULL]
+        + [f"{c} <> '[]'::jsonb" for c in _PAYLOAD_COLUMNS_JSON_ARRAY]
+    )
+    where = f"namespace = %s AND ({has_payload})"
+    if bounded:
+        where += " AND created_at < %s"
+    return f"UPDATE {target} SET {sets} WHERE {where}"
+
+
+def apply_retention(
+    cur: Any,
+    *,
+    namespace: str,
+    hot_days: int = 30,
+    strip_payloads: bool = True,
+    drop_after_days: int | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Age traces out in two tiers.
+
+    Past *hot_days*, the captured payload — ``task_input``, ``response_text``,
+    ``tool_calls``, ``query_events``, ``error_events`` — is cleared while the
+    trace itself, its ``causal_entries``, contexts, state diff and metadata
+    stay, so explainability survives and only the bulk goes. Past
+    *drop_after_days*, whole monthly partitions are dropped.
+
+    Stripping is scoped to *namespace* and runs one partition at a time so no
+    single statement touches the whole table. Dropping a partition is not
+    scoped — a partition holds every namespace's traces for that month — which
+    is why it is off unless asked for. On an unpartitioned table stripping
+    still works as one bounded ``UPDATE`` and nothing is dropped.
+    """
+    now = now or datetime.now(UTC)
+    hot_cutoff = now - timedelta(days=hot_days)
+    drop_cutoff = now - timedelta(days=drop_after_days) if drop_after_days is not None else None
+    result: dict[str, Any] = {
+        "stripped_rows": 0,
+        "dropped_partitions": [],
+        "hot_cutoff": hot_cutoff.isoformat(),
+        "drop_cutoff": drop_cutoff.isoformat() if drop_cutoff else None,
+    }
+
+    if not is_partitioned(cur):
+        if strip_payloads:
+            cur.execute(_strip_sql(TABLE, bounded=True), (namespace, hot_cutoff))
+            result["stripped_rows"] = max(cur.rowcount, 0)
+        return result
+
+    partitions = list_partitions(cur)
+
+    if drop_cutoff is not None:
+        for name in partitions:
+            bounds = partition_bounds(name)
+            if bounds is None:
+                continue
+            _, end = bounds
+            if end <= drop_cutoff:
+                cur.execute(f"DROP TABLE IF EXISTS {name}")
+                result["dropped_partitions"].append(name)
+        partitions = [p for p in partitions if p not in result["dropped_partitions"]]
+
+    if strip_payloads:
+        for name in partitions:
+            bounds = partition_bounds(name)
+            if bounds is not None:
+                start, end = bounds
+                if start >= hot_cutoff:
+                    continue
+                if end <= hot_cutoff:
+                    cur.execute(_strip_sql(name, bounded=False), (namespace,))
+                else:
+                    cur.execute(_strip_sql(name, bounded=True), (namespace, hot_cutoff))
+            elif name == DEFAULT_PARTITION:
+                cur.execute(_strip_sql(name, bounded=True), (namespace, hot_cutoff))
+            else:
+                continue
+            result["stripped_rows"] += max(cur.rowcount, 0)
+
+    return result
+
+
+def create_causal_entries_index(cur: Any) -> None:
+    """GIN index that serves ``causal_entries @> '[{"entity_path": ...}]'``.
+
+    ``jsonb_path_ops`` rather than the default opclass: it only supports
+    containment, which is the only operator the filter uses, and its index is
+    smaller and faster for exactly that. Works the same on a flat table and a
+    partitioned one, where it cascades to every partition.
+    """
+    cur.execute(
+        f"""
+        CREATE INDEX IF NOT EXISTS idx_traces_causal_entries_gin
+            ON {TABLE} USING gin (causal_entries jsonb_path_ops)
+        """
+    )

--- a/packages/core/src/amfs_core/abc.py
+++ b/packages/core/src/amfs_core/abc.py
@@ -116,14 +116,37 @@ class AdapterABC(ABC):
         entity_path: str | None = None,
         since: datetime | None = None,
         limit: int = 1000,
+        outcome_ref: str | None = None,
     ) -> list[OutcomeRecord]:
         """Return historical outcome records.
 
         Used by the Pro ML layer for training ranking models and calibrating
         confidence multipliers.  Default implementation returns an empty list;
         adapters that persist outcomes (e.g. Postgres) should override.
+
+        *outcome_ref* narrows to records with that reference. It exists so a
+        caller resolving one outcome does not have to page through all of
+        them to find it.
         """
         return []
+
+    def count_outcomes(
+        self,
+        *,
+        entity_path: str | None = None,
+        since: datetime | None = None,
+    ) -> int:
+        """How many outcome records match, counted where they are stored.
+
+        The default counts a bounded ``list_outcomes`` and so cannot see past
+        :func:`amfs_core.pagination.max_scan_rows`; adapters with SQL storage
+        override with ``COUNT(*)`` so the number is right at any volume.
+        """
+        from amfs_core.pagination import max_scan_rows
+
+        return len(
+            self.list_outcomes(entity_path=entity_path, since=since, limit=max_scan_rows())
+        )
 
     def read_at_version(
         self,
@@ -150,7 +173,9 @@ class AdapterABC(ABC):
         Default implementation scans ``list_traces()``; adapters with
         indexed storage (e.g. Postgres) should override for O(1) lookup.
         """
-        for t in self.list_traces(limit=10_000):
+        from amfs_core.pagination import max_scan_rows
+
+        for t in self.list_traces(limit=max_scan_rows()):
             if t.id == trace_id:
                 return t
         return None
@@ -167,9 +192,117 @@ class AdapterABC(ABC):
         agent_id: str | None = None,
         outcome_type: str | None = None,
         limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
     ) -> list[DecisionTrace]:
-        """Return persisted decision traces. Default returns an empty list."""
+        """Return persisted decision traces, newest first.
+
+        Ordering is total: ``created_at DESC, id DESC``. *cursor* is an opaque
+        keyset position from :func:`amfs_core.pagination.encode_cursor` naming
+        the last trace already seen; when given, only strictly older traces
+        are returned and *offset* is ignored. *offset* remains for callers on
+        the older contract. *since*/*until* bound ``created_at`` (inclusive
+        lower, exclusive upper) so a time-partitioned store can prune.
+
+        Callers wanting ``has_more`` ask for ``limit + 1`` rows and build the
+        page with :func:`amfs_core.pagination.page_from_overfetch`.
+
+        Every new parameter defaults to "no constraint", so adapters written
+        against the old signature keep working when called with the old
+        arguments. Default returns an empty list.
+        """
         return []
+
+    def count_traces(
+        self,
+        *,
+        entity_path: str | None = None,
+        agent_id: str | None = None,
+        outcome_type: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> int:
+        """How many traces match, counted where they are stored.
+
+        The default counts a bounded ``list_traces`` and cannot see past
+        :func:`amfs_core.pagination.max_scan_rows`; SQL adapters override
+        with ``COUNT(*)``.
+        """
+        from amfs_core.pagination import max_scan_rows
+
+        return len(
+            self.list_traces(
+                entity_path=entity_path,
+                agent_id=agent_id,
+                outcome_type=outcome_type,
+                since=since,
+                until=until,
+                limit=max_scan_rows(),
+            )
+        )
+
+    def trace_read_counts(self, agent_id: str) -> dict[str, dict[str, int]]:
+        """How often an agent's traces read each entry: ``{entity_path: {key: n}}``.
+
+        Summing every count gives the agent's total recorded reads. This is
+        the aggregate behind the memory-graph and cross-agent-read views,
+        which used to pull every trace over the wire to compute it.
+
+        The default scans a bounded ``list_traces``; SQL adapters override
+        with a JSONB unnest and ``GROUP BY`` so full traces never leave the
+        database.
+        """
+        from amfs_core.pagination import max_scan_rows
+
+        counts: dict[str, dict[str, int]] = {}
+        for t in self.list_traces(agent_id=agent_id, limit=max_scan_rows()):
+            for ce in t.causal_entries:
+                per_entity = counts.setdefault(ce.entity_path, {})
+                per_entity[ce.key] = per_entity.get(ce.key, 0) + 1
+        return counts
+
+    def list_entries_for_agent(
+        self,
+        agent_id: str,
+        *,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        cursor: str | None = None,
+        limit: int = 100,
+        exclude_prefixes: tuple[str, ...] = ("_system/",),
+    ) -> list[MemoryEntry]:
+        """Current entries written by *agent_id*, newest first, keyset-paged.
+
+        Ordering is total: ``written_at DESC, entity_path DESC, key DESC,
+        version DESC``; the cursor tiebreak is
+        :func:`amfs_core.pagination.entry_tiebreak`. *exclude_prefixes* drops
+        entity paths the activity views never show (``_system/`` by default).
+
+        The default filters ``list()`` in memory. Adapters with indexed
+        storage override so the filter, order and page happen in the query.
+        """
+        from amfs_core.pagination import entry_tiebreak, paginate_desc
+
+        def keep(e: MemoryEntry) -> bool:
+            if e.provenance.agent_id != agent_id:
+                return False
+            if any(e.entity_path.startswith(p) for p in exclude_prefixes):
+                return False
+            written = e.provenance.written_at
+            if since is not None and written < since:
+                return False
+            return not (until is not None and written >= until)
+
+        page = paginate_desc(
+            (e for e in self.list() if keep(e)),
+            timestamp=lambda e: e.provenance.written_at,
+            tiebreak=entry_tiebreak,
+            limit=limit,
+            cursor=cursor,
+        )
+        return page.items
 
     def list_traces_for_entry(
         self,
@@ -387,9 +520,10 @@ class AdapterABC(ABC):
         override with a JSONB aggregate so full traces never leave the DB.
         """
         from amfs_core.aggregates import share_stats_from_traces
+        from amfs_core.pagination import max_scan_rows
 
         return share_stats_from_traces(
-            self.list_traces(limit=10_000),
+            self.list_traces(limit=max_scan_rows()),
             since=since,
             pair_limit=pair_limit,
             agent_ids=agent_ids,
@@ -654,8 +788,18 @@ class AdapterABC(ABC):
         event_type: str | None = None,
         since: datetime | None = None,
         limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        until: datetime | None = None,
     ) -> list[Event]:
-        """Return events on an agent's timeline. Default returns empty list."""
+        """Return events on an agent's timeline, newest first.
+
+        Ordering is total: ``created_at DESC, id DESC``. *cursor* is a keyset
+        position (see :func:`amfs_core.pagination.encode_cursor`) naming the
+        last event already seen; when given, only strictly older events are
+        returned and *offset* is ignored. *until* is an exclusive upper bound
+        on ``created_at``. Default returns an empty list.
+        """
         return []
 
     def get_event(self, event_id: str, namespace: str = "default") -> Event | None:

--- a/packages/core/src/amfs_core/pagination.py
+++ b/packages/core/src/amfs_core/pagination.py
@@ -1,0 +1,195 @@
+"""Keyset pagination primitives shared by adapters and the HTTP server.
+
+A cursor names the last row a caller has already seen — its timestamp plus a
+tiebreaker that makes the ordering total — so the next page is "everything
+strictly older than this", which an index can answer directly. ``OFFSET`` has
+to walk and discard every skipped row first, which is why it degrades linearly
+with page depth; a keyset page costs the same at row 100 as at row 100,000.
+
+Cursors are opaque to callers: base64url over a small JSON document. Nothing
+in the encoding is a secret and nothing about it is stable API — a client that
+decodes one and depends on its shape has been warned here.
+
+Also home to the scan ceiling that replaced the hard-coded ``limit=10000``
+reads. Aggregates that cannot yet run in SQL still read a bounded number of
+rows; the bound is configurable and every caller reports when it was hit.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import os
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Generic, TypeVar
+
+T = TypeVar("T")
+
+#: Default ceiling for bounded scans. The historical hard-coded value, kept as
+#: the default so nothing changes for deployments that do not set the variable.
+DEFAULT_MAX_SCAN_ROWS = 10_000
+
+#: Hard upper bound on any single page, whatever the caller asks for.
+MAX_PAGE_SIZE = 1_000
+
+
+def max_scan_rows() -> int:
+    """Rows a bounded scan may read before it stops and reports truncation.
+
+    Read from ``AMFS_MAX_SCAN_ROWS`` on each call, not cached, so tests and
+    operators can change it without restarting. Anything unparseable or
+    non-positive falls back to the default rather than raising: a typo in an
+    environment variable should not take the server down.
+    """
+    raw = os.environ.get("AMFS_MAX_SCAN_ROWS", "").strip()
+    if not raw:
+        return DEFAULT_MAX_SCAN_ROWS
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_MAX_SCAN_ROWS
+    return value if value > 0 else DEFAULT_MAX_SCAN_ROWS
+
+
+def clamp_limit(limit: int | None, *, default: int = 100) -> int:
+    """A page size that is at least 1 and at most :data:`MAX_PAGE_SIZE`."""
+    if limit is None:
+        return default
+    return max(1, min(int(limit), MAX_PAGE_SIZE))
+
+
+class InvalidCursorError(ValueError):
+    """The cursor was not produced by :func:`encode_cursor`, or was corrupted."""
+
+
+def encode_cursor(timestamp: datetime, tiebreak: Any) -> str:
+    """Encode a ``(timestamp, tiebreak)`` position as an opaque string.
+
+    *tiebreak* is whatever makes the ordering total for the row set in
+    question — a row id for traces and events, a ``[entity_path, key, version]``
+    triple for entries. It must be JSON-serialisable and must compare the same
+    way in Python as in SQL for the adapter that issued it.
+    """
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=UTC)
+    payload = json.dumps(
+        {"t": timestamp.isoformat(), "k": tiebreak},
+        separators=(",", ":"),
+        default=str,
+    )
+    return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def decode_cursor(cursor: str) -> tuple[datetime, Any]:
+    """Invert :func:`encode_cursor`.
+
+    Raises :class:`InvalidCursorError` for anything that is not one of ours.
+    The HTTP layer turns that into a 400; adapters let it propagate.
+    """
+    if not isinstance(cursor, str) or not cursor:
+        raise InvalidCursorError("empty cursor")
+    padded = cursor + "=" * (-len(cursor) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(padded.encode("ascii"))
+        doc = json.loads(raw.decode("utf-8"))
+    except (binascii.Error, UnicodeDecodeError, UnicodeEncodeError, json.JSONDecodeError) as exc:
+        raise InvalidCursorError("malformed cursor") from exc
+    if not isinstance(doc, dict) or "t" not in doc or "k" not in doc:
+        raise InvalidCursorError("malformed cursor")
+    try:
+        ts = datetime.fromisoformat(doc["t"])
+    except (TypeError, ValueError) as exc:
+        raise InvalidCursorError("malformed cursor timestamp") from exc
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return ts, doc["k"]
+
+
+@dataclass
+class Page(Generic[T]):
+    """One page of results plus what a caller needs to ask for the next."""
+
+    items: list[T]
+    next_cursor: str | None
+    has_more: bool
+    #: True when a bounded scan stopped before seeing every candidate row, so
+    #: the page (or aggregate built from it) may be incomplete.
+    truncated: bool = False
+
+
+def _as_key(ts: datetime, tiebreak: Any) -> tuple[datetime, str]:
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return ts, json.dumps(tiebreak, default=str, sort_keys=True)
+
+
+def paginate_desc(
+    items: Iterable[T],
+    *,
+    timestamp: Callable[[T], datetime],
+    tiebreak: Callable[[T], Any],
+    limit: int,
+    cursor: str | None = None,
+    offset: int = 0,
+) -> Page[T]:
+    """Keyset-paginate an in-memory iterable, newest first.
+
+    The reference implementation for adapters that cannot push the predicate
+    into a query — the filesystem adapter, the ABC defaults, tests. SQL
+    adapters do the same thing with ``(created_at, id) < (%s, %s)`` and an
+    ``ORDER BY created_at DESC, id DESC``; this is what they must agree with.
+
+    *offset* is honoured only when no cursor is given, for callers still on
+    the old ``limit``/``offset`` contract.
+    """
+    # Not clamped: callers overfetch by one to learn ``has_more``, and the
+    # clamp belongs at the HTTP boundary, before that extra row is added.
+    limit = max(1, int(limit))
+    keyed = [(_as_key(timestamp(x), tiebreak(x)), x) for x in items]
+    keyed.sort(key=lambda kv: kv[0], reverse=True)
+
+    if cursor:
+        cursor_key = _as_key(*decode_cursor(cursor))
+        keyed = [kv for kv in keyed if kv[0] < cursor_key]
+    elif offset > 0:
+        keyed = keyed[offset:]
+
+    window = keyed[: limit + 1]
+    has_more = len(window) > limit
+    window = window[:limit]
+    next_cursor = None
+    if window and has_more:
+        last = window[-1][1]
+        next_cursor = encode_cursor(timestamp(last), tiebreak(last))
+    return Page(items=[x for _, x in window], next_cursor=next_cursor, has_more=has_more)
+
+
+def page_from_overfetch(
+    rows: list[T],
+    *,
+    limit: int,
+    timestamp: Callable[[T], datetime],
+    tiebreak: Callable[[T], Any],
+) -> Page[T]:
+    """Build a page from a query that fetched ``limit + 1`` rows.
+
+    The extra row is how ``has_more`` is known without a second COUNT query;
+    it is dropped from the page. The cursor points at the last row *returned*,
+    so a caller that filters the page afterwards (visibility, for instance)
+    still resumes from the right place.
+    """
+    has_more = len(rows) > limit
+    window = rows[:limit]
+    next_cursor = None
+    if window and has_more:
+        last = window[-1]
+        next_cursor = encode_cursor(timestamp(last), tiebreak(last))
+    return Page(items=window, next_cursor=next_cursor, has_more=has_more)
+
+
+def entry_tiebreak(entry: Any) -> list[Any]:
+    """Tiebreaker for ``MemoryEntry`` rows, which carry no row id."""
+    return [entry.entity_path, entry.key, entry.version]

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -2614,6 +2614,8 @@ async def list_traces(
     limit: int = Query(100, ge=1),
     offset: int = Query(0, ge=0),
     cursor: str | None = Query(None),
+    since: datetime | None = Query(None),
+    until: datetime | None = Query(None),
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
     """Decision traces, newest first, keyset-paginated.
@@ -2622,6 +2624,10 @@ async def list_traces(
     only when no cursor is given. The page's cursor points at the last row
     read, so a caller whose visibility hides some agents still advances past
     them rather than seeing the same rows again.
+
+    ``since`` (inclusive) and ``until`` (exclusive) bound ``created_at`` in
+    the query itself, so a window that excludes the newest traces still
+    returns the older matches instead of an empty first page.
     """
     limit = clamp_limit(limit)
     page = await _list_traces_page(
@@ -2631,6 +2637,8 @@ async def list_traces(
         limit=limit,
         offset=offset,
         cursor=_check_cursor(cursor),
+        since=since,
+        until=until,
     )
     traces = page.items
     allowed = _visible_agent_ids(request)

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -23,7 +23,7 @@ import re
 import secrets
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from typing import Any
 
 import uvicorn
@@ -48,6 +48,16 @@ from amfs_core.models import (
     MemoryEntry,
     SearchQuery,
     SemanticQuery,
+)
+from amfs_core.pagination import (
+    InvalidCursorError,
+    Page,
+    clamp_limit,
+    decode_cursor,
+    encode_cursor,
+    entry_tiebreak,
+    max_scan_rows,
+    page_from_overfetch,
 )
 from amfs_core.quality import HeuristicQualityEvaluator
 
@@ -283,10 +293,13 @@ try:
 
     from amfs_traces.store import PostgresImmutableTraceStore
     from amfs_traces.crypto import seal, get_signing_key, get_signing_key_id
-    from amfs_traces.models import ImmutableDecisionTrace, TraceEntry, TraceExternalContext
-    # Aliased because the OSS ``ToolCall`` of the same name is what arrives on the
-    # trace being sealed, and the two are easy to confuse at the mapping site.
-    from amfs_traces.models import ToolCall as ProToolCall
+    # The OSS -> immutable mapping lives with the Pro package, shared with its
+    # other two seal paths, so what this server seals is what they seal. It used
+    # to be inlined here and silently dropped the fields it did not know about.
+    from amfs_traces.seal_on_demand import (
+        finalize_spans as _pro_finalize_spans,
+        immutable_from_oss_trace as _pro_immutable_from_oss_trace,
+    )
     _HAS_PRO_TRACES = True
 except ImportError:
     _HAS_PRO_TRACES = False
@@ -514,6 +527,130 @@ def _require_agent_visible(request: Request, agent_id: str) -> None:
     vis = _active_visibility_filter(request)
     if vis is not None and not vis.is_agent_visible(agent_id):
         raise HTTPException(status_code=404, detail="Agent not found")
+
+
+# ── Keyset pagination and bounded scans ─────────────────────────────────
+#
+# Paged list routes return the existing list key plus ``next_cursor`` and
+# ``has_more``, the shape the rooms endpoints already use. ``limit``/``offset``
+# keep working for callers on the old contract; a cursor, when given, wins.
+
+
+def _check_cursor(cursor: str | None) -> str | None:
+    """Reject a malformed cursor at the boundary with a 400, not a 500 later."""
+    if not cursor:
+        return None
+    try:
+        decode_cursor(cursor)
+    except InvalidCursorError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid cursor: {exc}") from exc
+    return cursor
+
+
+def _page_meta(page: Page[Any]) -> dict[str, Any]:
+    return {"next_cursor": page.next_cursor, "has_more": page.has_more}
+
+
+def _parse_ts(value: str | None) -> datetime | None:
+    """ISO-8601 query parameter to an aware datetime; naive input is taken as UTC.
+
+    Adapters compare these against stored timestamps that are always aware,
+    and a naive value would raise from inside that comparison rather than
+    here, where it can be a 400.
+    """
+    if not value:
+        return None
+    try:
+        ts = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid timestamp: {value!r}") from exc
+    return ts if ts.tzinfo is not None else ts.replace(tzinfo=UTC)
+
+
+async def _via_async_or_sync(method: str, *args: Any, **kwargs: Any) -> Any:
+    """Call *method* on the async adapter when there is one, else on the sync adapter.
+
+    The async adapter is the request path's; falling back to the sync adapter
+    is what keeps the filesystem adapter and the tests working. A failure on
+    the async side is logged and retried on the sync side so a transient
+    pool problem degrades to a blocking call rather than an error — the same
+    posture the read and search routes take.
+    """
+    if _async_adapter is not None and hasattr(_async_adapter, method):
+        try:
+            return await getattr(_async_adapter, method)(*args, **kwargs)
+        except InvalidCursorError:
+            raise
+        except Exception:
+            logger.warning("async %s failed — falling back to sync adapter", method, exc_info=True)
+    return getattr(_get_memory()._adapter, method)(*args, **kwargs)
+
+
+async def _list_traces_page(
+    *,
+    limit: int,
+    offset: int = 0,
+    cursor: str | None = None,
+    **filters: Any,
+) -> Page[DecisionTrace]:
+    """One page of traces, overfetching by one row to learn ``has_more``."""
+    rows = await _via_async_or_sync(
+        "list_traces", limit=limit + 1, offset=offset, cursor=cursor, **filters
+    )
+    return page_from_overfetch(
+        list(rows),
+        limit=limit,
+        timestamp=lambda t: t.created_at,
+        tiebreak=lambda t: t.id,
+    )
+
+
+async def _list_events_page(
+    agent_id: str,
+    namespace: str,
+    *,
+    limit: int,
+    offset: int = 0,
+    cursor: str | None = None,
+    **filters: Any,
+) -> Page[Event]:
+    rows = await _via_async_or_sync(
+        "list_events", agent_id, namespace, limit=limit + 1, offset=offset, cursor=cursor,
+        **filters,
+    )
+    return page_from_overfetch(
+        list(rows),
+        limit=limit,
+        timestamp=lambda e: e.created_at,
+        tiebreak=lambda e: e.id,
+    )
+
+
+async def _list_agent_entries_page(
+    agent_id: str,
+    *,
+    limit: int,
+    cursor: str | None = None,
+    **filters: Any,
+) -> Page[MemoryEntry]:
+    rows = await _via_async_or_sync(
+        "list_entries_for_agent", agent_id, limit=limit + 1, cursor=cursor, **filters
+    )
+    return page_from_overfetch(
+        list(rows),
+        limit=limit,
+        timestamp=lambda e: e.provenance.written_at,
+        tiebreak=entry_tiebreak,
+    )
+
+
+def _bounded_scan(items: list[Any], ceiling: int) -> tuple[list[Any], bool]:
+    """Trim a scan to *ceiling* rows and say whether anything was cut.
+
+    Callers fetch ``ceiling + 1`` so the flag is exact: a result exactly at
+    the ceiling is complete, one row past it is not.
+    """
+    return items[:ceiling], len(items) > ceiling
 
 
 def _require_account_admin(request: Request) -> None:
@@ -1856,15 +1993,20 @@ async def get_agent_profile(
         (e.provenance.written_at for e in entries),
         default=None,
     )
-    traces = mem._adapter.list_traces(agent_id=agent_id, limit=10000)
+    # Both numbers are aggregates the adapter computes where the traces live;
+    # this route used to pull up to 10,000 full traces to count them.
+    trace_count = mem._adapter.count_traces(agent_id=agent_id)
+    total_reads = sum(
+        sum(keys.values()) for keys in mem._adapter.trace_read_counts(agent_id).values()
+    )
 
     result: dict[str, Any] = {
         "agentId": agent_id,
         "entriesWritten": len(entries),
         "entitiesTouched": len(entities_touched),
         "entityPaths": sorted(entities_touched),
-        "totalReads": sum(len(t.causal_entries) for t in traces),
-        "decisionTraces": len(traces),
+        "totalReads": total_reads,
+        "decisionTraces": trace_count,
         "lastActive": last_active.isoformat() if last_active else None,
     }
 
@@ -1875,7 +2017,7 @@ async def get_agent_profile(
 
         if not profile and not capabilities and entries:
             profile, capabilities = _synthesize_agent_profile(
-                agent_id, entries, traces,
+                agent_id, entries, trace_count,
             )
 
         result["profile"] = profile.model_dump() if profile else {}
@@ -1889,7 +2031,7 @@ async def get_agent_profile(
 def _synthesize_agent_profile(
     agent_id: str,
     entries: list,
-    traces: list,
+    traces: list | int,
 ) -> tuple:
     """Build an AgentProfile and capabilities from observed activity."""
     from amfs_core.models import AgentProfile, AgentCapability, MemoryType
@@ -1916,8 +2058,10 @@ def _synthesize_agent_profile(
             f"Active across {len(entities_touched)} "
             f"entit{'y' if len(entities_touched) == 1 else 'ies'}."
         )
-    if traces:
-        desc_parts.append(f"{len(traces)} decision trace(s) recorded.")
+    # Callers pass the count; a list is still accepted for older call sites.
+    trace_count = traces if isinstance(traces, int) else len(traces)
+    if trace_count:
+        desc_parts.append(f"{trace_count} decision trace(s) recorded.")
 
     profile = AgentProfile(
         description=" ".join(desc_parts),
@@ -2252,11 +2396,29 @@ def _scan_captured_actions(
     return kept
 
 
-def _auto_seal_trace(mem: AgentMemory) -> str | None:
-    """If Pro traces are available, auto-seal the last OSS trace as immutable."""
+def _auto_seal_trace(
+    mem: AgentMemory,
+    oss_trace: Any | None = None,
+    *,
+    session_metadata: Any | None = None,
+) -> str | None:
+    """If Pro traces are available, seal an OSS trace as immutable.
+
+    ``oss_trace`` defaults to the trace ``mem`` just committed. ``POST
+    /api/v1/traces`` passes the trace it persisted instead, together with the
+    request body's raw ``session_metadata``: validating the body into the OSS
+    model discards keys the model does not declare, and the Pro recorder's spans
+    and LLM calls travel in exactly such keys.
+
+    The OSS -> immutable mapping is the Pro package's, not this file's. The copy
+    that lived here mapped only the fields it knew about, so every field added
+    to the sealed record afterwards — ``llm_calls`` first — was silently dropped
+    on this path while the other two seal paths carried it.
+    """
     if not _HAS_PRO_TRACES:
         return None
-    oss_trace = getattr(mem, "_last_trace", None)
+    if oss_trace is None:
+        oss_trace = getattr(mem, "_last_trace", None)
     if oss_trace is None:
         return None
     store = _get_immutable_store()
@@ -2266,50 +2428,11 @@ def _auto_seal_trace(mem: AgentMemory) -> str | None:
         from uuid import UUID as _UUID
 
         now = datetime.now(timezone.utc)
-        causal = [
-            TraceEntry(
-                entity_path=e.entity_path,
-                key=e.key,
-                version=e.version,
-                confidence=e.confidence,
-                value=e.value,
-                memory_type=getattr(e, "memory_type", None) or "fact",
-                written_by=getattr(e, "written_by", None),
-                read_at=getattr(e, "read_at", None) or now,
-            )
-            for e in (oss_trace.causal_entries or [])
-        ]
-        contexts = [
-            TraceExternalContext(
-                label=c.label,
-                summary=c.summary,
-                source=getattr(c, "source", None),
-                recorded_at=getattr(c, "recorded_at", None) or now,
-            )
-            for c in (oss_trace.external_contexts or [])
-        ]
-        # The action side of the training pair. Mapped field by field rather than
-        # by model_dump so that a shape change on either model surfaces here as a
-        # type error instead of a silently empty column.
-        actions = [
-            ProToolCall(
-                tool_name=t.tool_name,
-                arguments=t.arguments,
-                result_summary=t.result_summary,
-                result_hash=t.result_hash,
-                started_at=t.started_at or now,
-                duration_ms=t.duration_ms,
-                source=t.source,
-                success=t.success,
-            )
-            for t in (getattr(oss_trace, "tool_calls", None) or [])
-        ]
-
-        session_id = mem.session_id
+        # The trace's own session when it has one: a trace posted by a remote
+        # client belongs to that client's session, not to the server handle's.
+        session_id = getattr(oss_trace, "session_id", None) or mem.session_id
         seq = _seal_sequence.get(session_id, 0)
         parent_hash = store.get_latest_hash(session_id)
-
-        trace_id = _UUID(oss_trace.id) if oss_trace.id else None
 
         account_id = None
         try:
@@ -2320,9 +2443,11 @@ def _auto_seal_trace(mem: AgentMemory) -> str | None:
         except (ImportError, ValueError):
             pass
 
-        imm = ImmutableDecisionTrace(
-            **({"id": trace_id} if trace_id else {}),
-            **({"account_id": account_id} if account_id else {}),
+        imm = _pro_immutable_from_oss_trace(
+            oss_trace,
+            session_id=session_id,
+            sequence_number=seq,
+            account_id=account_id,
             # From the trace, not from ``mem``. ``mem`` is shared by every
             # request: the caller's agent is written onto its tagger for the
             # duration of the commit and restored in a ``finally``, and this runs
@@ -2332,18 +2457,10 @@ def _auto_seal_trace(mem: AgentMemory) -> str | None:
             # model trains on an empty set. The trace was built while the tagger
             # still pointed at the caller.
             agent_id=getattr(oss_trace, "agent_id", None) or mem.agent_id,
-            session_id=session_id,
-            sequence_number=seq,
-            outcome_ref=oss_trace.outcome_ref,
-            outcome_type=oss_trace.outcome_type,
-            decision_summary=getattr(oss_trace, "decision_summary", None),
-            task_input=getattr(oss_trace, "task_input", None),
-            response_text=getattr(oss_trace, "response_text", None),
-            causal_entries=causal,
-            external_contexts=contexts,
-            tool_calls=actions,
             created_at=now,
+            session_metadata=session_metadata,
         )
+        imm = _pro_finalize_spans(imm)
         sealed = seal(
             imm,
             get_signing_key(),
@@ -2354,7 +2471,7 @@ def _auto_seal_trace(mem: AgentMemory) -> str | None:
         saved = store.save(sealed)
         _seal_sequence[session_id] = seq + 1
         logger.info("Auto-sealed immutable trace %s for outcome %s",
-                     saved.id, oss_trace.outcome_ref)
+                     saved.id, getattr(oss_trace, "outcome_ref", None))
         return str(saved.id)
     except Exception:
         logger.warning("Failed to auto-seal immutable trace", exc_info=True)
@@ -2429,6 +2546,7 @@ async def list_outcomes(
     entity_path: str | None = Query(None),
     since: str | None = Query(None),
     limit: int = Query(100),
+    outcome_ref: str | None = Query(None),
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
     mem = _get_memory()
@@ -2437,6 +2555,7 @@ async def list_outcomes(
         entity_path=entity_path,
         since=since_dt,
         limit=limit,
+        outcome_ref=outcome_ref,
     )
     allowed = _visible_agent_ids(request)
     if allowed is not None:
@@ -2472,8 +2591,10 @@ async def explain(
         # they can see; the ref-less session explain spans the whole account.
         if outcome_ref is None:
             raise HTTPException(status_code=403, detail="outcome_ref is required")
-        records = mem._adapter.list_outcomes(limit=10000)
-        record = next((r for r in records if r.outcome_ref == outcome_ref), None)
+        # Filtered where the outcomes live rather than paged through all of
+        # them here; an outcome_ref is not unique, so the newest record wins.
+        records = mem._adapter.list_outcomes(outcome_ref=outcome_ref, limit=1)
+        record = records[0] if records else None
         if record is None or record.agent_id not in allowed:
             raise HTTPException(status_code=404, detail="Outcome not found")
     return mem.explain(outcome_ref)
@@ -2490,20 +2611,35 @@ async def list_traces(
     entity_path: str | None = Query(None),
     agent_id: str | None = Query(None),
     outcome_type: str | None = Query(None),
-    limit: int = Query(100),
+    limit: int = Query(100, ge=1),
+    offset: int = Query(0, ge=0),
+    cursor: str | None = Query(None),
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
-    mem = _get_memory()
-    traces = mem._adapter.list_traces(
+    """Decision traces, newest first, keyset-paginated.
+
+    Follow ``next_cursor`` while ``has_more`` is true. ``offset`` is honoured
+    only when no cursor is given. The page's cursor points at the last row
+    read, so a caller whose visibility hides some agents still advances past
+    them rather than seeing the same rows again.
+    """
+    limit = clamp_limit(limit)
+    page = await _list_traces_page(
         entity_path=entity_path,
         agent_id=agent_id,
         outcome_type=outcome_type,
         limit=limit,
+        offset=offset,
+        cursor=_check_cursor(cursor),
     )
+    traces = page.items
     allowed = _visible_agent_ids(request)
     if allowed is not None:
         traces = [t for t in traces if t.agent_id in allowed]
-    return {"traces": [t.model_dump(mode="json") for t in traces]}
+    return {
+        "traces": [t.model_dump(mode="json") for t in traces],
+        **_page_meta(page),
+    }
 
 
 @app.post("/api/v1/traces")
@@ -2557,7 +2693,18 @@ async def save_trace(
             ),
         })
     saved = mem._adapter.save_trace(trace)
-    return saved.model_dump(mode="json")
+    # Sealed like a trace committed through /outcomes. Until this call, a trace
+    # arriving here — which is every trace an HttpAdapter client commits — was
+    # never sealed, so it had no immutable copy at all. The saved trace is what
+    # is sealed, so the immutable copy carries the persisted id; the raw body is
+    # passed alongside because ``model_validate`` above dropped the
+    # ``session_metadata`` keys the Pro recorder's spans travel in.
+    raw_meta = body.get("session_metadata") if isinstance(body, dict) else None
+    immutable_trace_id = _auto_seal_trace(mem, saved, session_metadata=raw_meta)
+    result = saved.model_dump(mode="json")
+    if immutable_trace_id:
+        result["immutable_trace_id"] = immutable_trace_id
+    return result
 
 
 # NOTE: must be registered before /api/v1/traces/{trace_id} so "share-stats"
@@ -2590,8 +2737,7 @@ async def get_trace(
     trace_id: str,
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
-    mem = _get_memory()
-    trace = mem._adapter.get_trace(trace_id)
+    trace = await _via_async_or_sync("get_trace", trace_id)
     allowed = _visible_agent_ids(request)
     if trace is not None and allowed is not None and trace.agent_id not in allowed:
         trace = None
@@ -2775,7 +2921,9 @@ async def get_usage(
         }
     mem = _get_memory()
     st = mem.stats()
-    outcomes = mem._adapter.list_outcomes(limit=10000)
+    # Counted in SQL. This used to be len() over a list capped at 10,000, so
+    # every account past that reported exactly 10,000 decision traces.
+    outcome_count = mem._adapter.count_outcomes()
 
     top_agents = sorted(st.agents.items(), key=lambda x: x[1], reverse=True)[:10]
     top_entities = sorted(st.entities.items(), key=lambda x: x[1], reverse=True)[:10]
@@ -2824,7 +2972,7 @@ async def get_usage(
         "avgLatencyMs": 0,
         "quotas": [
             {"label": "Memory entries", "current": st.total_entries, "limit": 0},
-            {"label": "Decision traces", "current": len(outcomes), "limit": 0},
+            {"label": "Decision traces", "current": outcome_count, "limit": 0},
             {"label": "API keys", "current": api_key_count, "limit": 0},
             {"label": "Users", "current": st.total_agents, "limit": 0},
         ],
@@ -3002,7 +3150,12 @@ async def agent_memory_graph(
 
     mem = _get_memory()
     entries = mem.list()
-    traces = mem._adapter.list_traces(agent_id=agent_id, limit=10000)
+    # Read counts and the trace count are aggregated by the adapter; this
+    # used to pull up to 10,000 full traces to tally causal_entries here.
+    trace_count = mem._adapter.count_traces(agent_id=agent_id)
+    read_entities: dict[str, dict[str, int]] = {
+        ep: dict(keys) for ep, keys in mem._adapter.trace_read_counts(agent_id).items()
+    }
 
     written_by_agent = [
         e for e in entries
@@ -3030,25 +3183,26 @@ async def agent_memory_graph(
     total_recalls = sum(getattr(e, "recall_count", 0) for e in written_by_agent)
     recalled_tokens_saved = sum(recall_tokens_saved(e) for e in written_by_agent)
 
-    # Build read counts from both traces (causal_entries) and timeline events.
-    read_entities: dict[str, dict[str, int]] = {}
-    for t in traces:
-        for ce in t.causal_entries:
-            ep = ce.entity_path
-            key = ce.key
-            if ep not in read_entities:
-                read_entities[ep] = {}
-            read_entities[ep][key] = read_entities[ep].get(key, 0) + 1
-
-    # Supplement with READ events from the timeline (persisted independently).
+    # Supplement the trace read counts with READ events from the timeline
+    # (persisted independently). Bounded by AMFS_MAX_SCAN_ROWS per event
+    # type, and the response says when the bound was hit.
     total_read_events = 0
+    read_events_truncated = False
+    ceiling = max_scan_rows()
     try:
-        read_events = mem._adapter.list_events(
-            agent_id, mem.namespace, event_type="read", limit=10000,
+        read_events, cut_a = _bounded_scan(
+            mem._adapter.list_events(
+                agent_id, mem.namespace, event_type="read", limit=ceiling + 1,
+            ),
+            ceiling,
         )
-        cross_read_events = mem._adapter.list_events(
-            agent_id, mem.namespace, event_type="cross_agent_read", limit=10000,
+        cross_read_events, cut_b = _bounded_scan(
+            mem._adapter.list_events(
+                agent_id, mem.namespace, event_type="cross_agent_read", limit=ceiling + 1,
+            ),
+            ceiling,
         )
+        read_events_truncated = cut_a or cut_b
         for ev in read_events + cross_read_events:
             ep = ev.details.get("entity_path", "")
             key = ev.details.get("key", "")
@@ -3088,12 +3242,13 @@ async def agent_memory_graph(
     return {
         "agentId": agent_id,
         "nodes": nodes,
-        "traceCount": len(traces),
+        "traceCount": trace_count,
         "totalWritten": len(written_by_agent),
         "totalReads": total_read_events,
         "totalRecalls": total_recalls,
         "recalledTokensSaved": recalled_tokens_saved,
         "crossAgentReads": cross_agent_reads,
+        "truncated": read_events_truncated,
     }
 
 
@@ -3110,20 +3265,14 @@ async def agent_cross_reads(
 
     mem = _get_memory()
     entries = mem.list()
-    traces = mem._adapter.list_traces(agent_id=agent_id, limit=10000)
 
     entry_authors: dict[str, str] = {}
     for e in entries:
         entry_authors[f"{e.entity_path}/{e.key}"] = e.provenance.agent_id
 
-    read_entities: dict[str, dict[str, int]] = {}
-    for t in traces:
-        for ce in t.causal_entries:
-            ep = ce.entity_path
-            key = ce.key
-            if ep not in read_entities:
-                read_entities[ep] = {}
-            read_entities[ep][key] = read_entities[ep].get(key, 0) + 1
+    # Aggregated by the adapter; previously up to 10,000 full traces were
+    # fetched to tally their causal_entries here.
+    read_entities = mem._adapter.trace_read_counts(agent_id)
 
     cross_reads: dict[str, list[dict[str, Any]]] = {}
     for ep, keys in read_entities.items():
@@ -3239,67 +3388,147 @@ async def agent_read_from(
     return _entry_to_response(entry)
 
 
+_ACTIVITY_SOURCES = ("w", "o", "e")  # writes, outcomes, events
+
+
+def _encode_activity_cursor(positions: dict[str, str | None]) -> str | None:
+    """A composite cursor over the three activity sources.
+
+    The activity feed merges three independently-ordered streams, so a
+    single ``(timestamp, id)`` position cannot resume it exactly: two
+    sources can share a timestamp, and dropping to a strict ``<`` on the
+    timestamp alone would skip rows. Each source keeps its own keyset
+    position instead, and the composite is just the three of them.
+    """
+    if all(v is None for v in positions.values()):
+        return None
+    return encode_cursor(datetime.now(UTC), {k: positions.get(k) for k in _ACTIVITY_SOURCES})
+
+
+def _decode_activity_cursor(cursor: str | None) -> dict[str, str | None]:
+    if not cursor:
+        return {k: None for k in _ACTIVITY_SOURCES}
+    _, positions = decode_cursor(cursor)
+    if not isinstance(positions, dict):
+        raise InvalidCursorError("cursor does not belong to the activity feed")
+    return {k: positions.get(k) for k in _ACTIVITY_SOURCES}
+
+
 @app.get("/api/v1/agents/{agent_id:path}/activity")
 async def agent_activity(
     request: Request,
     agent_id: str,
-    limit: int = Query(100),
+    limit: int = Query(100, ge=1),
+    cursor: str | None = Query(None),
+    since: str | None = Query(None),
+    until: str | None = Query(None),
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
-    """Timeline of writes, outcomes, reads, and other events for this agent."""
+    """Timeline of writes, outcomes, reads, and other events for this agent.
+
+    Each of the three sources — the agent's current entries, its traces, and
+    its timeline events — is filtered, ordered and paged by the adapter, so
+    this route reads at most ``3 * (limit + 1)`` rows however much history the
+    agent has. It used to list every entry in the namespace and filter here.
+
+    Keyset-paginated with a composite cursor: follow ``next_cursor`` while
+    ``has_more`` is true. ``since``/``until`` bound every source by time.
+    """
     vis = _get_visibility_filter(request)
     if vis is not None and vis.should_filter() and not vis.is_agent_visible(agent_id):
         raise HTTPException(status_code=404, detail="Agent not found")
 
+    limit = clamp_limit(limit)
+    try:
+        positions = _decode_activity_cursor(cursor)
+        for pos in positions.values():
+            _check_cursor(pos)
+    except InvalidCursorError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid cursor: {exc}") from exc
+    since_dt = _parse_ts(since)
+    until_dt = _parse_ts(until)
+
     mem = _get_memory()
-    entries = [
-        e for e in mem.list()
-        if e.provenance.agent_id == agent_id and not e.entity_path.startswith("_system/")
-    ]
-    entries.sort(key=lambda e: e.provenance.written_at, reverse=True)
+    entries_page = await _list_agent_entries_page(
+        agent_id, limit=limit, cursor=positions["w"], since=since_dt, until=until_dt,
+    )
+    traces_page = await _list_traces_page(
+        agent_id=agent_id, limit=limit, cursor=positions["o"], since=since_dt, until=until_dt,
+    )
+    events_page = await _list_events_page(
+        agent_id, mem.namespace, limit=limit, cursor=positions["e"],
+        since=since_dt, until=until_dt,
+    )
 
-    writes = [
-        {
-            "type": "write",
-            "entityPath": e.entity_path,
-            "key": e.key,
-            "version": e.version,
-            "confidence": e.confidence,
-            "timestamp": e.provenance.written_at.isoformat(),
-        }
-        for e in entries[:limit]
-    ]
-
-    traces = mem._adapter.list_traces(agent_id=agent_id, limit=limit)
-    outcomes = [
-        {
+    # Every candidate row carries the cursor its source would resume from if
+    # this row were the last one taken, so the merge can advance each source
+    # independently and exactly.
+    candidates: list[tuple[datetime, str, dict[str, Any], str]] = []
+    for e in entries_page.items:
+        candidates.append((
+            e.provenance.written_at, "w",
+            {
+                "type": "write",
+                "entityPath": e.entity_path,
+                "key": e.key,
+                "version": e.version,
+                "confidence": e.confidence,
+                "timestamp": e.provenance.written_at.isoformat(),
+            },
+            encode_cursor(e.provenance.written_at, entry_tiebreak(e)),
+        ))
+    for t in traces_page.items:
+        # Traces without an outcome_ref are not shown, but they still
+        # advance the trace cursor so paging never stalls on a run of them.
+        item = {
             "type": "outcome",
             "outcomeRef": t.outcome_ref,
             "outcomeType": t.outcome_type,
             "causalEntryCount": len(t.causal_entries),
             "timestamp": t.created_at.isoformat(),
-        }
-        for t in traces if t.outcome_ref
-    ]
+        } if t.outcome_ref else None
+        candidates.append((t.created_at, "o", item, encode_cursor(t.created_at, t.id)))
+    for evt in events_page.items:
+        candidates.append((
+            evt.created_at, "e",
+            {
+                "type": (
+                    evt.event_type.value
+                    if hasattr(evt.event_type, "value")
+                    else str(evt.event_type)
+                ),
+                "summary": evt.summary,
+                "details": evt.details,
+                "actorAgentId": evt.actor_agent_id,
+                "timestamp": evt.created_at.isoformat(),
+            },
+            encode_cursor(evt.created_at, evt.id),
+        ))
 
-    events = mem._adapter.list_events(agent_id, mem.namespace, limit=limit)
-    event_items = [
-        {
-            "type": evt.event_type.value if hasattr(evt.event_type, "value") else str(evt.event_type),
-            "summary": evt.summary,
-            "details": evt.details,
-            "actorAgentId": evt.actor_agent_id,
-            "timestamp": evt.created_at.isoformat(),
-        }
-        for evt in events
-    ]
+    def _sort_ts(ts: datetime) -> datetime:
+        return ts if ts.tzinfo is not None else ts.replace(tzinfo=UTC)
 
-    timeline = sorted(
-        writes + outcomes + event_items,
-        key=lambda x: x["timestamp"],
-        reverse=True,
-    )[:limit]
-    return {"agentId": agent_id, "timeline": timeline}
+    candidates.sort(key=lambda c: (_sort_ts(c[0]), c[1]), reverse=True)
+
+    timeline: list[dict[str, Any]] = []
+    next_positions: dict[str, str | None] = dict(positions)
+    consumed = 0
+    for _, source, item, pos in candidates:
+        if len(timeline) >= limit:
+            break
+        next_positions[source] = pos
+        consumed += 1
+        if item is not None:
+            timeline.append(item)
+
+    leftover = len(candidates) - consumed
+    has_more = leftover > 0 or entries_page.has_more or traces_page.has_more or events_page.has_more
+    return {
+        "agentId": agent_id,
+        "timeline": timeline,
+        "next_cursor": _encode_activity_cursor(next_positions) if has_more else None,
+        "has_more": has_more,
+    }
 
 
 @app.get("/api/v1/agents/{agent_id:path}/timeline")
@@ -3308,26 +3537,37 @@ async def agent_timeline(
     agent_id: str,
     event_type: str | None = Query(None),
     since: str | None = Query(None),
-    limit: int = Query(100),
+    until: str | None = Query(None),
+    limit: int = Query(100, ge=1),
+    offset: int = Query(0, ge=0),
+    cursor: str | None = Query(None),
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
     """Git-like event log for an agent — every write, outcome, and
-    cross-agent read is recorded as an event on the agent's timeline."""
+    cross-agent read is recorded as an event on the agent's timeline.
+
+    Keyset-paginated: follow ``next_cursor`` while ``has_more`` is true.
+    ``offset`` is honoured only when no cursor is given.
+    """
     vis = _get_visibility_filter(request)
     if vis is not None and vis.should_filter() and not vis.is_agent_visible(agent_id):
         raise HTTPException(status_code=404, detail="Agent not found")
 
     mem = _get_memory()
-    since_dt = datetime.fromisoformat(since) if since else None
-    events = mem._adapter.list_events(
+    since_dt = _parse_ts(since)
+    until_dt = _parse_ts(until)
+    limit = clamp_limit(limit)
+    page = await _list_events_page(
         agent_id, mem.namespace,
         event_type=event_type,
-        since=since_dt, limit=limit,
+        since=since_dt, until=until_dt,
+        limit=limit, offset=offset, cursor=_check_cursor(cursor),
     )
     return {
         "agentId": agent_id,
-        "events": [e.model_dump(mode="json") for e in events],
-        "count": len(events),
+        "events": [e.model_dump(mode="json") for e in page.items],
+        "count": len(page.items),
+        **_page_meta(page),
     }
 
 
@@ -3915,7 +4155,9 @@ async def rollback(
     if target_event_id:
         event = mem._adapter.get_event(target_event_id, mem.namespace)
         if event is None and agent_id:
-            for e in mem._adapter.list_events(agent_id, mem.namespace, limit=10000):
+            # Fallback for adapters without get_event: a bounded scan of the
+            # agent's timeline, newest first, capped by AMFS_MAX_SCAN_ROWS.
+            for e in mem._adapter.list_events(agent_id, mem.namespace, limit=max_scan_rows()):
                 if e.id == target_event_id:
                     event = e
                     break
@@ -4930,7 +5172,14 @@ async def run_pattern_scan(
 
     mem = _get_memory()
     entries = mem.list(req.entity_path)
-    outcomes = mem._adapter.list_outcomes(entity_path=req.entity_path, limit=10000)
+    # Pattern detection is a whole-history analysis, so it reads a bounded
+    # window of outcomes (AMFS_MAX_SCAN_ROWS, newest first) and reports when
+    # the window was not the whole history.
+    scan_ceiling = max_scan_rows()
+    outcomes, outcomes_truncated = _bounded_scan(
+        mem._adapter.list_outcomes(entity_path=req.entity_path, limit=scan_ceiling + 1),
+        scan_ceiling,
+    )
 
     if req.agent_id:
         entries = [e for e in entries if e.provenance.agent_id == req.agent_id]
@@ -4993,6 +5242,7 @@ async def run_pattern_scan(
     return {
         "scannedEntries": report.scanned_entries,
         "scannedOutcomes": report.scanned_outcomes,
+        "outcomesTruncated": outcomes_truncated,
         "scanDurationMs": round(report.scan_duration_ms, 2),
         "patternsFound": len(report.patterns),
         "patternsPersisted": persisted,

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -2614,8 +2614,8 @@ async def list_traces(
     limit: int = Query(100, ge=1),
     offset: int = Query(0, ge=0),
     cursor: str | None = Query(None),
-    since: datetime | None = Query(None),
-    until: datetime | None = Query(None),
+    since: str | None = Query(None),
+    until: str | None = Query(None),
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
     """Decision traces, newest first, keyset-paginated.
@@ -2627,7 +2627,9 @@ async def list_traces(
 
     ``since`` (inclusive) and ``until`` (exclusive) bound ``created_at`` in
     the query itself, so a window that excludes the newest traces still
-    returns the older matches instead of an empty first page.
+    returns the older matches instead of an empty first page. Both go through
+    :func:`_parse_ts` like the sibling list routes: naive input is taken as
+    UTC rather than compared naive against aware timestamps.
     """
     limit = clamp_limit(limit)
     page = await _list_traces_page(
@@ -2637,8 +2639,8 @@ async def list_traces(
         limit=limit,
         offset=offset,
         cursor=_check_cursor(cursor),
-        since=since,
-        until=until,
+        since=_parse_ts(since),
+        until=_parse_ts(until),
     )
     traces = page.items
     allowed = _visible_agent_ids(request)

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -2285,7 +2285,10 @@ def _http_api_call(method: str, path: str, *, params: dict | None = None, body: 
             resp = httpx.get(f"{base_url}{path}", params=params, headers=headers, timeout=30.0)
         else:
             resp = httpx.post(f"{base_url}{path}", params=params, json=body or {}, headers=headers, timeout=30.0)
-        if resp.status_code == 200:
+        if 200 <= resp.status_code < 300:
+            # 201 Created / 202 Accepted are success too; 204 has no body.
+            if resp.status_code == 204 or not resp.content:
+                return json.dumps({})
             return json.dumps(resp.json(), default=str)
         return json.dumps({"error": f"API returned {resp.status_code}", "detail": resp.text})
     except ImportError:

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -1407,8 +1407,12 @@ class AgentMemory:
         agent_id: str | None = None,
         outcome_type: str | None = None,
         limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
     ) -> list[DecisionTrace]:
-        """Browse persisted decision traces from past sessions.
+        """Browse persisted decision traces from past sessions, newest first.
 
         Each trace is the full causal chain a committed outcome snapshotted:
         the reads, external contexts, recorded actions, and the outcome itself.
@@ -1419,6 +1423,13 @@ class AgentMemory:
             agent_id: Only traces committed by this agent.
             outcome_type: Filter by outcome (e.g. "success", "failure").
             limit: Maximum traces to return (default 100).
+            offset: Rows to skip; honoured only when no cursor is given.
+            cursor: Opaque keyset position from a previous page — pass
+                ``amfs_core.pagination.encode_cursor(last.created_at, last.id)``
+                (or the ``next_cursor`` an HTTP page returned) to get the
+                traces strictly older than the last one seen.
+            since: Only traces created at or after this time.
+            until: Only traces created before this time.
 
         Returns an empty list on adapters without trace persistence (e.g. the
         default filesystem adapter) — traces live in Postgres or the hosted API.
@@ -1428,6 +1439,10 @@ class AgentMemory:
             agent_id=agent_id,
             outcome_type=outcome_type,
             limit=limit,
+            offset=offset,
+            cursor=cursor,
+            since=since,
+            until=until,
         )
 
     def get_trace(self, trace_id: str) -> DecisionTrace | None:
@@ -1598,20 +1613,14 @@ class AgentMemory:
             # {'deploy-agent': [{'entity_path': 'checkout-service', 'key': 'retry-pattern', 'read_count': 3}]}
         """
         entries = self.list()
-        traces = self._adapter.list_traces(agent_id=self.agent_id, limit=10000)
 
         entry_authors: dict[str, str] = {}
         for e in entries:
             entry_authors[f"{e.entity_path}/{e.key}"] = e.provenance.agent_id
 
-        read_entities: dict[str, dict[str, int]] = {}
-        for t in traces:
-            for ce in t.causal_entries:
-                ep = ce.entity_path
-                key = ce.key
-                if ep not in read_entities:
-                    read_entities[ep] = {}
-                read_entities[ep][key] = read_entities[ep].get(key, 0) + 1
+        # Aggregated by the adapter (in SQL on Postgres) instead of pulling up
+        # to 10,000 full traces here to tally their causal_entries.
+        read_entities = self._adapter.trace_read_counts(self.agent_id)
 
         cross_reads: dict[str, list[dict[str, Any]]] = {}
         for ep, keys in read_entities.items():

--- a/packages/sdk-typescript/src/__tests__/traces.test.ts
+++ b/packages/sdk-typescript/src/__tests__/traces.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentMemory, HttpAdapter, toDecisionTrace, toDecisionTracePage } from "../index.js";
+
+// Wire shape of a sealed trace, as GET /api/v1/traces/{id} returns it.
+const RAW_TRACE = {
+  id: "trace-1",
+  agent_id: "deploy-agent",
+  session_id: "sess-1",
+  outcome_ref: "deploy-v41",
+  outcome_type: "success",
+  decision_summary: "Rolled back checkout",
+  task_input: "checkout is returning 500s, roll back",
+  response_text: "Rolled checkout back to v41.",
+  tool_calls: [
+    {
+      tool_name: "deploy_rollback",
+      arguments: { service: "checkout", to_version: "v41", dry_run: false },
+      result_summary: "rolled back",
+      result_hash: "abc",
+      started_at: "2026-09-05T00:00:00Z",
+      duration_ms: 1200,
+      source: "deploy-cli",
+      success: true,
+    },
+  ],
+  session_metadata: {
+    model: "claude-4-opus",
+    client_name: "cursor",
+    platform: "darwin",
+    tools_available: ["amfs_write", "deploy_rollback"],
+    mcp_client_id: "c1",
+    mcp_session_id: null,
+  },
+  causal_entries: [
+    { entity_path: "shop/checkout", key: "runbook", version: 3, confidence: 0.9 },
+  ],
+  external_contexts: [{ label: "pagerduty", summary: "SEV-1 open", source: "PagerDuty" }],
+  query_events: [],
+  error_events: [],
+  state_diff: { entries_created: 1, entries_updated: 0 },
+  session_duration_ms: 4200,
+  created_at: "2026-09-05T00:01:00Z",
+};
+
+function mockFetch(responses: Array<{ status?: number; body: unknown }>) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fn = vi.fn(async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    const next = responses.shift() ?? { body: {} };
+    const status = next.status ?? 200;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => next.body,
+      text: async () => JSON.stringify(next.body),
+    } as unknown as Response;
+  });
+  vi.stubGlobal("fetch", fn);
+  return { calls, fn };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("toDecisionTrace", () => {
+  it("maps task_input, response_text, tool_calls and session_metadata", () => {
+    const trace = toDecisionTrace(RAW_TRACE);
+    expect(trace.id).toBe("trace-1");
+    expect(trace.agentId).toBe("deploy-agent");
+    expect(trace.taskInput).toBe("checkout is returning 500s, roll back");
+    expect(trace.responseText).toBe("Rolled checkout back to v41.");
+    expect(trace.toolCalls).toHaveLength(1);
+    expect(trace.toolCalls[0]).toEqual({
+      toolName: "deploy_rollback",
+      // caller-owned keys survive untouched
+      arguments: { service: "checkout", to_version: "v41", dry_run: false },
+      resultSummary: "rolled back",
+      resultHash: "abc",
+      startedAt: "2026-09-05T00:00:00Z",
+      durationMs: 1200,
+      source: "deploy-cli",
+      success: true,
+    });
+    expect(trace.sessionMetadata).toEqual({
+      model: "claude-4-opus",
+      clientName: "cursor",
+      platform: "darwin",
+      toolsAvailable: ["amfs_write", "deploy_rollback"],
+      mcpClientId: "c1",
+      mcpSessionId: null,
+    });
+    // The rest still goes through the generic converter.
+    expect(trace.causalEntries[0].entityPath).toBe("shop/checkout");
+    expect(trace.stateDiff).toEqual({ entriesCreated: 1, entriesUpdated: 0 });
+    expect(trace.createdAt).toBe("2026-09-05T00:01:00Z");
+  });
+
+  it("fills safe defaults for traces from servers that predate the fields", () => {
+    const { task_input, response_text, tool_calls, session_metadata, ...legacy } = RAW_TRACE;
+    void task_input;
+    void response_text;
+    void tool_calls;
+    void session_metadata;
+    const trace = toDecisionTrace(legacy);
+    expect(trace.taskInput).toBeNull();
+    expect(trace.responseText).toBeNull();
+    expect(trace.toolCalls).toEqual([]);
+    expect(trace.sessionMetadata).toBeNull();
+  });
+
+  it("tolerates partial tool calls", () => {
+    const trace = toDecisionTrace({ ...RAW_TRACE, tool_calls: [{ tool_name: "x", success: false }] });
+    expect(trace.toolCalls[0]).toMatchObject({
+      toolName: "x",
+      arguments: {},
+      durationMs: 0,
+      success: false,
+      source: null,
+    });
+  });
+});
+
+describe("toDecisionTracePage", () => {
+  it("reads the paged shape", () => {
+    const page = toDecisionTracePage({
+      traces: [RAW_TRACE],
+      next_cursor: "cur-2",
+      has_more: true,
+    });
+    expect(page.traces).toHaveLength(1);
+    expect(page.traces[0].agentId).toBe("deploy-agent");
+    expect(page.nextCursor).toBe("cur-2");
+    expect(page.hasMore).toBe(true);
+  });
+
+  it("accepts the legacy bare-array shape", () => {
+    const page = toDecisionTracePage([RAW_TRACE, RAW_TRACE]);
+    expect(page.traces).toHaveLength(2);
+    expect(page.nextCursor).toBeNull();
+    expect(page.hasMore).toBe(false);
+  });
+
+  it("applies since/until to createdAt client-side", () => {
+    const older = { ...RAW_TRACE, id: "old", created_at: "2026-08-01T00:00:00Z" };
+    const newer = { ...RAW_TRACE, id: "new", created_at: "2026-09-05T00:01:00Z" };
+    const body = { traces: [newer, older], next_cursor: null, has_more: false };
+
+    expect(toDecisionTracePage(body, { since: "2026-09-01T00:00:00Z" }).traces.map((t) => t.id))
+      .toEqual(["new"]);
+    expect(toDecisionTracePage(body, { until: new Date("2026-09-01T00:00:00Z") }).traces.map((t) => t.id))
+      .toEqual(["old"]);
+    // until is exclusive
+    expect(toDecisionTracePage(body, { until: "2026-09-05T00:01:00Z" }).traces.map((t) => t.id))
+      .toEqual(["old"]);
+  });
+});
+
+describe("HttpAdapter traces", () => {
+  it("listTracesPageAsync sends filters + cursor and returns page metadata", async () => {
+    const { calls } = mockFetch([
+      { body: { traces: [RAW_TRACE], next_cursor: "cur-2", has_more: true } },
+    ]);
+    const adapter = new HttpAdapter({ url: "https://api.test/", apiKey: "k" });
+    const page = await adapter.listTracesPageAsync({
+      agentId: "deploy-agent",
+      entityPath: "shop/checkout",
+      outcomeType: "success",
+      limit: 25,
+      cursor: "cur-1",
+      offset: 99, // ignored when a cursor is given
+    });
+    expect(page).toMatchObject({ nextCursor: "cur-2", hasMore: true });
+    expect(page.traces[0].id).toBe("trace-1");
+
+    const url = new URL(calls[0].url);
+    expect(url.pathname).toBe("/api/v1/traces");
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      entity_path: "shop/checkout",
+      agent_id: "deploy-agent",
+      outcome_type: "success",
+      limit: "25",
+      cursor: "cur-1",
+    });
+    expect((calls[0].init?.headers as Record<string, string>)["X-AMFS-API-Key"]).toBe("k");
+  });
+
+  it("uses offset only without a cursor", async () => {
+    const { calls } = mockFetch([{ body: { traces: [], next_cursor: null, has_more: false } }]);
+    const adapter = new HttpAdapter({ url: "https://api.test" });
+    await adapter.listTracesPageAsync({ offset: 10, limit: 5 });
+    expect(Object.fromEntries(new URL(calls[0].url).searchParams)).toEqual({
+      limit: "5",
+      offset: "10",
+    });
+  });
+
+  it("listTracesAsync keeps returning a flat array and follows a cursor when given one", async () => {
+    const { calls } = mockFetch([
+      { body: { traces: [RAW_TRACE], next_cursor: "cur-2", has_more: true } },
+      { body: { traces: [{ ...RAW_TRACE, id: "trace-2" }], next_cursor: null, has_more: false } },
+    ]);
+    const adapter = new HttpAdapter({ url: "https://api.test" });
+    const first = await adapter.listTracesAsync({ agentId: "deploy-agent" });
+    expect(Array.isArray(first)).toBe(true);
+    expect(first.map((t) => t.id)).toEqual(["trace-1"]);
+
+    const second = await adapter.listTracesAsync({ agentId: "deploy-agent", cursor: "cur-2" });
+    expect(second.map((t) => t.id)).toEqual(["trace-2"]);
+    expect(new URL(calls[1].url).searchParams.get("cursor")).toBe("cur-2");
+  });
+
+  it("walks every page via nextCursor / hasMore", async () => {
+    mockFetch([
+      { body: { traces: [{ ...RAW_TRACE, id: "a" }], next_cursor: "c1", has_more: true } },
+      { body: { traces: [{ ...RAW_TRACE, id: "b" }], next_cursor: "c2", has_more: true } },
+      { body: { traces: [{ ...RAW_TRACE, id: "c" }], next_cursor: null, has_more: false } },
+    ]);
+    const adapter = new HttpAdapter({ url: "https://api.test" });
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    for (;;) {
+      const page = await adapter.listTracesPageAsync({ limit: 1, cursor });
+      seen.push(...page.traces.map((t) => t.id));
+      if (!page.hasMore || !page.nextCursor) break;
+      cursor = page.nextCursor;
+    }
+    expect(seen).toEqual(["a", "b", "c"]);
+  });
+
+  it("getTraceAsync returns the mapped trace and null on 404", async () => {
+    mockFetch([{ body: RAW_TRACE }, { status: 404, body: { detail: "not found" } }]);
+    const adapter = new HttpAdapter({ url: "https://api.test" });
+    const trace = await adapter.getTraceAsync("trace-1");
+    expect(trace?.taskInput).toBe("checkout is returning 500s, roll back");
+    expect(trace?.toolCalls[0].arguments).toEqual({
+      service: "checkout",
+      to_version: "v41",
+      dry_run: false,
+    });
+    expect(trace?.sessionMetadata?.model).toBe("claude-4-opus");
+    expect(await adapter.getTraceAsync("missing")).toBeNull();
+  });
+});
+
+describe("AgentMemory trace facade", () => {
+  it("delegates listTracesAsync / listTracesPageAsync / getTraceAsync to the HTTP adapter", async () => {
+    mockFetch([
+      { body: { traces: [RAW_TRACE], next_cursor: "cur-2", has_more: true } },
+      { body: { traces: [RAW_TRACE], next_cursor: "cur-2", has_more: true } },
+      { body: RAW_TRACE },
+    ]);
+    const memory = new AgentMemory("deploy-agent", {
+      adapter: new HttpAdapter({ url: "https://api.test", apiKey: "k" }),
+    });
+    const flat = await memory.listTracesAsync({ since: "2026-09-01T00:00:00Z", limit: 10 });
+    expect(flat).toHaveLength(1);
+    const page = await memory.listTracesPageAsync({ cursor: "cur-1" });
+    expect(page.nextCursor).toBe("cur-2");
+    expect(page.hasMore).toBe(true);
+    const trace = await memory.getTraceAsync("trace-1");
+    expect(trace?.responseText).toBe("Rolled checkout back to v41.");
+  });
+
+  it("refuses without an HTTP adapter", async () => {
+    const memory = new AgentMemory("local");
+    await expect(memory.listTracesPageAsync()).rejects.toThrow(/requires a remote HTTP adapter/);
+  });
+});

--- a/packages/sdk-typescript/src/__tests__/traces.test.ts
+++ b/packages/sdk-typescript/src/__tests__/traces.test.ts
@@ -141,22 +141,33 @@ describe("toDecisionTracePage", () => {
     expect(page.hasMore).toBe(false);
   });
 
-  it("applies since/until to createdAt client-side", () => {
+  it("keeps every row the server returned — the window is the server's job", () => {
     const older = { ...RAW_TRACE, id: "old", created_at: "2026-08-01T00:00:00Z" };
     const newer = { ...RAW_TRACE, id: "new", created_at: "2026-09-05T00:01:00Z" };
     const body = { traces: [newer, older], next_cursor: null, has_more: false };
-
-    expect(toDecisionTracePage(body, { since: "2026-09-01T00:00:00Z" }).traces.map((t) => t.id))
-      .toEqual(["new"]);
-    expect(toDecisionTracePage(body, { until: new Date("2026-09-01T00:00:00Z") }).traces.map((t) => t.id))
-      .toEqual(["old"]);
-    // until is exclusive
-    expect(toDecisionTracePage(body, { until: "2026-09-05T00:01:00Z" }).traces.map((t) => t.id))
-      .toEqual(["old"]);
+    expect(toDecisionTracePage(body).traces.map((t) => t.id)).toEqual(["new", "old"]);
   });
 });
 
 describe("HttpAdapter traces", () => {
+  it("sends since/until as query parameters instead of filtering the page", async () => {
+    // A window that excludes the newest traces must reach the server: filtering
+    // the returned page would empty it and stop a cursor walk before the older
+    // matches were ever read.
+    const older = { ...RAW_TRACE, id: "old", created_at: "2026-08-01T00:00:00Z" };
+    const { calls } = mockFetch([{ body: { traces: [older], next_cursor: null, has_more: false } }]);
+    const adapter = new HttpAdapter({ url: "https://api.test" });
+    const page = await adapter.listTracesPageAsync({
+      since: "2026-07-01T00:00:00Z",
+      until: new Date("2026-09-01T00:00:00Z"),
+    });
+    expect(page.traces.map((t) => t.id)).toEqual(["old"]);
+    expect(Object.fromEntries(new URL(calls[0].url).searchParams)).toEqual({
+      since: "2026-07-01T00:00:00Z",
+      until: "2026-09-01T00:00:00.000Z",
+    });
+  });
+
   it("listTracesPageAsync sends filters + cursor and returns page metadata", async () => {
     const { calls } = mockFetch([
       { body: { traces: [RAW_TRACE], next_cursor: "cur-2", has_more: true } },

--- a/packages/sdk-typescript/src/adapters/http.ts
+++ b/packages/sdk-typescript/src/adapters/http.ts
@@ -51,6 +51,12 @@ export class HttpAdapter implements AmfsAdapter {
     path: string,
     init?: RequestInit
   ): Promise<T> {
+    const raw = await this.fetchRaw(path, init);
+    return convertKeys(raw) as T;
+  }
+
+  /** Like `fetch` but returns the server's JSON untouched (snake_case keys). */
+  private async fetchRaw(path: string, init?: RequestInit): Promise<unknown> {
     const resp = await globalThis.fetch(`${this.baseUrl}${path}`, {
       ...init,
       headers: { ...this.headers, ...(init?.headers as Record<string, string>) },
@@ -59,8 +65,7 @@ export class HttpAdapter implements AmfsAdapter {
       const body = await resp.text().catch(() => "");
       throw new Error(`AMFS API ${resp.status}: ${body}`);
     }
-    const raw = await resp.json();
-    return convertKeys(raw) as T;
+    return resp.json();
   }
 
   read(
@@ -296,28 +301,42 @@ export class HttpAdapter implements AmfsAdapter {
     });
   }
 
-  async listTracesAsync(options?: {
-    entityPath?: string;
-    agentId?: string;
-    outcomeType?: string;
-    limit?: number;
-  }): Promise<DecisionTraceSummary[]> {
+  /**
+   * One page of decision traces, newest first, exactly as the server pages them.
+   *
+   * Mirrors GET /api/v1/traces: pass `cursor` (the previous page's `nextCursor`)
+   * to continue; `offset` is honoured only when no cursor is given. `since` and
+   * `until` are not server-side parameters — like the Python HttpAdapter, they
+   * are applied here to the page's `createdAt`, so a filtered page may hold fewer
+   * than `limit` rows while `hasMore` still reports the server's view.
+   */
+  async listTracesPageAsync(options?: ListTracesOptions): Promise<DecisionTracePage> {
     const params = new URLSearchParams();
     if (options?.entityPath) params.set("entity_path", options.entityPath);
     if (options?.agentId) params.set("agent_id", options.agentId);
     if (options?.outcomeType) params.set("outcome_type", options.outcomeType);
     if (options?.limit) params.set("limit", String(options.limit));
+    if (options?.cursor) params.set("cursor", options.cursor);
+    else if (options?.offset) params.set("offset", String(options.offset));
     const qs = params.toString();
-    const data = await this.fetch<{ traces: DecisionTraceSummary[] } | DecisionTraceSummary[]>(
-      `/api/v1/traces${qs ? `?${qs}` : ""}`
-    );
-    if (Array.isArray(data)) return data;
-    return data.traces ?? [];
+    const raw = await this.fetchRaw(`/api/v1/traces${qs ? `?${qs}` : ""}`);
+    return toDecisionTracePage(raw, options);
+  }
+
+  /**
+   * Decision traces as a flat array. Accepts the same paging options as
+   * {@link listTracesPageAsync}; use that method when you need `nextCursor` /
+   * `hasMore` to walk beyond one page.
+   */
+  async listTracesAsync(options?: ListTracesOptions): Promise<DecisionTraceSummary[]> {
+    const page = await this.listTracesPageAsync(options);
+    return page.traces;
   }
 
   async getTraceAsync(traceId: string): Promise<DecisionTrace | null> {
     try {
-      return await this.fetch<DecisionTrace>(`/api/v1/traces/${encodeURIComponent(traceId)}`);
+      const raw = await this.fetchRaw(`/api/v1/traces/${encodeURIComponent(traceId)}`);
+      return toDecisionTrace(raw);
     } catch {
       return null;
     }
@@ -449,6 +468,55 @@ export interface DecisionTraceSummary {
   createdAt: string;
 }
 
+/** Filters and paging for GET /api/v1/traces. */
+export interface ListTracesOptions {
+  entityPath?: string;
+  agentId?: string;
+  outcomeType?: string;
+  limit?: number;
+  /** Rows to skip; honoured only when no `cursor` is given. */
+  offset?: number;
+  /** Opaque keyset position — the `nextCursor` of the previous page. */
+  cursor?: string;
+  /** Only traces created at or after this instant (ISO-8601 string or Date). */
+  since?: string | Date;
+  /** Only traces created before this instant (ISO-8601 string or Date). */
+  until?: string | Date;
+}
+
+/** One page of GET /api/v1/traces. Follow `nextCursor` while `hasMore` is true. */
+export interface DecisionTracePage {
+  traces: DecisionTraceSummary[];
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
+/**
+ * An action the agent recorded during the session (`amfs_record_action`).
+ * `arguments` is passed through exactly as stored — its keys are the caller's,
+ * not the API's, so they are not converted to camelCase.
+ */
+export interface ToolCall {
+  toolName: string;
+  arguments: Record<string, unknown>;
+  resultSummary: string;
+  resultHash: string;
+  startedAt?: string;
+  durationMs: number;
+  source?: string | null;
+  success: boolean;
+}
+
+/** Which model, client and toolset produced the session's decisions. */
+export interface SessionMetadata {
+  model?: string | null;
+  clientName?: string | null;
+  platform?: string | null;
+  toolsAvailable: string[];
+  mcpClientId?: string | null;
+  mcpSessionId?: string | null;
+}
+
 export interface DecisionTrace {
   id: string;
   agentId: string;
@@ -456,6 +524,13 @@ export interface DecisionTrace {
   outcomeRef: string;
   outcomeType: string;
   decisionSummary?: string;
+  /** The request that started the work, as it arrived (may be redacted). */
+  taskInput?: string | null;
+  /** The agent's answer, when it was captured. */
+  responseText?: string | null;
+  /** Actions the agent recorded; empty for read/write-only sessions. */
+  toolCalls: ToolCall[];
+  sessionMetadata?: SessionMetadata | null;
   causalEntries: Array<{
     entityPath: string;
     key: string;
@@ -494,4 +569,104 @@ export interface DecisionTrace {
   sessionEndedAt?: string;
   sessionDurationMs?: number;
   createdAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Trace mappers (snake_case wire → camelCase SDK types)
+// ---------------------------------------------------------------------------
+
+type Raw = Record<string, unknown>;
+
+function asRecord(value: unknown): Raw {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Raw)
+    : {};
+}
+
+function toToolCall(raw: unknown): ToolCall {
+  const r = asRecord(raw);
+  return {
+    toolName: String(r.tool_name ?? ""),
+    // Caller-owned keys: never camelCased.
+    arguments: asRecord(r.arguments),
+    resultSummary: String(r.result_summary ?? ""),
+    resultHash: String(r.result_hash ?? ""),
+    startedAt: typeof r.started_at === "string" ? r.started_at : undefined,
+    durationMs: typeof r.duration_ms === "number" ? r.duration_ms : 0,
+    source: (r.source as string | null | undefined) ?? null,
+    success: r.success !== false,
+  };
+}
+
+function toSessionMetadata(raw: unknown): SessionMetadata | null {
+  if (raw === null || raw === undefined) return null;
+  const r = asRecord(raw);
+  return {
+    model: (r.model as string | null | undefined) ?? null,
+    clientName: (r.client_name as string | null | undefined) ?? null,
+    platform: (r.platform as string | null | undefined) ?? null,
+    toolsAvailable: Array.isArray(r.tools_available) ? r.tools_available.map(String) : [],
+    mcpClientId: (r.mcp_client_id as string | null | undefined) ?? null,
+    mcpSessionId: (r.mcp_session_id as string | null | undefined) ?? null,
+  };
+}
+
+/**
+ * Map a raw (snake_case) trace from the server to a `DecisionTrace`.
+ *
+ * The bulk of the object goes through the generic key converter, as before;
+ * the fields the converter would get wrong are set explicitly afterwards:
+ * `toolCalls[].arguments` must keep the caller's own keys, and
+ * `taskInput` / `responseText` / `sessionMetadata` must exist (null, not
+ * undefined) so consumers can distinguish "not captured" from "old server".
+ */
+export function toDecisionTrace(raw: unknown): DecisionTrace {
+  const r = asRecord(raw);
+  const converted = convertKeys(r) as Raw;
+  const toolCalls = Array.isArray(r.tool_calls) ? r.tool_calls.map(toToolCall) : [];
+  return {
+    ...(converted as unknown as DecisionTrace),
+    taskInput: (r.task_input as string | null | undefined) ?? null,
+    responseText: (r.response_text as string | null | undefined) ?? null,
+    toolCalls,
+    sessionMetadata: toSessionMetadata(r.session_metadata),
+  };
+}
+
+function toInstant(value: string | Date | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const ms = value instanceof Date ? value.getTime() : Date.parse(value);
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
+/** Map a raw GET /api/v1/traces body (new page shape or legacy array) to a page. */
+export function toDecisionTracePage(
+  raw: unknown,
+  options?: Pick<ListTracesOptions, "since" | "until">
+): DecisionTracePage {
+  const rows: unknown[] = Array.isArray(raw)
+    ? raw
+    : Array.isArray(asRecord(raw).traces)
+      ? (asRecord(raw).traces as unknown[])
+      : [];
+  const body = Array.isArray(raw) ? {} : asRecord(raw);
+  let traces = rows.map((t) => toDecisionTrace(t) as unknown as DecisionTraceSummary);
+
+  const since = toInstant(options?.since);
+  const until = toInstant(options?.until);
+  if (since !== undefined || until !== undefined) {
+    traces = traces.filter((t) => {
+      const created = Date.parse(t.createdAt);
+      if (Number.isNaN(created)) return true;
+      if (since !== undefined && created < since) return false;
+      if (until !== undefined && created >= until) return false;
+      return true;
+    });
+  }
+
+  return {
+    traces,
+    nextCursor: typeof body.next_cursor === "string" ? body.next_cursor : null,
+    hasMore: body.has_more === true,
+  };
 }

--- a/packages/sdk-typescript/src/adapters/http.ts
+++ b/packages/sdk-typescript/src/adapters/http.ts
@@ -305,10 +305,10 @@ export class HttpAdapter implements AmfsAdapter {
    * One page of decision traces, newest first, exactly as the server pages them.
    *
    * Mirrors GET /api/v1/traces: pass `cursor` (the previous page's `nextCursor`)
-   * to continue; `offset` is honoured only when no cursor is given. `since` and
-   * `until` are not server-side parameters — like the Python HttpAdapter, they
-   * are applied here to the page's `createdAt`, so a filtered page may hold fewer
-   * than `limit` rows while `hasMore` still reports the server's view.
+   * to continue; `offset` is honoured only when no cursor is given. `since`
+   * (inclusive) and `until` (exclusive) are sent to the server and bound the
+   * query itself, so a window that excludes the newest traces still returns
+   * the older matches rather than an empty first page.
    */
   async listTracesPageAsync(options?: ListTracesOptions): Promise<DecisionTracePage> {
     const params = new URLSearchParams();
@@ -318,9 +318,13 @@ export class HttpAdapter implements AmfsAdapter {
     if (options?.limit) params.set("limit", String(options.limit));
     if (options?.cursor) params.set("cursor", options.cursor);
     else if (options?.offset) params.set("offset", String(options.offset));
+    const since = toIsoString(options?.since);
+    const until = toIsoString(options?.until);
+    if (since) params.set("since", since);
+    if (until) params.set("until", until);
     const qs = params.toString();
     const raw = await this.fetchRaw(`/api/v1/traces${qs ? `?${qs}` : ""}`);
-    return toDecisionTracePage(raw, options);
+    return toDecisionTracePage(raw);
   }
 
   /**
@@ -633,36 +637,22 @@ export function toDecisionTrace(raw: unknown): DecisionTrace {
   };
 }
 
-function toInstant(value: string | Date | undefined): number | undefined {
+/** ISO-8601 for a query parameter; `undefined` when absent or unparseable. */
+function toIsoString(value: string | Date | undefined): string | undefined {
   if (value === undefined) return undefined;
-  const ms = value instanceof Date ? value.getTime() : Date.parse(value);
-  return Number.isNaN(ms) ? undefined : ms;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? undefined : value.toISOString();
+  return Number.isNaN(Date.parse(value)) ? undefined : value;
 }
 
 /** Map a raw GET /api/v1/traces body (new page shape or legacy array) to a page. */
-export function toDecisionTracePage(
-  raw: unknown,
-  options?: Pick<ListTracesOptions, "since" | "until">
-): DecisionTracePage {
+export function toDecisionTracePage(raw: unknown): DecisionTracePage {
   const rows: unknown[] = Array.isArray(raw)
     ? raw
     : Array.isArray(asRecord(raw).traces)
       ? (asRecord(raw).traces as unknown[])
       : [];
   const body = Array.isArray(raw) ? {} : asRecord(raw);
-  let traces = rows.map((t) => toDecisionTrace(t) as unknown as DecisionTraceSummary);
-
-  const since = toInstant(options?.since);
-  const until = toInstant(options?.until);
-  if (since !== undefined || until !== undefined) {
-    traces = traces.filter((t) => {
-      const created = Date.parse(t.createdAt);
-      if (Number.isNaN(created)) return true;
-      if (since !== undefined && created < since) return false;
-      if (until !== undefined && created >= until) return false;
-      return true;
-    });
-  }
+  const traces = rows.map((t) => toDecisionTrace(t) as unknown as DecisionTraceSummary);
 
   return {
     traces,

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -7,8 +7,16 @@ export type { AgentMemoryOptions, SearchOptions, MemoryStats } from "./memory.js
 export type { AmfsAdapter, WatchHandle } from "./adapter.js";
 export { createWatchHandle } from "./adapter.js";
 export { InMemoryAdapter } from "./adapters/filesystem.js";
-export { HttpAdapter } from "./adapters/http.js";
-export type { HttpAdapterOptions, DecisionTrace, DecisionTraceSummary } from "./adapters/http.js";
+export { HttpAdapter, toDecisionTrace, toDecisionTracePage } from "./adapters/http.js";
+export type {
+  HttpAdapterOptions,
+  DecisionTrace,
+  DecisionTraceSummary,
+  DecisionTracePage,
+  ListTracesOptions,
+  ToolCall,
+  SessionMetadata,
+} from "./adapters/http.js";
 export { CausalTagger, CoWEngine } from "./engine.js";
 export { ReadTracker } from "./tracker.js";
 export type { ExternalContext } from "./tracker.js";

--- a/packages/sdk-typescript/src/memory.ts
+++ b/packages/sdk-typescript/src/memory.ts
@@ -3,7 +3,13 @@
  */
 
 import type { AmfsAdapter, WatchHandle } from "./adapter.js";
-import type { DecisionTrace, DecisionTraceSummary, HttpAdapter } from "./adapters/http.js";
+import type {
+  DecisionTrace,
+  DecisionTracePage,
+  DecisionTraceSummary,
+  HttpAdapter,
+  ListTracesOptions,
+} from "./adapters/http.js";
 import { InMemoryAdapter } from "./adapters/filesystem.js";
 import { defaultConfig } from "./config.js";
 import { CausalTagger, CoWEngine } from "./engine.js";
@@ -662,14 +668,23 @@ export class AgentMemory {
     return this.requireHttp("graphNeighborsAsync").graphNeighborsAsync(options);
   }
 
-  /** Browse persisted decision traces from past sessions. */
-  async listTracesAsync(options?: {
-    entityPath?: string;
-    agentId?: string;
-    outcomeType?: string;
-    limit?: number;
-  }): Promise<DecisionTraceSummary[]> {
+  /**
+   * Browse persisted decision traces from past sessions, newest first.
+   *
+   * Returns one page as a flat array. Pass `cursor` (from
+   * {@link listTracesPageAsync}) to continue, or `since` / `until` to bound by
+   * creation time.
+   */
+  async listTracesAsync(options?: ListTracesOptions): Promise<DecisionTraceSummary[]> {
     return this.requireHttp("listTracesAsync").listTracesAsync(options);
+  }
+
+  /**
+   * One page of decision traces with paging metadata:
+   * `{ traces, nextCursor, hasMore }`. Follow `nextCursor` while `hasMore`.
+   */
+  async listTracesPageAsync(options?: ListTracesOptions): Promise<DecisionTracePage> {
+    return this.requireHttp("listTracesPageAsync").listTracesPageAsync(options);
   }
 
   /** Retrieve a full decision trace by ID, or null if not found. */

--- a/tests/integration/test_postgres_adapter.py
+++ b/tests/integration/test_postgres_adapter.py
@@ -10,7 +10,7 @@ import os
 
 import pytest
 
-from tests.integration.adapter_contract import AdapterContractTests
+from tests.integration.adapter_contract import AdapterContractTests, _make_entry
 
 PG_DSN = os.environ.get("AMFS_TEST_PG_DSN")
 
@@ -30,6 +30,11 @@ def adapter():
     conn = psycopg.connect(PG_DSN, autocommit=True)
     conn.execute("DROP TABLE IF EXISTS amfs_outcomes CASCADE")
     conn.execute("DROP TABLE IF EXISTS amfs_memory_entries CASCADE")
+    # Traces and events too, so the pagination and partitioning tests below
+    # start from an empty, freshly bootstrapped (partitioned) trace table.
+    conn.execute("DROP TABLE IF EXISTS amfs_decision_traces CASCADE")
+    conn.execute("DROP TABLE IF EXISTS amfs_decision_traces_legacy CASCADE")
+    conn.execute("DROP TABLE IF EXISTS amfs_events CASCADE")
     conn.close()
 
     a = PostgresAdapter(dsn=PG_DSN, namespace="test", auto_schema=True)
@@ -197,3 +202,464 @@ def test_a_trace_without_session_metadata_still_saves(adapter) -> None:
     assert fetched.session_metadata is None or (
         fetched.session_metadata.model is None
     )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Keyset pagination, SQL counts, and the causal_entries containment filter
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _saved_traces(adapter, n: int, *, agent_id: str = "page-agent", entity_path: str = "svc/api"):
+    """Persist *n* traces a minute apart, oldest first; returns them newest first."""
+    from datetime import UTC, datetime, timedelta
+
+    from amfs_core.models import DecisionTrace, TraceEntry
+
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    out = []
+    for i in range(n):
+        out.append(
+            adapter.save_trace(
+                DecisionTrace(
+                    agent_id=agent_id,
+                    session_id="s",
+                    outcome_ref=f"PAGE-{i}",
+                    outcome_type="success" if i % 2 == 0 else "failure",
+                    causal_entries=[
+                        TraceEntry(entity_path=entity_path, key=f"k{i}", version=1, confidence=1.0)
+                    ],
+                    created_at=base + timedelta(minutes=i),
+                )
+            )
+        )
+    return list(reversed(out))
+
+
+def test_list_traces_pages_by_cursor_without_gaps_or_repeats(adapter) -> None:
+    from amfs_core.pagination import page_from_overfetch
+
+    expected = [t.outcome_ref for t in _saved_traces(adapter, 11)]
+
+    seen, cursor, pages = [], None, 0
+    while True:
+        rows = adapter.list_traces(agent_id="page-agent", limit=4 + 1, cursor=cursor)
+        page = page_from_overfetch(
+            rows, limit=4, timestamp=lambda t: t.created_at, tiebreak=lambda t: t.id
+        )
+        pages += 1
+        seen.extend(t.outcome_ref for t in page.items)
+        if not page.has_more:
+            assert page.next_cursor is None
+            break
+        cursor = page.next_cursor
+    assert pages == 3
+    assert seen == expected
+
+    # offset is still honoured when no cursor is given
+    rows = adapter.list_traces(agent_id="page-agent", limit=3, offset=4)
+    assert [t.outcome_ref for t in rows] == expected[4:7]
+
+
+def test_list_traces_since_until_and_count(adapter) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    _saved_traces(adapter, 10)
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    since, until = base + timedelta(minutes=2), base + timedelta(minutes=6)
+
+    rows = adapter.list_traces(agent_id="page-agent", since=since, until=until, limit=100)
+    assert [t.outcome_ref for t in rows] == ["PAGE-5", "PAGE-4", "PAGE-3", "PAGE-2"]
+
+    assert adapter.count_traces(agent_id="page-agent") == 10
+    assert adapter.count_traces(agent_id="page-agent", since=since, until=until) == 4
+    assert adapter.count_traces(agent_id="page-agent", outcome_type="success") == 5
+    assert adapter.count_traces(agent_id="nobody") == 0
+
+
+def test_entity_path_filter_uses_containment_and_matches_the_old_scan(adapter, pg_conn) -> None:
+    """The ``@>`` rewrite must return exactly what ``jsonb_array_elements`` did."""
+    _saved_traces(adapter, 6, entity_path="svc/api")
+    _saved_traces(adapter, 3, agent_id="other-agent", entity_path="svc/other")
+
+    new = adapter.list_traces(entity_path="svc/api", limit=100)
+    assert len(new) == 6
+    assert all(any(c.entity_path == "svc/api" for c in t.causal_entries) for t in new)
+
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id FROM amfs_decision_traces
+            WHERE namespace = %s AND EXISTS (
+                SELECT 1 FROM jsonb_array_elements(causal_entries) ce
+                WHERE ce->>'entity_path' = %s
+            )
+            ORDER BY created_at DESC, id DESC
+            """,
+            (adapter._namespace, "svc/api"),
+        )
+        old_ids = [r[0] for r in cur.fetchall()]
+        cur.execute(
+            "SELECT 1 FROM pg_indexes WHERE indexname = 'idx_traces_causal_entries_gin'"
+        )
+        assert cur.fetchone() is not None, "GIN index on causal_entries was not created"
+    assert [t.id for t in new] == [str(i) for i in old_ids]
+
+    assert adapter.count_traces(entity_path="svc/api") == 6
+    assert adapter.list_traces(entity_path="svc/nope", limit=100) == []
+
+
+def test_trace_read_counts_aggregates_in_sql(adapter) -> None:
+    from amfs_core.abc import AdapterABC
+
+    _saved_traces(adapter, 5)
+    counts = adapter.trace_read_counts("page-agent")
+    assert counts == {"svc/api": {f"k{i}": 1 for i in range(5)}}
+    # identical to the base-class scan it replaces
+    assert counts == AdapterABC.trace_read_counts(adapter, "page-agent")
+    assert adapter.trace_read_counts("nobody") == {}
+
+
+def test_count_outcomes_matches_rows_not_a_capped_list(adapter, monkeypatch) -> None:
+    from amfs_core.models import OutcomeRecord, OutcomeType
+
+    adapter.write(_make_entry(key="counted"))
+    for i in range(7):
+        adapter.commit_outcome(
+            OutcomeRecord(
+                outcome_ref=f"CNT-{i}",
+                outcome_type=OutcomeType.SUCCESS,
+                committed_at=_make_entry().provenance.written_at,
+                causal_entry_keys=["checkout-service/counted"],
+                agent_id="review-agent",
+            )
+        )
+    # A scan ceiling smaller than the row count must not affect a SQL count.
+    monkeypatch.setenv("AMFS_MAX_SCAN_ROWS", "3")
+    assert adapter.count_outcomes() == 7
+    assert len(adapter.list_outcomes(limit=3)) == 3
+    assert [o.outcome_ref for o in adapter.list_outcomes(outcome_ref="CNT-4")] == ["CNT-4"]
+
+
+def test_list_entries_for_agent_pages_and_filters_in_sql(adapter) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from amfs_core.abc import AdapterABC
+    from amfs_core.models import MemoryEntry, Provenance
+    from amfs_core.pagination import entry_tiebreak, page_from_overfetch
+
+    base = datetime(2026, 2, 1, tzinfo=UTC)
+
+    def write(i, agent="act-agent", entity="svc/api"):
+        adapter.write(
+            MemoryEntry(
+                entity_path=entity,
+                key=f"k{i:02d}",
+                value={"i": i},
+                provenance=Provenance(
+                    agent_id=agent, session_id="s", written_at=base + timedelta(minutes=i)
+                ),
+            )
+        )
+
+    for i in range(9):
+        write(i)
+    write(50, agent="someone-else")
+    write(60, entity="_system/hidden")
+
+    seen, cursor = [], None
+    while True:
+        rows = adapter.list_entries_for_agent("act-agent", limit=4 + 1, cursor=cursor)
+        page = page_from_overfetch(
+            rows, limit=4, timestamp=lambda e: e.provenance.written_at, tiebreak=entry_tiebreak
+        )
+        seen.extend(e.key for e in page.items)
+        if not page.has_more:
+            break
+        cursor = page.next_cursor
+    assert seen == [f"k{i:02d}" for i in reversed(range(9))]
+
+    window = adapter.list_entries_for_agent(
+        "act-agent", since=base + timedelta(minutes=2), until=base + timedelta(minutes=5), limit=50
+    )
+    assert [e.key for e in window] == ["k04", "k03", "k02"]
+
+    # same answer as the in-memory base implementation
+    base_rows = AdapterABC.list_entries_for_agent(adapter, "act-agent", limit=6)
+    sql_rows = adapter.list_entries_for_agent("act-agent", limit=6)
+    assert [(e.entity_path, e.key) for e in sql_rows] == [
+        (e.entity_path, e.key) for e in base_rows
+    ]
+
+
+def test_list_events_pages_by_cursor(adapter) -> None:
+    from amfs_core.models import Event, EventType
+    from amfs_core.pagination import page_from_overfetch
+
+    for i in range(7):
+        adapter.log_event(
+            Event(
+                agent_id="evt-agent", namespace=adapter._namespace,
+                event_type=EventType.READ, summary=f"r{i}",
+            )
+        )
+    seen, cursor = [], None
+    while True:
+        rows = adapter.list_events("evt-agent", adapter._namespace, limit=3 + 1, cursor=cursor)
+        page = page_from_overfetch(
+            rows, limit=3, timestamp=lambda e: e.created_at, tiebreak=lambda e: e.id
+        )
+        seen.extend(e.summary for e in page.items)
+        if not page.has_more:
+            break
+        cursor = page.next_cursor
+    assert sorted(seen) == [f"r{i}" for i in range(7)]
+    assert len(seen) == 7
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Partitioning and retention
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def pg_conn():
+    import psycopg
+
+    conn = psycopg.connect(PG_DSN, autocommit=True)
+    yield conn
+    conn.close()
+
+
+def _relkind(conn, name: str) -> str | None:
+    with conn.cursor() as cur:
+        cur.execute("SELECT relkind FROM pg_class WHERE relname = %s", (name,))
+        row = cur.fetchone()
+    return row[0] if row else None
+
+
+def _partitions(conn) -> list[str]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT c.relname FROM pg_inherits i
+            JOIN pg_class c ON c.oid = i.inhrelid
+            WHERE i.inhparent = 'amfs_decision_traces'::regclass ORDER BY 1
+            """
+        )
+        return [r[0] for r in cur.fetchall()]
+
+
+def test_fresh_install_creates_a_partitioned_trace_table(adapter, pg_conn) -> None:
+    from datetime import UTC, datetime
+
+    from amfs_postgres.trace_partitions import partition_name
+
+    assert _relkind(pg_conn, "amfs_decision_traces") == "p"
+    parts = _partitions(pg_conn)
+    assert "amfs_decision_traces_default" in parts
+    now = datetime.now(UTC)
+    assert partition_name(now.year, now.month) in parts  # ensure_trace_partitions ran at init
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT a.attname FROM pg_index x
+            JOIN pg_attribute a ON a.attrelid = x.indrelid AND a.attnum = ANY (x.indkey)
+            WHERE x.indrelid = 'amfs_decision_traces'::regclass AND x.indisprimary
+            ORDER BY a.attname
+            """
+        )
+        assert [r[0] for r in cur.fetchall()] == ["created_at", "id"]
+
+
+def test_get_trace_by_id_works_on_the_partitioned_table(adapter) -> None:
+    traces = _saved_traces(adapter, 3)
+    for t in traces:
+        got = adapter.get_trace(t.id)
+        assert got is not None and got.outcome_ref == t.outcome_ref
+    assert adapter.get_trace("00000000-0000-0000-0000-000000000000") is None
+
+
+def test_flat_table_is_migrated_in_place_with_rows_and_policies_kept(adapter, pg_conn) -> None:
+    """The upgrade path: a database from before partitioning, with traces in it."""
+    from amfs_postgres.adapter import PostgresAdapter
+
+    saved = _saved_traces(adapter, 5)
+    adapter.close()
+
+    with pg_conn.cursor() as cur:
+        # Rebuild the pre-partitioning shape: a flat table with PRIMARY KEY (id),
+        # holding the same rows, an RLS policy and an extra index.
+        cur.execute("CREATE TABLE flat_traces (LIKE amfs_decision_traces INCLUDING DEFAULTS)")
+        cur.execute("INSERT INTO flat_traces SELECT * FROM amfs_decision_traces")
+        cur.execute("DROP TABLE amfs_decision_traces CASCADE")
+        cur.execute("ALTER TABLE flat_traces RENAME TO amfs_decision_traces")
+        cur.execute("ALTER TABLE amfs_decision_traces ADD PRIMARY KEY (id)")
+        cur.execute("CREATE INDEX idx_traces_test_extra ON amfs_decision_traces (outcome_ref)")
+        cur.execute(
+            "CREATE POLICY traces_test_policy ON amfs_decision_traces "
+            "USING (namespace = current_setting('amfs.test_ns', true))"
+        )
+        cur.execute("ALTER TABLE amfs_decision_traces ENABLE ROW LEVEL SECURITY")
+        # A stored fingerprint would let the fast path skip the migration.
+        cur.execute("DELETE FROM amfs_schema_state")
+    assert _relkind(pg_conn, "amfs_decision_traces") == "r"
+
+    migrated = PostgresAdapter(dsn=PG_DSN, namespace="test", auto_schema=True)
+    try:
+        assert _relkind(pg_conn, "amfs_decision_traces") == "p"
+        assert _relkind(pg_conn, "amfs_decision_traces_legacy") is None
+        parts = _partitions(pg_conn)
+        assert "amfs_decision_traces_default" in parts
+        assert "amfs_decision_traces_y2026m01" in parts  # the month the rows live in
+
+        # every row survived, is reachable by id, and lives in its month
+        assert migrated.count_traces(agent_id="page-agent") == 5
+        for t in saved:
+            assert migrated.get_trace(t.id) is not None
+        with pg_conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM amfs_decision_traces_default")
+            assert cur.fetchone()[0] == 0
+            cur.execute("SELECT count(*) FROM amfs_decision_traces_y2026m01")
+            assert cur.fetchone()[0] == 5
+            cur.execute("SELECT 1 FROM pg_indexes WHERE indexname = 'idx_traces_test_extra'")
+            assert cur.fetchone() is not None
+            cur.execute(
+                "SELECT 1 FROM pg_policies WHERE tablename = 'amfs_decision_traces' "
+                "AND policyname = 'traces_test_policy'"
+            )
+            assert cur.fetchone() is not None
+            cur.execute(
+                "SELECT relrowsecurity FROM pg_class WHERE relname = 'amfs_decision_traces'"
+            )
+            assert cur.fetchone()[0] is True
+            # the new primary key includes the partition key
+            cur.execute(
+                """
+                SELECT count(*) FROM pg_index x
+                JOIN pg_attribute a ON a.attrelid = x.indrelid AND a.attnum = ANY (x.indkey)
+                WHERE x.indrelid = 'amfs_decision_traces'::regclass AND x.indisprimary
+                """
+            )
+            assert cur.fetchone()[0] == 2
+
+        # a second start is a no-op, not a second migration
+        again = PostgresAdapter(dsn=PG_DSN, namespace="test", auto_schema=True)
+        again.close()
+        assert migrated.count_traces(agent_id="page-agent") == 5
+    finally:
+        migrated.close()
+
+
+def test_ensure_trace_partitions_creates_months_ahead_and_drains_default(adapter, pg_conn) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from amfs_core.models import DecisionTrace
+    from amfs_postgres.trace_partitions import partition_name
+
+    now = datetime.now(UTC)
+    created = adapter.ensure_trace_partitions(months_ahead=4)
+    parts = _partitions(pg_conn)
+    m = now.replace(day=1)
+    for _ in range(5):
+        assert partition_name(m.year, m.month) in parts
+        m = (m.replace(day=28) + timedelta(days=4)).replace(day=1)
+    # the two extra months are new; this month and the next two existed from init
+    assert len(created) == 2
+
+    # A backdated trace lands in DEFAULT; the next upkeep gives its month a
+    # partition and moves the row out.
+    old = adapter.save_trace(
+        DecisionTrace(
+            agent_id="old-agent",
+            session_id="s",
+            outcome_ref="OLD-1",
+            outcome_type="success",
+            created_at=datetime(2019, 6, 15, tzinfo=UTC),
+        )
+    )
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM amfs_decision_traces_default")
+        assert cur.fetchone()[0] == 1
+    assert adapter.ensure_trace_partitions() == ["amfs_decision_traces_y2019m06"]
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM amfs_decision_traces_default")
+        assert cur.fetchone()[0] == 0
+        cur.execute("SELECT count(*) FROM amfs_decision_traces_y2019m06")
+        assert cur.fetchone()[0] == 1
+    assert adapter.get_trace(old.id) is not None
+    assert adapter.ensure_trace_partitions() == []
+
+
+def test_apply_trace_retention_strips_payloads_and_drops_old_partitions(adapter, pg_conn) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from amfs_core.models import DecisionTrace, ToolCall
+
+    now = datetime.now(UTC)
+
+    def save(ref, age_days):
+        return adapter.save_trace(
+            DecisionTrace(
+                agent_id="ret-agent",
+                session_id="s",
+                outcome_ref=ref,
+                outcome_type="success",
+                task_input="prompt " + ref,
+                response_text="answer " + ref,
+                tool_calls=[ToolCall(tool_name="Shell", arguments={"cmd": "ls"})],
+                created_at=now - timedelta(days=age_days),
+            )
+        )
+
+    fresh = save("FRESH", 1)
+    cold = save("COLD", 45)
+    ancient = save("ANCIENT", 400)
+    adapter.ensure_trace_partitions()  # gives the backdated rows their months
+
+    # Payload stripping only: nothing dropped, metadata kept.
+    result = adapter.apply_trace_retention(hot_days=30)
+    assert result["dropped_partitions"] == []
+    assert result["stripped_rows"] == 2
+
+    f = adapter.get_trace(fresh.id)
+    assert f.task_input == "prompt FRESH" and len(f.tool_calls) == 1
+    for t in (adapter.get_trace(cold.id), adapter.get_trace(ancient.id)):
+        assert t is not None
+        assert t.task_input is None and t.response_text is None
+        assert t.tool_calls == []
+        assert t.outcome_ref in ("COLD", "ANCIENT")  # metadata stays
+
+    # Running again strips nothing new.
+    assert adapter.apply_trace_retention(hot_days=30)["stripped_rows"] == 0
+
+    # Dropping: only partitions wholly older than the cutoff go.
+    ancient_month = (now - timedelta(days=400)).strftime("amfs_decision_traces_y%Ym%m")
+    result = adapter.apply_trace_retention(hot_days=30, drop_after_days=365)
+    assert ancient_month in result["dropped_partitions"]
+    assert adapter.get_trace(ancient.id) is None
+    assert adapter.get_trace(cold.id) is not None
+    assert adapter.get_trace(fresh.id) is not None
+    assert ancient_month not in _partitions(pg_conn)
+
+
+def test_retention_cli_dry_run_reports_without_changing_anything(adapter, pg_conn) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from amfs_core.models import DecisionTrace
+    from amfs_postgres import retention
+
+    adapter.save_trace(
+        DecisionTrace(
+            agent_id="cli-agent",
+            session_id="s",
+            outcome_ref="CLI-1",
+            outcome_type="success",
+            task_input="keep me",
+            created_at=datetime.now(UTC) - timedelta(days=90),
+        )
+    )
+    adapter.ensure_trace_partitions()
+    code = retention.main(["--dsn", PG_DSN, "--namespace", "test", "--hot-days", "30", "--dry-run"])
+    assert code == 0
+    rows = adapter.list_traces(agent_id="cli-agent", limit=10)
+    assert rows[0].task_input == "keep me"

--- a/tests/test_event_account_scoping.py
+++ b/tests/test_event_account_scoping.py
@@ -95,6 +95,13 @@ class TestTheTimelineStaysScoped:
         """These return whole event rows rather than counts, so the same
         omission would disclose another account's agent names and summaries."""
         body = _method(SYNC, method)
+        if "_event_conditions(" in body:
+            # The WHERE clause is built by a helper shared with the async adapter;
+            # the filter has to be in there, and the method has to pass the account.
+            assert "account_id=self._get_current_account_id()" in body, (
+                f"{method} does not pass the current account to _event_conditions"
+            )
+            body += _method(SYNC, "_event_conditions")
         assert "account_id = %s" in body, (
             f"{method} reads amfs_events without an account filter"
         )

--- a/tests/unit/test_keyset_pagination.py
+++ b/tests/unit/test_keyset_pagination.py
@@ -1,0 +1,606 @@
+"""Keyset pagination: the cursor codec, ``has_more`` semantics, the paginated
+routes, and the counts that used to be capped at 10,000 rows.
+
+These run without Postgres. The SQL side of the same contract is exercised in
+tests/integration/test_postgres_adapter.py when ``AMFS_TEST_PG_DSN`` is set.
+"""
+
+from __future__ import annotations
+
+import types
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from amfs_core.abc import AdapterABC
+from amfs_core.models import (
+    DecisionTrace,
+    Event,
+    EventType,
+    MemoryEntry,
+    OutcomeRecord,
+    Provenance,
+    TraceEntry,
+)
+from amfs_core.pagination import (
+    DEFAULT_MAX_SCAN_ROWS,
+    MAX_PAGE_SIZE,
+    InvalidCursorError,
+    clamp_limit,
+    decode_cursor,
+    encode_cursor,
+    entry_tiebreak,
+    max_scan_rows,
+    page_from_overfetch,
+    paginate_desc,
+)
+
+T0 = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _entry(
+    i: int,
+    *,
+    agent: str = "agent-a",
+    entity_path: str = "svc/api",
+    key: str | None = None,
+    written_at: datetime | None = None,
+) -> MemoryEntry:
+    return MemoryEntry(
+        entity_path=entity_path,
+        key=key or f"k{i:03d}",
+        value={"i": i},
+        provenance=Provenance(
+            agent_id=agent,
+            session_id="s",
+            written_at=written_at or (T0 + timedelta(minutes=i)),
+        ),
+    )
+
+
+def _trace(i: int, *, agent: str = "agent-a", outcome_ref: str | None = None) -> DecisionTrace:
+    return DecisionTrace(
+        id=str(uuid.UUID(int=i)),
+        agent_id=agent,
+        session_id="s",
+        outcome_ref=outcome_ref if outcome_ref is not None else f"OUT-{i}",
+        outcome_type="success",
+        causal_entries=[TraceEntry(entity_path="svc/api", key="k", version=1, confidence=1.0)],
+        created_at=T0 + timedelta(minutes=i),
+    )
+
+
+def _event(i: int, *, agent: str = "agent-a") -> Event:
+    return Event(
+        id=str(uuid.UUID(int=10_000 + i)),
+        agent_id=agent,
+        event_type=EventType.READ,
+        summary=f"read {i}",
+        created_at=T0 + timedelta(minutes=i, seconds=30),
+    )
+
+
+# ── cursor codec ──────────────────────────────────────────────────────
+
+
+class TestCursorCodec:
+    def test_round_trip_with_string_tiebreak(self):
+        ts = datetime(2026, 3, 4, 5, 6, 7, 123456, tzinfo=UTC)
+        cur = encode_cursor(ts, "abc-123")
+        assert isinstance(cur, str) and "=" not in cur  # url-safe, unpadded
+        assert decode_cursor(cur) == (ts, "abc-123")
+
+    def test_round_trip_with_composite_tiebreak(self):
+        ts = datetime(2026, 3, 4, tzinfo=UTC)
+        tb = ["svc/api", "k001", 3]
+        assert decode_cursor(encode_cursor(ts, tb)) == (ts, tb)
+
+    def test_naive_timestamp_is_read_back_as_utc(self):
+        cur = encode_cursor(datetime(2026, 3, 4, 12, 0, 0), "x")
+        ts, _ = decode_cursor(cur)
+        assert ts.tzinfo is not None
+        assert ts == datetime(2026, 3, 4, 12, 0, 0, tzinfo=UTC)
+
+    def test_non_utc_timestamp_keeps_its_instant(self):
+        from datetime import timezone
+
+        plus9 = timezone(timedelta(hours=9))
+        ts = datetime(2026, 3, 4, 21, 0, 0, tzinfo=plus9)
+        decoded, _ = decode_cursor(encode_cursor(ts, "x"))
+        assert decoded == ts
+
+    @pytest.mark.parametrize("bad", ["", "not base64!", "AAAA", "e30", "WzEsMl0"])
+    def test_malformed_cursors_raise(self, bad):
+        with pytest.raises(InvalidCursorError):
+            decode_cursor(bad)
+
+    def test_entry_tiebreak_is_json_shaped(self):
+        e = _entry(1)
+        assert entry_tiebreak(e) == ["svc/api", "k001", 1]
+
+
+class TestLimits:
+    def test_clamp_limit(self):
+        assert clamp_limit(None) == 100
+        assert clamp_limit(0) == 1
+        assert clamp_limit(-5) == 1
+        assert clamp_limit(50) == 50
+        assert clamp_limit(MAX_PAGE_SIZE + 1) == MAX_PAGE_SIZE
+
+    def test_max_scan_rows_reads_env(self, monkeypatch):
+        monkeypatch.delenv("AMFS_MAX_SCAN_ROWS", raising=False)
+        assert max_scan_rows() == DEFAULT_MAX_SCAN_ROWS
+        monkeypatch.setenv("AMFS_MAX_SCAN_ROWS", "250")
+        assert max_scan_rows() == 250
+        monkeypatch.setenv("AMFS_MAX_SCAN_ROWS", "garbage")
+        assert max_scan_rows() == DEFAULT_MAX_SCAN_ROWS
+        monkeypatch.setenv("AMFS_MAX_SCAN_ROWS", "0")
+        assert max_scan_rows() == DEFAULT_MAX_SCAN_ROWS
+
+
+# ── in-memory pagination primitives ───────────────────────────────────
+
+
+class TestPaginateDesc:
+    def _walk(self, items, limit, **kw):
+        seen, cursor, pages = [], None, 0
+        while True:
+            page = paginate_desc(
+                items,
+                timestamp=lambda e: e.provenance.written_at,
+                tiebreak=entry_tiebreak,
+                limit=limit,
+                cursor=cursor,
+                **kw,
+            )
+            pages += 1
+            seen.extend(page.items)
+            if not page.has_more:
+                assert page.next_cursor is None
+                return seen, pages
+            assert page.next_cursor is not None
+            cursor = page.next_cursor
+
+    def test_pages_cover_everything_once_newest_first(self):
+        items = [_entry(i) for i in range(23)]
+        seen, pages = self._walk(items, 5)
+        assert pages == 5
+        assert [e.key for e in seen] == [f"k{i:03d}" for i in reversed(range(23))]
+
+    def test_exact_multiple_has_no_phantom_page(self):
+        items = [_entry(i) for i in range(10)]
+        page = paginate_desc(
+            items,
+            timestamp=lambda e: e.provenance.written_at,
+            tiebreak=entry_tiebreak,
+            limit=10,
+        )
+        assert len(page.items) == 10
+        assert page.has_more is False
+        assert page.next_cursor is None
+
+    def test_ties_on_timestamp_are_broken_deterministically(self):
+        same = T0 + timedelta(hours=1)
+        items = [_entry(i, written_at=same) for i in range(7)]
+        seen, _ = self._walk(items, 3)
+        assert len(seen) == 7
+        assert len({e.key for e in seen}) == 7
+
+    def test_offset_is_honoured_without_a_cursor(self):
+        items = [_entry(i) for i in range(10)]
+        page = paginate_desc(
+            items,
+            timestamp=lambda e: e.provenance.written_at,
+            tiebreak=entry_tiebreak,
+            limit=3,
+            offset=4,
+        )
+        assert [e.key for e in page.items] == ["k005", "k004", "k003"]
+        assert page.has_more is True
+
+    def test_page_from_overfetch(self):
+        rows = [_trace(i) for i in range(6)]
+        page = page_from_overfetch(
+            rows, limit=5, timestamp=lambda t: t.created_at, tiebreak=lambda t: t.id
+        )
+        assert len(page.items) == 5 and page.has_more
+        assert decode_cursor(page.next_cursor) == (rows[4].created_at, rows[4].id)
+        page = page_from_overfetch(
+            rows[:5], limit=5, timestamp=lambda t: t.created_at, tiebreak=lambda t: t.id
+        )
+        assert len(page.items) == 5 and not page.has_more and page.next_cursor is None
+
+
+# ── filesystem adapter: has_more and agent filtering ─────────────────
+
+
+@pytest.fixture
+def fs_adapter(tmp_path):
+    from amfs_filesystem.adapter import FilesystemAdapter
+
+    return FilesystemAdapter(root=tmp_path, namespace="test")
+
+
+class TestFilesystemListEntriesForAgent:
+    # The filesystem layout keys entities by directory name, so these use flat
+    # entity paths and an explicit hidden prefix rather than ``_system/``.
+    HIDDEN = ("hidden-",)
+
+    def _seed(self, adapter):
+        for i in range(12):
+            adapter.write(_entry(i, entity_path="svc-api"))
+        for i in range(3):
+            adapter.write(_entry(100 + i, agent="agent-b", entity_path="svc-other"))
+        adapter.write(_entry(200, entity_path="hidden-internal"))
+        adapter.write(_entry(300, entity_path="hidden-internal", key="k300"))
+
+    def test_has_more_semantics_across_pages(self, fs_adapter):
+        self._seed(fs_adapter)
+        seen: list[str] = []
+        cursor = None
+        pages = 0
+        while True:
+            rows = fs_adapter.list_entries_for_agent(
+                "agent-a", limit=5 + 1, cursor=cursor, exclude_prefixes=self.HIDDEN
+            )
+            page = page_from_overfetch(
+                rows, limit=5, timestamp=lambda e: e.provenance.written_at, tiebreak=entry_tiebreak
+            )
+            pages += 1
+            seen.extend(e.key for e in page.items)
+            if not page.has_more:
+                break
+            cursor = page.next_cursor
+        # 12 of agent-a's entries; the hidden ones are excluded.
+        assert pages == 3
+        assert seen == [f"k{i:03d}" for i in reversed(range(12))]
+
+    def test_exact_page_boundary_reports_no_more(self, fs_adapter):
+        for i in range(5):
+            fs_adapter.write(_entry(i, entity_path="svc-api"))
+        rows = fs_adapter.list_entries_for_agent("agent-a", limit=6)
+        page = page_from_overfetch(
+            rows, limit=5, timestamp=lambda e: e.provenance.written_at, tiebreak=entry_tiebreak
+        )
+        assert len(page.items) == 5 and page.has_more is False
+
+    def test_filters_by_agent_time_window_and_prefix(self, fs_adapter):
+        self._seed(fs_adapter)
+        rows = fs_adapter.list_entries_for_agent(
+            "agent-a",
+            since=T0 + timedelta(minutes=3),
+            until=T0 + timedelta(minutes=8),
+            limit=100,
+            exclude_prefixes=self.HIDDEN,
+        )
+        assert [e.key for e in rows] == ["k007", "k006", "k005", "k004", "k003"]
+        assert all(e.provenance.agent_id == "agent-a" for e in rows)
+
+        rows = fs_adapter.list_entries_for_agent("agent-a", limit=100, exclude_prefixes=self.HIDDEN)
+        assert not any(e.entity_path.startswith("hidden-") for e in rows)
+        assert len(rows) == 12
+
+        rows = fs_adapter.list_entries_for_agent("agent-b", limit=100)
+        assert [e.key for e in rows] == ["k102", "k101", "k100"]
+
+        rows = fs_adapter.list_entries_for_agent("agent-a", limit=100, exclude_prefixes=())
+        assert "k300" in {e.key for e in rows}
+
+    def test_only_current_versions_are_listed(self, fs_adapter):
+        fs_adapter.write(_entry(1, key="dup", entity_path="svc-api"))
+        fs_adapter.write(
+            _entry(2, key="dup", entity_path="svc-api", written_at=T0 + timedelta(hours=1))
+        )
+        rows = fs_adapter.list_entries_for_agent("agent-a", limit=10)
+        assert [(e.key, e.version) for e in rows] == [("dup", 2)]
+
+    def test_matches_the_abc_default_ordering(self, fs_adapter):
+        """The streaming override must page identically to the base class."""
+        self._seed(fs_adapter)
+        base = AdapterABC.list_entries_for_agent(
+            fs_adapter, "agent-a", limit=7, exclude_prefixes=self.HIDDEN
+        )
+        fast = fs_adapter.list_entries_for_agent("agent-a", limit=7, exclude_prefixes=self.HIDDEN)
+        assert [(e.entity_path, e.key, e.version) for e in base] == [
+            (e.entity_path, e.key, e.version) for e in fast
+        ]
+
+
+# ── a small in-memory adapter for the route and count tests ──────────
+
+
+class _FakeAdapter(AdapterABC):
+    """Enough of the adapter contract for the paginated routes.
+
+    Lists are held in memory; ``list_traces``/``list_events`` page with the same
+    primitive the base class uses, so the routes see the sync contract exactly
+    as a filesystem-backed server would.
+    """
+
+    def __init__(self, *, traces=(), events=(), entries=(), outcome_total=0):
+        self.traces = list(traces)
+        self.events = list(events)
+        self.entries = list(entries)
+        self.outcome_total = outcome_total
+        self.calls: list[tuple[str, dict]] = []
+
+    # unused parts of the contract
+    def read(self, *a, **k):
+        return None
+
+    def write(self, entry):
+        return entry
+
+    def watch(self, *a, **k):
+        raise NotImplementedError
+
+    def commit_outcome(self, record):
+        return []
+
+    def write_batch(self, entries):
+        return entries
+
+    def list(self, entity_path=None, **k):
+        return list(self.entries)
+
+    def search(self, *a, **k):
+        return []
+
+    def stats(self):
+        raise NotImplementedError
+
+    def record_outcome(self, *a, **k):
+        return []
+
+    def list_outcomes(self, *, entity_path=None, since=None, limit=1000, outcome_ref=None):
+        self.calls.append(("list_outcomes", {"limit": limit}))
+        return [
+            OutcomeRecord(
+                outcome_ref=f"O-{i}", outcome_type="success", committed_at=T0, agent_id="agent-a",
+            )
+            for i in range(min(limit, self.outcome_total))
+        ]
+
+    def count_outcomes(self, *, entity_path=None, since=None):
+        self.calls.append(("count_outcomes", {}))
+        return self.outcome_total
+
+    def list_traces(
+        self, *, entity_path=None, agent_id=None, outcome_type=None,
+        limit=100, offset=0, cursor=None, since=None, until=None,
+    ):
+        self.calls.append(("list_traces", {"limit": limit, "offset": offset, "cursor": cursor}))
+        rows = [
+            t for t in self.traces
+            if (agent_id is None or t.agent_id == agent_id)
+            and (outcome_type is None or t.outcome_type == outcome_type)
+            and (entity_path is None or any(c.entity_path == entity_path for c in t.causal_entries))
+            and (since is None or t.created_at >= since)
+            and (until is None or t.created_at < until)
+        ]
+        return paginate_desc(
+            rows, timestamp=lambda t: t.created_at, tiebreak=lambda t: t.id,
+            limit=limit, cursor=cursor, offset=offset,
+        ).items
+
+    def list_events(
+        self, agent_id, namespace="default", *, branch=None, event_type=None,
+        since=None, limit=100, offset=0, cursor=None, until=None,
+    ):
+        self.calls.append(("list_events", {"limit": limit, "offset": offset, "cursor": cursor}))
+        rows = [
+            e for e in self.events
+            if e.agent_id == agent_id
+            and (event_type is None or e.event_type.value == event_type)
+            and (since is None or e.created_at >= since)
+            and (until is None or e.created_at < until)
+        ]
+        return paginate_desc(
+            rows, timestamp=lambda e: e.created_at, tiebreak=lambda e: e.id,
+            limit=limit, cursor=cursor, offset=offset,
+        ).items
+
+
+# ── the routes ────────────────────────────────────────────────────────
+
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+import amfs_http.server as server  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+def _client(monkeypatch, adapter):
+    stats = types.SimpleNamespace(
+        total_entries=3, total_agents=1, agents={"agent-a": 3}, entities={"svc/api": 3},
+    )
+    mem = types.SimpleNamespace(
+        namespace="test-ns",
+        _adapter=adapter,
+        list=lambda entity_path=None, branch="main": list(adapter.entries),
+        stats=lambda: stats,
+    )
+    monkeypatch.setattr(server, "_get_memory", lambda: mem)
+    monkeypatch.setattr(server, "_async_adapter", None)
+    monkeypatch.setattr(server, "_get_visibility_filter", lambda request: None)
+    monkeypatch.setattr(server, "_active_visibility_filter", lambda request: None)
+    monkeypatch.setattr(server, "_visible_agent_ids", lambda request: None)
+    monkeypatch.setattr(server, "_get_db_pool", lambda: None)
+    return TestClient(server.app)
+
+
+class TestTracesRoute:
+    def test_pages_with_cursor_and_reports_has_more(self, monkeypatch):
+        adapter = _FakeAdapter(traces=[_trace(i) for i in range(7)])
+        client = _client(monkeypatch, adapter)
+
+        r = client.get("/api/v1/traces", params={"limit": 3})
+        body = r.json()
+        assert r.status_code == 200
+        assert [t["outcome_ref"] for t in body["traces"]] == ["OUT-6", "OUT-5", "OUT-4"]
+        assert body["has_more"] is True and body["next_cursor"]
+        # overfetch by one so has_more is exact
+        assert adapter.calls[-1] == ("list_traces", {"limit": 4, "offset": 0, "cursor": None})
+
+        r = client.get("/api/v1/traces", params={"limit": 3, "cursor": body["next_cursor"]})
+        body = r.json()
+        assert [t["outcome_ref"] for t in body["traces"]] == ["OUT-3", "OUT-2", "OUT-1"]
+        assert body["has_more"] is True
+
+        r = client.get("/api/v1/traces", params={"limit": 3, "cursor": body["next_cursor"]})
+        body = r.json()
+        assert [t["outcome_ref"] for t in body["traces"]] == ["OUT-0"]
+        assert body["has_more"] is False and body["next_cursor"] is None
+
+    def test_offset_still_works_without_a_cursor(self, monkeypatch):
+        adapter = _FakeAdapter(traces=[_trace(i) for i in range(7)])
+        client = _client(monkeypatch, adapter)
+        body = client.get("/api/v1/traces", params={"limit": 2, "offset": 2}).json()
+        assert [t["outcome_ref"] for t in body["traces"]] == ["OUT-4", "OUT-3"]
+        assert body["has_more"] is True
+
+    def test_bad_cursor_is_a_400(self, monkeypatch):
+        client = _client(monkeypatch, _FakeAdapter())
+        r = client.get("/api/v1/traces", params={"cursor": "definitely-not-a-cursor"})
+        assert r.status_code == 400
+        assert "cursor" in r.json()["detail"].lower()
+
+    def test_limit_is_clamped(self, monkeypatch):
+        adapter = _FakeAdapter(traces=[_trace(i) for i in range(3)])
+        client = _client(monkeypatch, adapter)
+        assert client.get("/api/v1/traces", params={"limit": 50_000}).status_code == 200
+        assert adapter.calls[-1][1]["limit"] == MAX_PAGE_SIZE + 1
+
+
+class TestTimelineRoute:
+    def test_pages_with_cursor(self, monkeypatch):
+        adapter = _FakeAdapter(events=[_event(i) for i in range(5)])
+        client = _client(monkeypatch, adapter)
+        body = client.get("/api/v1/agents/agent-a/timeline", params={"limit": 2}).json()
+        assert [e["summary"] for e in body["events"]] == ["read 4", "read 3"]
+        assert body["count"] == 2 and body["has_more"] is True
+        body = client.get(
+            "/api/v1/agents/agent-a/timeline",
+            params={"limit": 2, "cursor": body["next_cursor"]},
+        ).json()
+        assert [e["summary"] for e in body["events"]] == ["read 2", "read 1"]
+        body = client.get(
+            "/api/v1/agents/agent-a/timeline",
+            params={"limit": 2, "cursor": body["next_cursor"]},
+        ).json()
+        assert [e["summary"] for e in body["events"]] == ["read 0"]
+        assert body["has_more"] is False and body["next_cursor"] is None
+
+    def test_since_until_window(self, monkeypatch):
+        adapter = _FakeAdapter(events=[_event(i) for i in range(5)])
+        client = _client(monkeypatch, adapter)
+        body = client.get(
+            "/api/v1/agents/agent-a/timeline",
+            params={
+                "since": (T0 + timedelta(minutes=1)).isoformat(),
+                "until": (T0 + timedelta(minutes=3)).isoformat(),
+            },
+        ).json()
+        assert [e["summary"] for e in body["events"]] == ["read 2", "read 1"]
+
+    def test_bad_timestamp_is_a_400(self, monkeypatch):
+        client = _client(monkeypatch, _FakeAdapter())
+        r = client.get("/api/v1/agents/agent-a/timeline", params={"since": "yesterday"})
+        assert r.status_code == 400
+
+
+class TestActivityRoute:
+    def _adapter(self):
+        entries = [_entry(i) for i in range(6)]  # agent-a writes at T0+0..5 min
+        entries += [_entry(50 + i, agent="agent-b") for i in range(3)]  # not agent-a
+        entries += [_entry(90, entity_path="_system/x")]  # hidden prefix
+        traces = [_trace(i) for i in range(4)]  # outcomes at T0+0..3 min
+        traces.append(_trace(20, outcome_ref=""))  # no outcome_ref: never shown
+        traces.append(_trace(30, agent="agent-b"))  # not agent-a
+        events = [_event(i) for i in range(3)]  # T0+0..2 min +30s
+        events.append(_event(40, agent="agent-b"))
+        return _FakeAdapter(traces=traces, events=events, entries=entries)
+
+    def test_filters_to_the_agent_and_merges_newest_first(self, monkeypatch):
+        client = _client(monkeypatch, self._adapter())
+        body = client.get("/api/v1/agents/agent-a/activity", params={"limit": 100}).json()
+        assert body["agentId"] == "agent-a"
+        assert body["has_more"] is False and body["next_cursor"] is None
+        kinds = [(t["type"], t["timestamp"]) for t in body["timeline"]]
+        # 6 writes + 4 outcomes + 3 read events; agent-b and _system/ excluded,
+        # the trace without an outcome_ref dropped.
+        assert len(kinds) == 13
+        stamps = [k[1] for k in kinds]
+        assert stamps == sorted(stamps, reverse=True)
+        assert {k[0] for k in kinds} == {"write", "outcome", "read"}
+        assert all(t.get("outcomeRef", "x") for t in body["timeline"])
+        assert not any(t.get("entityPath", "").startswith("_system/") for t in body["timeline"])
+
+    def test_pages_cover_the_merged_feed_exactly_once(self, monkeypatch):
+        client = _client(monkeypatch, self._adapter())
+        full = client.get("/api/v1/agents/agent-a/activity", params={"limit": 100}).json()
+        expected = [(t["type"], t["timestamp"]) for t in full["timeline"]]
+
+        seen: list[tuple[str, str]] = []
+        cursor = None
+        for _ in range(20):
+            params = {"limit": 4}
+            if cursor:
+                params["cursor"] = cursor
+            body = client.get("/api/v1/agents/agent-a/activity", params=params).json()
+            seen.extend((t["type"], t["timestamp"]) for t in body["timeline"])
+            if not body["has_more"]:
+                assert body["next_cursor"] is None
+                break
+            cursor = body["next_cursor"]
+        assert seen == expected
+
+    def test_since_until_bound_every_source(self, monkeypatch):
+        client = _client(monkeypatch, self._adapter())
+        body = client.get(
+            "/api/v1/agents/agent-a/activity",
+            params={
+                "since": (T0 + timedelta(minutes=1)).isoformat(),
+                "until": (T0 + timedelta(minutes=3)).isoformat(),
+            },
+        ).json()
+        stamps = [datetime.fromisoformat(t["timestamp"]) for t in body["timeline"]]
+        lo, hi = T0 + timedelta(minutes=1), T0 + timedelta(minutes=3)
+        assert stamps and all(lo <= s < hi for s in stamps)
+        assert {t["type"] for t in body["timeline"]} == {"write", "outcome", "read"}
+
+    def test_reads_bounded_pages_not_the_whole_namespace(self, monkeypatch):
+        adapter = self._adapter()
+        client = _client(monkeypatch, adapter)
+        client.get("/api/v1/agents/agent-a/activity", params={"limit": 2})
+        limits = {
+            name: kw["limit"]
+            for name, kw in adapter.calls
+            if name in ("list_traces", "list_events")
+        }
+        assert limits == {"list_traces": 3, "list_events": 3}
+
+    def test_foreign_cursor_is_a_400(self, monkeypatch):
+        client = _client(monkeypatch, self._adapter())
+        cur = encode_cursor(T0, "a-plain-trace-cursor")
+        r = client.get("/api/v1/agents/agent-a/activity", params={"cursor": cur})
+        assert r.status_code == 400
+
+
+class TestAdminUsageCount:
+    def test_decision_trace_quota_counts_past_ten_thousand(self, monkeypatch):
+        adapter = _FakeAdapter(outcome_total=25_000)
+        client = _client(monkeypatch, adapter)
+        r = client.get("/api/v1/admin/usage")
+        assert r.status_code == 200
+        quotas = {q["label"]: q["current"] for q in r.json()["quotas"]}
+        assert quotas["Decision traces"] == 25_000
+        assert ("count_outcomes", {}) in adapter.calls
+        assert not any(name == "list_outcomes" for name, _ in adapter.calls)
+
+    def test_base_class_count_is_bounded_by_the_scan_ceiling(self, monkeypatch):
+        """Adapters without a SQL count fall back to a capped scan, so the
+        ceiling is what limits them, and it is configurable."""
+        adapter = _FakeAdapter(outcome_total=25_000)
+        monkeypatch.setenv("AMFS_MAX_SCAN_ROWS", "500")
+        assert AdapterABC.count_outcomes(adapter) == 500
+        assert adapter.calls[-1] == ("list_outcomes", {"limit": 500})

--- a/tests/unit/test_keyset_pagination.py
+++ b/tests/unit/test_keyset_pagination.py
@@ -470,6 +470,25 @@ class TestTracesRoute:
         assert client.get("/api/v1/traces", params={"limit": 50_000}).status_code == 200
         assert adapter.calls[-1][1]["limit"] == MAX_PAGE_SIZE + 1
 
+    def test_since_until_bound_the_query_not_the_page(self, monkeypatch):
+        # A window that excludes the newest traces must still return the older
+        # matches on the first page. Filtering the page after the fact would
+        # return [] here and stop any cursor walk before reaching OUT-1/OUT-2.
+        adapter = _FakeAdapter(traces=[_trace(i) for i in range(7)])
+        client = _client(monkeypatch, adapter)
+        r = client.get(
+            "/api/v1/traces",
+            params={
+                "limit": 2,
+                "since": (T0 + timedelta(minutes=1)).isoformat(),
+                "until": (T0 + timedelta(minutes=3)).isoformat(),  # exclusive
+            },
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert [t["outcome_ref"] for t in body["traces"]] == ["OUT-2", "OUT-1"]
+        assert body["has_more"] is False
+
 
 class TestTimelineRoute:
     def test_pages_with_cursor(self, monkeypatch):

--- a/tests/unit/test_keyset_pagination.py
+++ b/tests/unit/test_keyset_pagination.py
@@ -489,6 +489,25 @@ class TestTracesRoute:
         assert [t["outcome_ref"] for t in body["traces"]] == ["OUT-2", "OUT-1"]
         assert body["has_more"] is False
 
+    def test_naive_since_until_are_taken_as_utc(self, monkeypatch):
+        # Stored timestamps are aware; a naive query value must not reach the
+        # adapter's comparison naive (TypeError) or be read in the session
+        # timezone. Same window as above, written without an offset.
+        adapter = _FakeAdapter(traces=[_trace(i) for i in range(7)])
+        client = _client(monkeypatch, adapter)
+        r = client.get(
+            "/api/v1/traces",
+            params={"since": "2026-01-01T00:01:00", "until": "2026-01-01T00:03:00"},
+        )
+        assert r.status_code == 200
+        assert [t["outcome_ref"] for t in r.json()["traces"]] == ["OUT-2", "OUT-1"]
+
+    def test_bad_timestamp_is_a_400(self, monkeypatch):
+        client = _client(monkeypatch, _FakeAdapter())
+        r = client.get("/api/v1/traces", params={"since": "yesterday"})
+        assert r.status_code == 400
+        assert "timestamp" in r.json()["detail"].lower()
+
 
 class TestTimelineRoute:
     def test_pages_with_cursor(self, monkeypatch):

--- a/tests/unit/test_seal_attribution.py
+++ b/tests/unit/test_seal_attribution.py
@@ -73,11 +73,24 @@ def sealed(monkeypatch) -> list[Any]:
     records: list[Any] = []
 
     monkeypatch.setattr(http_server, "_HAS_PRO_TRACES", True, raising=False)
-    for name in ("ImmutableDecisionTrace", "TraceEntry", "TraceExternalContext",
-                 "ProToolCall"):
-        monkeypatch.setattr(
-            http_server, name, lambda **kw: SimpleNamespace(**kw), raising=False
-        )
+
+    # The OSS -> immutable mapping is the Pro package's; the server hands it the
+    # trace plus the identity it resolved. The stub keeps both so the assertions
+    # below read what the server passed, not what the trace happened to carry.
+    def _map(oss_trace, **kw):
+        fields = {
+            k: getattr(oss_trace, k, None)
+            for k in ("outcome_ref", "outcome_type", "task_input", "agent_id")
+        }
+        fields.update(kw)
+        return SimpleNamespace(**fields)
+
+    monkeypatch.setattr(
+        http_server, "_pro_immutable_from_oss_trace", _map, raising=False
+    )
+    monkeypatch.setattr(
+        http_server, "_pro_finalize_spans", lambda imm: imm, raising=False
+    )
     monkeypatch.setattr(
         http_server, "seal", lambda imm, *a, **kw: imm, raising=False
     )

--- a/tests/unit/test_trace_capture.py
+++ b/tests/unit/test_trace_capture.py
@@ -543,5 +543,8 @@ def test_the_postgres_read_queries_select_the_capture_columns() -> None:
 
     for fn in (pg.PostgresAdapter.get_trace, pg.PostgresAdapter.list_traces):
         source = inspect.getsource(fn)
+        if "_TRACE_COLUMNS" in source:
+            # The SELECT list lives in a shared class constant; check that instead.
+            source += pg.PostgresAdapter._TRACE_COLUMNS
         assert "task_input" in source, f"{fn.__name__} does not select task_input"
         assert "response_text" in source, f"{fn.__name__} does not select response_text"


### PR DESCRIPTION
## Summary

OSS half of the agent-evaluation build. Everything feature-level (span model, OTLP ingest, judges, behaviors, fixes, investigate, dashboard) is private and lands in the companion `amfs-internal` PR; this PR carries only the scale and correctness fixes the hosted app needs from the OSS package it runs on, plus a TypeScript SDK gap fix and docs.

No new OSS features. No new OSS routes.

## Changes

**Scale (`e6aedc1`)**
- Keyset pagination on `GET /api/v1/traces` and `/timeline` (opaque cursor, `next_cursor`/`has_more`); `since`/`until` filters.
- `agent_activity` aggregated in SQL instead of loading every trace into Python.
- Removed the hard-coded `limit=10000` reads; `/admin/usage` counts in SQL.
- `amfs_decision_traces` is range-partitioned by month on new installs, with a migration path for flat tables and a retention CLI (`amfs_postgres.retention`) that strips payloads then drops old partitions.
- GIN index on `causal_entries`; filtering uses it.
- Trace routes go through the async adapter.

**Correctness (`1419994`)**
- `POST /api/v1/traces` did not seal traces — when `amfs_traces` is installed it now delegates to `seal_on_demand.immutable_from_oss_trace`, the same mapper the Cortex worker uses.

**SDK / MCP (`d671c05`)**
- TypeScript `DecisionTrace` was dropping `taskInput`, `responseText`, `toolCalls`, `sessionMetadata`. Added, with `listTracesPageAsync` returning the paged shape; `listTracesAsync` stays array-returning.
- `_http_api_call` treated any non-200 as an error, so proxied tools hitting 201/202 endpoints got their body wrapped in `{"error"}`. Accepts all 2xx now.

**Docs (`5758193`, `d671c05`)**
- `editions.md`: `amfs_record_llm_call` and agent evaluation are Pro-only.
- `reference/api.md`: pagination parameters and response shape.
- `reference/sdk-mcp-parity.md`: Pro span/trace-navigation and eval tools listed.

## Compatibility

- Existing `GET /api/v1/traces` callers that pass `offset` keep working; `cursor` wins when both are given.
- Partitioning applies to fresh installs; existing flat tables are migrated by `trace_partitions.migrate_flat_table` (idempotent, guarded).
- Python SDK `list_traces` gains optional `cursor/since/until`; no signature breaks.

## Tests

- `uv run pytest tests -q`: 1093 passed, 84 skipped, 2 failed — both pre-existing on `dev` (`test_explicit_env_var` is environmental via the sticky `~/.amfs/.identity`; `test_outcome_propagates_across_agents` asserts old confidence semantics that `dev` already changed).
- `packages/sdk-typescript`: 50 vitest passed, `tsc` build clean.

## Merge order

Merge this before or together with `raia-live/amfs-internal` `feat/agent-evaluation`; the private PR's seal path and pagination consumers assume these are present.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large Postgres migration/partitioning and pagination behavior changes affect core trace storage and list APIs; incorrect cursors or failed migrations could impact hosted reads, though failures are designed to retry or fall back to flat tables.
> 
> **Overview**
> This PR hardens OSS for hosted trace volume and closes a sealing gap, without adding new public product surfaces.
> 
> **Pagination and bounded scans.** Shared keyset helpers in `amfs_core.pagination` drive `GET /api/v1/traces`, agent timeline, and activity feeds with `cursor`, `since`/`until`, and `next_cursor` / `has_more`. Agent activity merges three adapter-paged streams instead of scanning the whole namespace. Hard-coded 10k trace/outcome pulls are replaced by SQL `count_*`, `trace_read_counts`, and `list_entries_for_agent` (filesystem uses a streaming heap). Trace list/detail/timeline routes prefer the async Postgres adapter with sync fallback.
> 
> **Postgres traces at scale.** `amfs_decision_traces` becomes monthly range-partitioned (migrate + partition upkeep on start), with payload stripping and optional partition drops via `apply_trace_retention` / `python -m amfs_postgres.retention`. Entity-path filtering uses `causal_entries @> …` and a GIN index; schema fingerprinting ignores partition DDL tables that may never exist.
> 
> **Correctness.** `POST /api/v1/traces` now auto-seals through Pro’s `seal_on_demand` (preserving raw `session_metadata` for spans). Explain resolves outcomes by `outcome_ref` in the adapter instead of loading 10k records.
> 
> **SDK / MCP / docs.** TypeScript gains `listTracesPageAsync`, richer `DecisionTrace` fields, and exported mappers; Python `list_traces` accepts cursor/time bounds. OSS MCP HTTP proxy accepts any 2xx. Docs clarify Pro-only eval/LLM recording and document pagination parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf56ed762f6c4800c19ba5c04ddb35032710f547. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->