### PR TITLE
feat(sdk): session attributes and LLM call recording for trace capture

### DIFF
--- a/docs/editions.md
+++ b/docs/editions.md
@@ -110,6 +110,11 @@ AMFS is GitHub for agent memory, split into two layers. The open-source core giv
 | Session-level causal explainability (`explain`) | Yes | Yes |
 | Enriched decision traces (query events, error events, state diff) | Yes | Yes |
 | Session timing and per-operation latency tracking | Yes | Yes |
+| Session attributes on traces (`set_session_attributes` / `setSessionAttributes`, `commit_outcome(attributes=...)`) | Yes | Yes |
+| Manual LLM call recording (`record_llm_call` / `recordLlmCall`) — tokens, cost, latency on the trace | Yes | Yes |
+| Automatic LLM call capture (`instrumentOpenAI` / `instrumentAnthropic`, TypeScript) | Yes | Yes |
+| Automatic LLM call capture with cost estimation and `llm` spans (`amfs_pro.tracing.instrument_openai` / `instrument_anthropic` / `instrument_litellm`, Python) | — | Yes |
+| Span tree per run (`trace_session`, `span()`, `@traced`; memory ops auto-mirrored as spans) | — | Yes |
 | Per-agent memory graph and activity timeline | Yes | Yes |
 | Composite recall scoring | Yes | Yes |
 | Multi-scope search | Yes | Yes |
@@ -390,6 +395,8 @@ The OSS `explain()` only works within the active session and captures enriched t
 - **Error events** — any errors during reads, writes, or tool calls
 - **State diff** — entries created, updated, and confidence changes during the session
 - **Full entry snapshots** — `value`, `memory_type`, and `written_by` captured at read time
+- **Session attributes** — `set_session_attributes({"customer": "acme"})` / `commit_outcome(..., attributes=...)` (TS: `setSessionAttributes`, `commitOutcome({attributes})`) stamp the dimensions a run is filtered and grouped by onto `session_metadata["attributes"]`
+- **LLM calls** — `record_llm_call(model, input_tokens, output_tokens, cost_usd=..., latency_ms=...)` (TS: `recordLlmCall`, or `instrumentOpenAI(client, memory)` / `instrumentAnthropic` to capture them automatically) fill `session_metadata["llm_calls"]`, which is the only way a trace gets real token and cost figures
 
 **Pro immutable traces** add:
 
@@ -397,6 +404,7 @@ The OSS `explain()` only works within the active session and captures enriched t
 - **LLM call spans** — model, provider, prompt/completion token counts, cost, latency, temperature, finish reason
 - **Write events, tool calls, agent interactions** — full record of every action
 - **Token and cost aggregates** — `total_llm_calls`, `total_tokens`, `total_cost_usd` per trace
+- **Span trees from the SDK** — `amfs_pro.tracing`: `trace_session(mem, attributes=...)` opens a root span and mirrors the memory's reads/writes/actions/contexts as child spans; `span()` / `@traced` add your own steps; `instrument_openai` / `instrument_anthropic` / `instrument_litellm` turn LLM calls into `llm` spans with estimated cost
 
 ```python
 from amfs_traces import TraceRecorder, InMemoryTraceStore
@@ -659,6 +667,7 @@ The Pro API layer wraps `AgentMemory` and `CoWEngine` with authentication, tenan
 | Enriched decision traces with error/query events and session timing | OSS |
 | Per-agent memory graph and activity timeline | OSS |
 | Immutable, cryptographically signed traces | **Pro** |
+| Session attributes and manually recorded LLM calls on traces | OSS |
 | LLM call span tracking with token/cost analytics | **Pro** |
 | OpenTelemetry export for existing observability stacks | **Pro** |
 | Auto entity/relationship extraction from traces | **Pro** |

--- a/docs/reference/sdk-mcp-parity.md
+++ b/docs/reference/sdk-mcp-parity.md
@@ -48,6 +48,45 @@ AMFS exposes memory three ways: the **MCP server** (for agents), the **Python SD
 | Timeline | `amfs_timeline` | `timeline` | `timelineAsync` |
 | List traces | `amfs_list_traces` | `list_traces` (cursor / since / until) | `listTracesAsync`, `listTracesPageAsync` (`{traces, nextCursor, hasMore}`) |
 | Get trace | `amfs_get_trace` | `get_trace` | `getTraceAsync` |
+| Session attributes on the trace | `amfs_set_trace_attributes` (Pro) | `set_session_attributes`, `commit_outcome(attributes=...)` | `setSessionAttributes`, `commitOutcome(..., {attributes})`, `commitOutcomeAsync(..., {attributes})` |
+| Record an LLM call by hand | `amfs_record_llm_call` (Pro) | `record_llm_call` | `recordLlmCall` |
+| Record LLM calls automatically | — | `amfs_pro.tracing.instrument_openai` / `instrument_anthropic` / `instrument_litellm` (Pro) | `instrumentOpenAI`, `instrumentAnthropic` |
+
+### Capturing runs for the Behavior section
+
+The dashboard's Behavior section shows, per run, a duration, a span tree, token counts, a cost and the attributes the run can be grouped by. None of that exists unless the SDK sends it: a trace committed by an uninstrumented agent reaches the server flat — blank duration, no spans, no attributes, and a cost it cannot know. What each figure needs:
+
+| Figure | Captured | How |
+|:--|:--|:--|
+| Session duration (`session_started_at` / `session_ended_at` / `session_duration_ms`) | **Automatically** | Every `commit_outcome` / `commitOutcomeAsync` — the session starts at the first memory operation. |
+| Memory operations as spans (reads, writes, `record_action`, `record_context`) | **Automatically inside `trace_session`** (Python, Pro) | `with trace_session(mem): ...` — the recorder mirrors the memory's own operations as `memory_read` / `memory_write` / `tool` / `context` spans under a `session` root, so even a run that records nothing else gets a real tree and duration. The Pro MCP server does the same for MCP agents. |
+| LLM calls — model, tokens, latency | **One line** | Python (Pro): `client = instrument_openai(OpenAI())` / `instrument_anthropic(Anthropic())` / `instrument_litellm()`. TypeScript: `const openai = instrumentOpenAI(new OpenAI(), memory)` / `instrumentAnthropic(client, memory)`. Sync, async and streaming calls are all recorded; an instrumentation failure never breaks the call. Any other provider: `record_llm_call(model, input_tokens, output_tokens, ...)` / `memory.recordLlmCall({...})`. |
+| Cost | **Only when LLM calls are recorded** | The Python instrumentation estimates `cost_usd` from a small price table (`AMFS_LLM_PRICE_TABLE` overrides it; LiteLLM's registry is used when `litellm` is already imported); a model it cannot price records `None`. The TypeScript SDK records tokens and leaves `cost_usd` null unless you pass `costUsd`. A run with no recorded LLM calls has an **unknown** cost, shown as a dash — never `$0.00`. |
+| Your own steps (`plan`, `pagerduty.list_incidents`, ...) | **By the developer** (Python, Pro) | `with span("plan", kind="agent"):` / `@traced("fetch", kind="tool")`; exceptions mark the span `error` and propagate. Payloads are redacted and capped at 32 000 characters (`AMFS_SPAN_PAYLOAD_MAX_CHARS`). |
+| Attributes (`customer`, `task_type`, `environment`, ...) | **By the developer** | `trace_session(mem, attributes={...})`, `mem.set_session_attributes({...})`, `mem.commit_outcome(..., attributes={...})`; TS: `memory.setSessionAttributes({...})` or `commitOutcomeAsync(..., { attributes })`. Scalars only, at most 20 keys of up to 64 characters, string values up to 256 characters; keys are lowercased. `source`, `model`, `client` and `outcome_type` are reserved and stamped by the server. |
+
+```python
+from amfs import AgentMemory
+from amfs_core.models import OutcomeType
+from amfs_pro.tracing import trace_session, span, instrument_openai
+
+client = instrument_openai(OpenAI())
+with trace_session(mem, attributes={"customer": "acme", "task_type": "deploy"}):
+    with span("plan", kind="agent"):
+        plan = client.chat.completions.create(model="gpt-4o-mini", messages=[...])
+    with span("pagerduty.list_incidents", kind="tool", input={"service": "checkout"}) as s:
+        s.set_output(incidents)
+    mem.commit_outcome("deploy-42", OutcomeType.SUCCESS, task_input="roll back checkout")
+```
+
+```ts
+const openai = instrumentOpenAI(new OpenAI(), memory);
+memory.setSessionAttributes({ customer: "acme", task_type: "deploy" });
+const r = await openai.chat.completions.create({ model: "gpt-4o-mini", messages });
+await memory.commitOutcomeAsync("deploy-42", OutcomeType.SUCCESS);
+```
+
+Everything travels in `DecisionTrace.session_metadata` — `attributes` (a flat bag), `llm_calls` (`{call_id, model, provider, input_tokens, output_tokens, cost_usd, latency_ms, started_at}`) and, from `amfs_pro.tracing`, `spans` — and the server lifts those keys onto the sealed trace. OSS keeps only the generic parts: the two `AgentMemory` methods, the `attributes` argument, and the TypeScript instrumentation; cost estimation, span trees and the Python instrumentation are `amfs-sdk-pro`. Inspect the result with `amfs-pro traces show <trace_id>` or `amfs-pro traces search --agent X --attr customer=acme`.
 
 ### Spans & trace navigation (Pro)
 
@@ -55,12 +94,13 @@ These ship in the **Pro MCP server** (`amfs-mcp-server-pro`) only. The recording
 
 | Capability | MCP tool (Pro) | Python SDK | TypeScript SDK |
 |:--|:--|:--|:--|
-| Record a completed span | `amfs_record_span` | `SpanRecorder.record_span` (`amfs_traces`) | — |
-| Open / close a span | `amfs_start_span` / `amfs_end_span` | `SpanRecorder.start_span` / `end_span`, `with recorder.span(...)` | — |
-| Trace attribute bag | `amfs_set_trace_attributes` | `SpanRecorder.set_attributes` | — |
-| Record an LLM call (also emits an `llm` span) | `amfs_record_llm_call` | `SpanRecorder.record_llm_call` | — |
-| Search traces by content, attributes, span name/kind, errors | `amfs_trace_search` | — (HTTP `POST /api/v1/pro/traces/search`) | — |
-| Span tree with text outline | `amfs_trace_spans` | — (HTTP `GET /api/v1/pro/traces/{id}/spans`) | — |
+| Trace one run (root `session` span, memory ops mirrored as child spans) | — (the Pro MCP server does this per session) | `amfs_pro.tracing.trace_session(mem, attributes=...)` | — |
+| Record a completed span | `amfs_record_span` | `SessionRecorder.record_span` (`amfs_pro.tracing`), `SpanRecorder.record_span` (`amfs_traces`) | — |
+| Open / close a span | `amfs_start_span` / `amfs_end_span` | `with span("plan", kind="agent")`, `@traced(name, kind)` (`amfs_pro.tracing`); `SpanRecorder.start_span` / `end_span` | — |
+| Trace attribute bag | `amfs_set_trace_attributes` | `trace_session(..., attributes=)`, `session.set_attributes`; OSS `set_session_attributes` | `setSessionAttributes` (OSS) |
+| Record an LLM call (also emits an `llm` span) | `amfs_record_llm_call` | `amfs_pro.tracing.record_llm_call`, `instrument_openai` / `instrument_anthropic` / `instrument_litellm`; OSS `record_llm_call` (no span) | `recordLlmCall`, `instrumentOpenAI` / `instrumentAnthropic` (OSS, no span) |
+| Search traces by content, attributes, span name/kind, errors | `amfs_trace_search` | `ProClient.traces.search(attributes=..., span_kind=...)`; CLI `amfs-pro traces search --agent X --attr customer=acme` | — |
+| Span tree with text outline | `amfs_trace_spans` | `ProClient.traces.spans`; CLI `amfs-pro traces show <trace_id>` | — |
 | One span's input/output payloads | `amfs_span_payload` | — (HTTP `GET /api/v1/pro/traces/{id}/spans/{span_id}`) | — |
 | Compare two traces span by span | `amfs_trace_compare` | — (HTTP `POST /api/v1/pro/traces/compare`) | — |
 
@@ -97,7 +137,7 @@ Judges, verdicts, behaviors, incidents, the fix loop and the investigator are **
 | Regression cases | — | `eval.cases.sets` / `.create_set` / `.get_set` / `.cases` / `.run` (inline or queued) / `.get_run` / `.runs` / `.compare` | `cases run <set_id> --label [--since --compare-to --fail-on-fail]` |
 | Investigate a question across runs | `amfs_investigate` (non-streaming) | `eval.investigate`, `eval.investigate_stream` (SSE events) | `investigate <agent> "<question>" [--trace --max-steps --no-stream]` (streams steps) |
 | Alerts | `amfs_alerts` | `eval.alerts.list` / `.ack` / `.mute` / `.rules` | — |
-| Sealed traces | `amfs_trace_search`, `amfs_trace_spans`, `amfs_span_payload`, `amfs_trace_compare` | `traces.search` / `.iter_search` / `.get` / `.spans` / `.span` / `.compare` / `.otlp_export` | `traces search [--query --agent --since --until --has-error --outcome --limit --cursor]` |
+| Sealed traces | `amfs_trace_search`, `amfs_trace_spans`, `amfs_span_payload`, `amfs_trace_compare` | `traces.search` / `.iter_search` / `.get` / `.spans` / `.span` / `.compare` / `.otlp_export` | `traces search [--query --agent --attr key=value --span-name --span-kind --since --until --has-error --outcome --limit --cursor]`, `traces show <trace_id>` (span tree with durations, tokens, cost, attributes; unknown cost and duration print as `—`) |
 
 Where the Python SDK column above says "—", the same routes are reachable by any HTTP client with the `X-AMFS-API-Key` header; the `amfs_pro` client is the supported wrapper.
 
@@ -115,7 +155,7 @@ These MCP tools are **not** mirrored 1:1 in the SDKs, by design. They are either
 |:--|:--|:--|
 | `amfs_consolidate`, `amfs_consolidation_status/proposals/candidates` | Pro (HTTP-proxied) | Backed by the Cortex consolidation API, not the OSS adapter ABC. The TypeScript `HttpAdapter` exposes `consolidation*Async` passthroughs; the Python SDK reaches them via the HTTP API directly. See the caveat below. |
 | `amfs_export_training_data` | Pro (HTTP-proxied) | Calls `GET /api/v1/pro/export`. Exposed on the TS `HttpAdapter` as `exportTrainingDataAsync`; Python calls the endpoint directly. |
-| `amfs_record_span`, `amfs_start_span`, `amfs_end_span`, `amfs_set_trace_attributes`, `amfs_record_llm_call` | Pro (works locally and over HTTP) | Spans live on the Pro `ImmutableDecisionTrace`; the OSS `DecisionTrace` carries them only as `session_metadata` extras that the seal path lifts out. The Python side is the `amfs_traces.spans.SpanRecorder` in the private repo, not an `AgentMemory` method; the TS SDK has no span recorder yet. |
+| `amfs_record_span`, `amfs_start_span`, `amfs_end_span`, `amfs_set_trace_attributes`, `amfs_record_llm_call` | Pro (works locally and over HTTP) | Spans live on the Pro `ImmutableDecisionTrace`; the OSS `DecisionTrace` carries them only as `session_metadata` extras that the seal path lifts out. The Python side is `amfs_pro.tracing` (`trace_session`, `span`, `traced`, `record_llm_call`, `instrument_*`) in the private `amfs-sdk-pro` dist; OSS `AgentMemory` has only the generic `set_session_attributes` / `record_llm_call` / `commit_outcome(attributes=...)`. The TS SDK has `setSessionAttributes`, `recordLlmCall` and `instrumentOpenAI` / `instrumentAnthropic` but no span recorder. |
 | `amfs_trace_search`, `amfs_trace_spans`, `amfs_span_payload`, `amfs_trace_compare` | Pro (HTTP-proxied, local fallback) | Backed by the Pro traces API (`/api/v1/pro/traces/search`, `/{id}/spans`, `/{id}/spans/{span_id}`, `/compare`). The local fallback has no semantic search or paging and can only see traces the adapter persists plus the last one committed in-process. No SDK methods yet; call the endpoints through the `HttpAdapter`. |
 | `amfs_judge_trace`, `amfs_judge_define`, `amfs_judges`, `amfs_seed_starter_judges`, `amfs_verdicts`, `amfs_eval_summary`, `amfs_backfill`, `amfs_behaviors`, `amfs_behavior_define`, `amfs_behavior_from_trace`, `amfs_blast_radius`, `amfs_incident`, `amfs_segment`, `amfs_dimensions`, `amfs_attribute_failure`, `amfs_propose_fix`, `amfs_fixes`, `amfs_approve_fix_memory`, `amfs_investigate`, `amfs_alerts` | Pro (HTTP-proxied, **no local mode**) | Agent evaluation runs on the hosted `/api/v1/eval` service (LLM judges, budgets, behavior mining). Without `AMFS_HTTP_URL` the tools answer `{"mode": "local"}` and do nothing. The OSS SDKs have no methods for these; use the private `amfs_pro` client or the `amfs-pro` CLI (see *Agent evaluation* above). |
 | `amfs_room_*`, `amfs_negotiate_*` | Pro (rooms backend) | Multi-agent rooms/negotiation require the Pro rooms service. The TS SDK has `room*`/`negotiate*` methods; `amfs_negotiate_cancel` has **no OSS backend endpoint**, so it's not added as an SDK method (it would be a broken stub). |

--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -213,6 +213,12 @@ class HttpAdapter(AdapterABC):
             body["response_text"] = record.response_text
         if record.tool_calls:
             body["tool_calls"] = record.tool_calls
+        # Same story for the session's attribute bag and LLM calls: the server
+        # reads ``session_metadata.attributes`` / ``.llm_calls`` from this body
+        # when it seals, so a bag sent only with the trace never reached the
+        # sealed copy.
+        if record.session_metadata:
+            body["session_metadata"] = record.session_metadata
         data = self._post("/api/v1/outcomes", body)
         return [_parse_entry(e) for e in data.get("entries", [])]
 

--- a/packages/core/src/amfs_core/models.py
+++ b/packages/core/src/amfs_core/models.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class MemoryType(str, Enum):
@@ -649,7 +649,17 @@ class SessionMetadata(BaseModel):
     Captured once per session (typically via amfs_set_identity) and attached
     to the AgentProfile and DecisionTrace so every trace records which model,
     platform, and toolset produced the decisions.
+
+    Extra keys are kept and serialised. Session-scoped data the SDKs collect for
+    a trace — the ``attributes`` bag set by ``AgentMemory.set_session_attributes``
+    and the ``llm_calls`` list built by ``AgentMemory.record_llm_call`` — rides
+    here rather than as new fields on ``DecisionTrace``, and a subclass or
+    extension may add keys of its own. Without ``extra="allow"`` such keys were
+    dropped twice: once when a dict was validated into this model and again when
+    a trace was dumped for the HTTP adapter, which serialises by declared type.
     """
+
+    model_config = ConfigDict(extra="allow")
 
     model: str | None = None
     client_name: str | None = None

--- a/packages/core/src/amfs_core/models.py
+++ b/packages/core/src/amfs_core/models.py
@@ -261,6 +261,11 @@ class OutcomeRecord(BaseModel):
     #: Typed as plain dicts because ``ToolCall`` is declared further down this
     #: module; they are the ``model_dump`` of one.
     tool_calls: list[dict[str, Any]] = Field(default_factory=list)
+    #: The session's metadata as the trace will carry it — the ``attributes``
+    #: bag and ``llm_calls`` list merged in — carried here for the same reason:
+    #: the server seals from this call, and a bag that arrived only on the later
+    #: trace left the sealed copy with no attributes and no token or cost figures.
+    session_metadata: dict[str, Any] | None = None
 
 
 class TraceEntry(BaseModel):

--- a/packages/core/src/amfs_core/outcome.py
+++ b/packages/core/src/amfs_core/outcome.py
@@ -91,6 +91,7 @@ class OutcomeBackPropagator:
         task_input: str | None = None,
         response_text: str | None = None,
         tool_calls: list[dict[str, Any]] | None = None,
+        session_metadata: dict[str, Any] | None = None,
     ) -> OutcomeRecord:
         """Convenience factory for creating OutcomeRecord instances."""
         return OutcomeRecord(
@@ -103,4 +104,5 @@ class OutcomeBackPropagator:
             task_input=task_input,
             response_text=response_text,
             tool_calls=tool_calls or [],
+            session_metadata=session_metadata or None,
         )

--- a/packages/http-server/src/amfs_http/models.py
+++ b/packages/http-server/src/amfs_http/models.py
@@ -41,6 +41,11 @@ class OutcomeRequest(BaseModel):
     #: Already scanned by the client before they reach here, and scanned again on
     #: the way in, because this endpoint is reachable by anything with a key.
     tool_calls: list[dict[str, Any]] = Field(default_factory=list)
+    #: The client's session metadata. Only ``attributes`` (the trace's dimension
+    #: bag) and ``llm_calls`` (token/cost records) are read from it; a remote
+    #: client has no other way to get either onto the trace this commit builds,
+    #: since the trace is assembled here from the server's own handle.
+    session_metadata: dict[str, Any] | None = None
 
 
 class SearchRequest(BaseModel):

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -34,6 +34,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from amfs import AgentMemory, MemoryType, OutcomeType
 from amfs.config import load_config_or_default
+from amfs.memory import validate_session_attributes
 from pydantic import BaseModel, Field
 from amfs_core.aggregates import REUSE_CREDIT_K
 from amfs_core.capture import scan_captured_arguments, scan_captured_text
@@ -2501,6 +2502,20 @@ async def commit_outcome(
             mem._adapter.ensure_agent(req.agent_id, mem.namespace)
         except Exception:
             pass
+    # The remote session's attribute bag and LLM calls, passed explicitly for
+    # the same reason ``tool_calls`` is: ``mem`` is shared, so nothing may be
+    # buffered on it between requests. Attributes are validated by
+    # ``commit_outcome``; a bad bag is a 422 here rather than a lost commit.
+    client_meta = req.session_metadata or {}
+    try:
+        client_attributes = validate_session_attributes(client_meta.get("attributes"))
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=422, detail=f"session_metadata.attributes: {exc}"
+        ) from exc
+    client_llm_calls = client_meta.get("llm_calls")
+    if not isinstance(client_llm_calls, list):
+        client_llm_calls = []
     try:
         entries = mem.commit_outcome(
             req.outcome_ref,
@@ -2517,6 +2532,8 @@ async def commit_outcome(
             # requests, so letting this fall through to its tracker would attribute
             # whatever actions happen to be buffered there to this caller.
             tool_calls=req.tool_calls,
+            attributes=client_attributes or None,
+            llm_calls=client_llm_calls or None,
         )
     finally:
         if original_agent is not None:

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -86,6 +86,20 @@ SESSION_ATTRIBUTE_VALUE_MAX_LEN = 256
 _ATTRIBUTE_SCALARS = (str, int, float, bool)
 
 
+def _check_attribute_count(attributes: dict[str, Any], what: str = "session attributes") -> None:
+    """``ValueError`` when *attributes* holds more than ``SESSION_ATTRIBUTES_MAX_KEYS``.
+
+    Applied to each incoming bag and again to every merge (the session bag as
+    it grows, and the trace's bag of identity metadata + session bag + commit
+    attributes): a per-call check alone lets three bags of 20 become one of 60.
+    """
+    if len(attributes) > SESSION_ATTRIBUTES_MAX_KEYS:
+        raise ValueError(
+            f"at most {SESSION_ATTRIBUTES_MAX_KEYS} {what} are allowed "
+            f"(got {len(attributes)})"
+        )
+
+
 def validate_session_attributes(attributes: Any) -> dict[str, str | int | float | bool]:
     """The validated form of a session attribute bag, or ``ValueError``.
 
@@ -102,11 +116,7 @@ def validate_session_attributes(attributes: Any) -> dict[str, str | int | float 
         return {}
     if not isinstance(attributes, dict):
         raise TypeError("attributes must be a dict of scalar values")
-    if len(attributes) > SESSION_ATTRIBUTES_MAX_KEYS:
-        raise ValueError(
-            f"at most {SESSION_ATTRIBUTES_MAX_KEYS} session attributes are allowed "
-            f"(got {len(attributes)})"
-        )
+    _check_attribute_count(attributes)
     out: dict[str, str | int | float | bool] = {}
     for raw_key, value in attributes.items():
         key = str(raw_key).strip().lower()
@@ -1179,6 +1189,12 @@ class AgentMemory:
         explicit_calls = [
             c for c in (_normalize_llm_call(lc) for lc in (llm_calls or [])) if c is not None
         ]
+        # Built here, before the record leaves for the adapter: the server seals
+        # its trace from the outcome call, so the bag has to travel on it. This
+        # is also where the merged bag (session metadata + set_session_attributes
+        # + *attributes*) is checked against the key cap, so an oversized merge
+        # raises before anything is sent.
+        session_metadata = self._session_metadata_for_trace(commit_attributes, explicit_calls)
 
         if causal_entry_keys is None:
             causal_entry_keys = self._read_tracker.causal_keys
@@ -1218,6 +1234,7 @@ class AgentMemory:
             task_input=task_input,
             response_text=response_text,
             tool_calls=tool_calls,
+            session_metadata=_metadata_to_dict(session_metadata) or None,
         )
         updated = self._propagator.propagate(record)
 
@@ -1292,8 +1309,6 @@ class AgentMemory:
             entries_created=sum(1 for w in writes if w.get("is_new")),
             entries_updated=sum(1 for w in writes if not w.get("is_new")),
         )
-
-        session_metadata = self._session_metadata_for_trace(commit_attributes, explicit_calls)
 
         trace = DecisionTrace(
             agent_id=self.agent_id,
@@ -1375,6 +1390,10 @@ class AgentMemory:
         span tree a Pro recorder placed there, say — are kept, and so the trace
         holds its own instance rather than the one the session keeps mutating.
         ``None`` stays ``None`` when there is nothing to add.
+
+        Raises ``ValueError`` when the merged bag exceeds
+        ``SESSION_ATTRIBUTES_MAX_KEYS``: each source is capped on its own, so
+        only the merge can tell whether the trace's bag is within the limit.
         """
         data = _metadata_to_dict(self._session_metadata)
         existing_attrs = data.get(SESSION_ATTRIBUTES_KEY)
@@ -1383,6 +1402,7 @@ class AgentMemory:
             **self._session_attributes,
             **commit_attributes,
         }
+        _check_attribute_count(attributes, "the merged session attributes")
         existing_calls = data.get(SESSION_LLM_CALLS_KEY)
         llm_calls = [
             *(existing_calls if isinstance(existing_calls, list) else []),
@@ -1418,12 +1438,18 @@ class AgentMemory:
         string values up to 256 characters; anything else raises. Keys are
         lowercased. The bag is cleared when the trace is committed.
 
+        The key cap applies to the bag as merged, not to each call: a merge that
+        would take it past 20 keys raises ``ValueError`` and leaves the bag as
+        it was.
+
         Example::
 
             mem.set_session_attributes({"customer": "acme", "task_type": "deploy"})
         """
         validated = validate_session_attributes(attributes)
-        self._session_attributes.update(validated)
+        merged = {**self._session_attributes, **validated}
+        _check_attribute_count(merged, "the session attribute bag")
+        self._session_attributes = merged
         return dict(self._session_attributes)
 
     def record_llm_call(

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import logging
 import math
 import threading
+import uuid
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
@@ -65,6 +66,125 @@ def _get_sdk_executor() -> ThreadPoolExecutor:
                     max_workers=1, thread_name_prefix="amfs-sdk-bg"
                 )
     return _sdk_bg_executor
+
+
+# ---------------------------------------------------------------------------
+# Session metadata extras: the attribute bag and the LLM-call list a session
+# collects for its trace. Both travel in ``DecisionTrace.session_metadata``
+# under the keys below, which is what the server lifts into the sealed trace.
+# ---------------------------------------------------------------------------
+
+SESSION_ATTRIBUTES_KEY = "attributes"
+SESSION_LLM_CALLS_KEY = "llm_calls"
+
+#: Attributes are dimensions to filter and group traces by (customer, task
+#: type, ...). They are indexed server-side, so the bag is kept small and flat.
+SESSION_ATTRIBUTES_MAX_KEYS = 20
+SESSION_ATTRIBUTE_KEY_MAX_LEN = 64
+SESSION_ATTRIBUTE_VALUE_MAX_LEN = 256
+
+_ATTRIBUTE_SCALARS = (str, int, float, bool)
+
+
+def validate_session_attributes(attributes: Any) -> dict[str, str | int | float | bool]:
+    """The validated form of a session attribute bag, or ``ValueError``.
+
+    Keys are stripped and lowercased (the server indexes them that way, so two
+    spellings of one dimension would otherwise never group together). Values
+    must be ``str``, ``int``, ``float`` or ``bool``; at most
+    ``SESSION_ATTRIBUTES_MAX_KEYS`` keys, each at most
+    ``SESSION_ATTRIBUTE_KEY_MAX_LEN`` characters, string values at most
+    ``SESSION_ATTRIBUTE_VALUE_MAX_LEN``. Rejected rather than trimmed: this is a
+    developer-facing API, and a silently shortened customer id is worse than an
+    error at the call site.
+    """
+    if attributes is None:
+        return {}
+    if not isinstance(attributes, dict):
+        raise TypeError("attributes must be a dict of scalar values")
+    if len(attributes) > SESSION_ATTRIBUTES_MAX_KEYS:
+        raise ValueError(
+            f"at most {SESSION_ATTRIBUTES_MAX_KEYS} session attributes are allowed "
+            f"(got {len(attributes)})"
+        )
+    out: dict[str, str | int | float | bool] = {}
+    for raw_key, value in attributes.items():
+        key = str(raw_key).strip().lower()
+        if not key:
+            raise ValueError("attribute keys must be non-empty strings")
+        if len(key) > SESSION_ATTRIBUTE_KEY_MAX_LEN:
+            raise ValueError(
+                f"attribute key {key[:20]!r}... exceeds {SESSION_ATTRIBUTE_KEY_MAX_LEN} characters"
+            )
+        if not isinstance(value, _ATTRIBUTE_SCALARS):
+            raise TypeError(
+                f"attribute {key!r} must be str, int, float or bool, "
+                f"not {type(value).__name__}"
+            )
+        if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+            raise ValueError(f"attribute {key!r} must be a finite number")
+        if isinstance(value, str) and len(value) > SESSION_ATTRIBUTE_VALUE_MAX_LEN:
+            raise ValueError(
+                f"attribute {key!r} exceeds {SESSION_ATTRIBUTE_VALUE_MAX_LEN} characters"
+            )
+        out[key] = value
+    return out
+
+
+def _normalize_llm_call(call: Any) -> dict[str, Any] | None:
+    """A JSON-safe LLM call record in the shape the trace pipeline reads
+    (``call_id``, ``model``, ``provider``, ``input_tokens``, ``output_tokens``,
+    ``cost_usd``, ``latency_ms``, ``started_at``), or ``None`` for an entry that
+    is not a usable call. Unknown keys are kept, so a richer client record
+    (cached tokens, finish reason, request id) travels intact."""
+    if not isinstance(call, dict):
+        return None
+    try:
+        input_tokens = int(call.get("input_tokens") or 0)
+        output_tokens = int(call.get("output_tokens") or 0)
+    except (TypeError, ValueError):
+        return None
+    model = call.get("model")
+    if not model and not input_tokens and not output_tokens:
+        return None
+    started_at = call.get("started_at")
+    if isinstance(started_at, datetime):
+        started_at = started_at.isoformat()
+    elif not isinstance(started_at, str) or not started_at:
+        started_at = datetime.now(UTC).isoformat()
+
+    def _num(value: Any) -> float | None:
+        if value is None:
+            return None
+        try:
+            out = float(value)
+        except (TypeError, ValueError):
+            return None
+        return out if math.isfinite(out) else None
+
+    normalized: dict[str, Any] = {
+        **call,
+        "call_id": str(call.get("call_id") or uuid.uuid4()),
+        "model": str(model or ""),
+        "provider": str(call.get("provider") or ""),
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cost_usd": _num(call.get("cost_usd")),
+        "latency_ms": _num(call.get("latency_ms")),
+        "started_at": started_at,
+    }
+    return normalized
+
+
+def _metadata_to_dict(meta: Any) -> dict[str, Any]:
+    """``session_metadata`` as a plain dict, extras included, whatever it is held as."""
+    if meta is None:
+        return {}
+    if hasattr(meta, "model_dump"):
+        return meta.model_dump(mode="json")
+    if isinstance(meta, dict):
+        return dict(meta)
+    return {}
 
 
 # ---------------------------------------------------------------------------
@@ -177,6 +297,10 @@ class AgentMemory:
         self._importance_evaluator = importance_evaluator
         self._branch = "main"
         self._session_metadata: SessionMetadata | None = None
+        # Buffered separately from ``_session_metadata`` — which callers (and the
+        # MCP server) reassign wholesale — and merged into it at commit time.
+        self._session_attributes: dict[str, str | int | float | bool] = {}
+        self._session_llm_calls: list[dict[str, Any]] = []
 
         self._lifecycle: LifecycleManager | None = None
         if ttl_sweep_interval is not None:
@@ -204,6 +328,16 @@ class AgentMemory:
     @session_metadata.setter
     def session_metadata(self, value: SessionMetadata | None) -> None:
         self._session_metadata = value
+
+    @property
+    def session_attributes(self) -> dict[str, str | int | float | bool]:
+        """The attribute bag the next ``commit_outcome`` will stamp on its trace."""
+        return dict(self._session_attributes)
+
+    @property
+    def session_llm_calls(self) -> list[dict[str, Any]]:
+        """The LLM calls recorded since the last ``commit_outcome``."""
+        return [dict(c) for c in self._session_llm_calls]
 
     @property
     def namespace(self) -> str:
@@ -1014,6 +1148,8 @@ class AgentMemory:
         task_input: str | None = None,
         response_text: str | None = None,
         tool_calls: list[dict[str, Any]] | None = None,
+        attributes: dict[str, Any] | None = None,
+        llm_calls: list[dict[str, Any]] | None = None,
     ) -> list[MemoryEntry]:
         """Record an outcome and back-propagate confidence changes.
 
@@ -1029,7 +1165,21 @@ class AgentMemory:
         to the session's own log, filled in by ``record_action``; pass a list to
         supply them directly, which is what the HTTP server does when relaying a
         remote client's actions.
+
+        *attributes* are merged over the bag built by ``set_session_attributes``
+        and stored in ``session_metadata["attributes"]`` — the dimensions the
+        trace can later be filtered and grouped by. *llm_calls* are appended to
+        the calls recorded with ``record_llm_call`` and stored in
+        ``session_metadata["llm_calls"]``; like *tool_calls*, the explicit form
+        exists for a server relaying a remote client's session. Both buffers are
+        cleared once the trace is built.
         """
+        # Validated first so a bad bag fails before anything is written.
+        commit_attributes = validate_session_attributes(attributes)
+        explicit_calls = [
+            c for c in (_normalize_llm_call(lc) for lc in (llm_calls or [])) if c is not None
+        ]
+
         if causal_entry_keys is None:
             causal_entry_keys = self._read_tracker.causal_keys
 
@@ -1143,6 +1293,8 @@ class AgentMemory:
             entries_updated=sum(1 for w in writes if not w.get("is_new")),
         )
 
+        session_metadata = self._session_metadata_for_trace(commit_attributes, explicit_calls)
+
         trace = DecisionTrace(
             agent_id=self.agent_id,
             session_id=self.session_id,
@@ -1159,7 +1311,7 @@ class AgentMemory:
             causal_entries=causal_trace_entries,
             external_contexts=ext_contexts,
             query_events=query_events,
-            session_metadata=self._session_metadata,
+            session_metadata=session_metadata,
             session_started_at=session_started,
             session_ended_at=now,
             session_duration_ms=session_duration,
@@ -1207,7 +1359,132 @@ class AgentMemory:
         # reinforces them again, and the trace's duration keeps growing from
         # process start rather than describing the work it covers.
         self._read_tracker.clear()
+        self._session_attributes = {}
+        self._session_llm_calls = []
         return updated
+
+    def _session_metadata_for_trace(
+        self,
+        commit_attributes: dict[str, Any],
+        explicit_calls: list[dict[str, Any]],
+    ) -> SessionMetadata | None:
+        """The metadata the trace carries: the session's own, with the attribute
+        bag and LLM calls merged in under ``attributes`` / ``llm_calls``.
+
+        Built from a dump of the current metadata so extras already on it — a
+        span tree a Pro recorder placed there, say — are kept, and so the trace
+        holds its own instance rather than the one the session keeps mutating.
+        ``None`` stays ``None`` when there is nothing to add.
+        """
+        data = _metadata_to_dict(self._session_metadata)
+        existing_attrs = data.get(SESSION_ATTRIBUTES_KEY)
+        attributes = {
+            **(existing_attrs if isinstance(existing_attrs, dict) else {}),
+            **self._session_attributes,
+            **commit_attributes,
+        }
+        existing_calls = data.get(SESSION_LLM_CALLS_KEY)
+        llm_calls = [
+            *(existing_calls if isinstance(existing_calls, list) else []),
+            *self._session_llm_calls,
+            *explicit_calls,
+        ]
+        if attributes:
+            data[SESSION_ATTRIBUTES_KEY] = attributes
+        else:
+            data.pop(SESSION_ATTRIBUTES_KEY, None)
+        if llm_calls:
+            data[SESSION_LLM_CALLS_KEY] = llm_calls
+        else:
+            data.pop(SESSION_LLM_CALLS_KEY, None)
+        if not data:
+            return None
+        try:
+            return SessionMetadata(**data)
+        except (TypeError, ValidationError):
+            logger.debug("session metadata could not be rebuilt; sending it as-is", exc_info=True)
+            return self._session_metadata
+
+    def set_session_attributes(
+        self, attributes: dict[str, Any]
+    ) -> dict[str, str | int | float | bool]:
+        """Merge *attributes* into the bag the next ``commit_outcome`` stamps on
+        its trace (``session_metadata["attributes"]``). Returns the bag as it
+        now stands.
+
+        Attributes are the dimensions a run is later filtered and grouped by —
+        ``customer``, ``task_type``, ``environment``. Scalars only (``str``,
+        ``int``, ``float``, ``bool``), at most 20 keys of up to 64 characters,
+        string values up to 256 characters; anything else raises. Keys are
+        lowercased. The bag is cleared when the trace is committed.
+
+        Example::
+
+            mem.set_session_attributes({"customer": "acme", "task_type": "deploy"})
+        """
+        validated = validate_session_attributes(attributes)
+        self._session_attributes.update(validated)
+        return dict(self._session_attributes)
+
+    def record_llm_call(
+        self,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        *,
+        cost_usd: float | None = None,
+        latency_ms: float | None = None,
+        provider: str | None = None,
+        call_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Record one LLM call for the trace the next ``commit_outcome`` builds.
+
+        Token counts and cost are only ever known if the agent reports them, so
+        this is what makes a trace's duration, token and cost figures real
+        rather than blank. Stored in ``session_metadata["llm_calls"]`` as::
+
+            {"call_id", "model", "provider", "input_tokens", "output_tokens",
+             "cost_usd", "latency_ms", "started_at"}
+
+        Returns the record as stored. Cleared when the trace is committed.
+
+        Example::
+
+            resp = client.chat.completions.create(...)
+            mem.record_llm_call(
+                resp.model, resp.usage.prompt_tokens, resp.usage.completion_tokens,
+                provider="openai", latency_ms=412.0,
+            )
+        """
+        if not isinstance(model, str) or not model:
+            raise ValueError("model must be a non-empty string")
+        try:
+            in_tokens = int(input_tokens)
+            out_tokens = int(output_tokens)
+        except (TypeError, ValueError) as exc:
+            raise TypeError("input_tokens and output_tokens must be integers") from exc
+        if in_tokens < 0 or out_tokens < 0:
+            raise ValueError("token counts must be non-negative")
+        for label, value in (("cost_usd", cost_usd), ("latency_ms", latency_ms)):
+            if value is not None and (
+                not isinstance(value, (int, float)) or isinstance(value, bool)
+                or not math.isfinite(float(value)) or value < 0
+            ):
+                raise ValueError(f"{label} must be a non-negative number or None")
+        record = _normalize_llm_call({
+            "call_id": call_id,
+            "model": model,
+            "provider": provider or "",
+            "input_tokens": in_tokens,
+            "output_tokens": out_tokens,
+            "cost_usd": cost_usd,
+            "latency_ms": latency_ms,
+            "started_at": datetime.now(UTC),
+        })
+        if record is None:  # pragma: no cover - a named model always normalises
+            raise ValueError("could not build an LLM call record")
+        self._session_llm_calls.append(record)
+        return dict(record)
 
     def _materialize_causal_edges(
         self,

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -13,10 +13,19 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {},
+  "peerDependencies": {
+    "openai": ">=4.0.0",
+    "@anthropic-ai/sdk": ">=0.20.0"
+  },
+  "peerDependenciesMeta": {
+    "openai": { "optional": true },
+    "@anthropic-ai/sdk": { "optional": true }
+  },
   "devDependencies": {
     "typescript": "^5.4",
     "vitest": "^3.1"

--- a/packages/sdk-typescript/src/__tests__/instrument.test.ts
+++ b/packages/sdk-typescript/src/__tests__/instrument.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgentMemory, instrumentAnthropic, instrumentOpenAI } from "../index.js";
+
+async function* stream<T>(chunks: T[], failAfter?: number): AsyncGenerator<T> {
+  let i = 0;
+  for (const c of chunks) {
+    if (failAfter !== undefined && i++ >= failAfter) throw new Error("stream broke");
+    yield c;
+  }
+}
+
+/** A stream that also carries a method, as the SDKs' `Stream` objects do. */
+function streamWithMethod<T>(chunks: T[]) {
+  const inner = stream(chunks);
+  return Object.assign(inner, { controller: { abort: vi.fn() } });
+}
+
+function chatResponse(model = "gpt-4o-mini", prompt = 100, completion = 20) {
+  return {
+    id: "chatcmpl-1",
+    model,
+    choices: [{ finish_reason: "stop", message: { content: "hi" } }],
+    usage: { prompt_tokens: prompt, completion_tokens: completion },
+  };
+}
+
+function fakeOpenAI(create: (...args: unknown[]) => unknown, responsesCreate?: (...a: unknown[]) => unknown) {
+  const client: Record<string, unknown> = { chat: { completions: { create } } };
+  if (responsesCreate) client.responses = { create: responsesCreate };
+  return client as {
+    chat: { completions: { create: (...args: unknown[]) => Promise<unknown> } };
+    responses?: { create: (...args: unknown[]) => Promise<unknown> };
+  };
+}
+
+describe("instrumentOpenAI", () => {
+  it("records a chat completion with model, tokens, latency and provider", async () => {
+    const mem = new AgentMemory("deploy-agent");
+    const create = vi.fn(async (params: unknown) => chatResponse());
+    const client = instrumentOpenAI(fakeOpenAI(create), mem);
+    expect(instrumentOpenAI(client, mem)).toBe(client); // idempotent
+
+    const out = (await client.chat.completions.create({
+      model: "gpt-4o-mini",
+      messages: [{ role: "user", content: "hi" }],
+    })) as ReturnType<typeof chatResponse>;
+    expect(out.choices[0].message.content).toBe("hi"); // untouched
+    expect(create).toHaveBeenCalledTimes(1);
+
+    const [call] = mem.sessionLlmCalls;
+    expect(call).toMatchObject({
+      model: "gpt-4o-mini", provider: "openai", input_tokens: 100, output_tokens: 20,
+    });
+    expect(call.latency_ms).toBeGreaterThanOrEqual(0);
+    expect(call.cost_usd).toBeNull(); // pricing is the server's job
+  });
+
+  it("uses the requested model when the response has none", async () => {
+    const mem = new AgentMemory("a");
+    const client = instrumentOpenAI(fakeOpenAI(async () => ({ usage: { prompt_tokens: 1, completion_tokens: 1 } })), mem);
+    await client.chat.completions.create({ model: "gpt-4o", messages: [] });
+    expect(mem.sessionLlmCalls[0].model).toBe("gpt-4o");
+  });
+
+  it("records a stream when it is exhausted, from the final usage chunk", async () => {
+    const mem = new AgentMemory("a");
+    const chunks = [
+      { id: "c", model: "gpt-4o-mini", choices: [{ delta: { content: "h" } }], usage: null },
+      { id: "c", model: "gpt-4o-mini", choices: [{ delta: { content: "i" }, finish_reason: "stop" }], usage: null },
+      { id: "c", model: "gpt-4o-mini", choices: [], usage: { prompt_tokens: 7, completion_tokens: 2 } },
+    ];
+    const s = streamWithMethod(chunks);
+    const client = instrumentOpenAI(fakeOpenAI(async () => s), mem);
+    const result = (await client.chat.completions.create({
+      model: "gpt-4o-mini", messages: [], stream: true,
+    })) as AsyncIterable<unknown> & { controller: { abort: () => void } };
+
+    expect(mem.sessionLlmCalls).toHaveLength(0); // not yet: the stream is still open
+    const seen: unknown[] = [];
+    for await (const chunk of result) seen.push(chunk);
+    expect(seen).toEqual(chunks);
+    expect(mem.sessionLlmCalls).toHaveLength(1);
+    expect(mem.sessionLlmCalls[0]).toMatchObject({ input_tokens: 7, output_tokens: 2, model: "gpt-4o-mini" });
+    result.controller.abort(); // other members are forwarded
+    expect(s.controller.abort).toHaveBeenCalled();
+  });
+
+  it("records a stream the consumer breaks out of, without tokens", async () => {
+    const mem = new AgentMemory("a");
+    const chunks = [{ model: "gpt-4o" }, { model: "gpt-4o" }, { model: "gpt-4o", usage: { prompt_tokens: 9, completion_tokens: 9 } }];
+    const client = instrumentOpenAI(fakeOpenAI(async () => stream(chunks)), mem);
+    const result = (await client.chat.completions.create({ model: "gpt-4o", stream: true })) as AsyncIterable<unknown>;
+    for await (const _ of result) break;
+    expect(mem.sessionLlmCalls).toHaveLength(1);
+    expect(mem.sessionLlmCalls[0]).toMatchObject({ model: "gpt-4o", input_tokens: 0, output_tokens: 0 });
+  });
+
+  it("records a failing stream as a failed call and rethrows", async () => {
+    const mem = new AgentMemory("a");
+    const client = instrumentOpenAI(fakeOpenAI(async () => stream([{ model: "gpt-4o" }, { model: "gpt-4o" }], 1)), mem);
+    const result = (await client.chat.completions.create({ model: "gpt-4o", stream: true })) as AsyncIterable<unknown>;
+    await expect((async () => { for await (const _ of result) { /* drain */ } })()).rejects.toThrow("stream broke");
+    expect(mem.sessionLlmCalls).toHaveLength(1);
+    expect(mem.sessionLlmCalls[0].error).toMatch(/stream broke/);
+  });
+
+  it("records a provider error and rethrows it unchanged", async () => {
+    const mem = new AgentMemory("a");
+    const boom = new Error("429 rate limited");
+    const client = instrumentOpenAI(fakeOpenAI(async () => { throw boom; }), mem);
+    await expect(client.chat.completions.create({ model: "gpt-4o", messages: [] })).rejects.toBe(boom);
+    const [call] = mem.sessionLlmCalls;
+    expect(call).toMatchObject({ model: "gpt-4o", input_tokens: 0, output_tokens: 0 });
+    expect(call.error).toContain("429");
+  });
+
+  it("instruments the Responses API, streaming included", async () => {
+    const mem = new AgentMemory("a");
+    const events = [
+      { type: "response.created", response: { id: "r", model: "gpt-4o" } },
+      { type: "response.output_text.delta", delta: "x" },
+      { type: "response.completed", response: { id: "r", model: "gpt-4o", usage: { input_tokens: 30, output_tokens: 10 } } },
+    ];
+    const responsesCreate = vi.fn(async (params: { stream?: boolean }) =>
+      params.stream ? stream(events) : { id: "r2", model: "gpt-4o-2024-08-06", usage: { input_tokens: 3, output_tokens: 4 } },
+    );
+    const client = instrumentOpenAI(fakeOpenAI(async () => chatResponse(), responsesCreate), mem);
+    await client.responses!.create({ model: "gpt-4o", input: "y" });
+    const s = (await client.responses!.create({ model: "gpt-4o", input: "x", stream: true })) as AsyncIterable<unknown>;
+    for await (const _ of s) { /* drain */ }
+    expect(mem.sessionLlmCalls.map((c) => [c.model, c.input_tokens, c.output_tokens])).toEqual([
+      ["gpt-4o-2024-08-06", 3, 4],
+      ["gpt-4o", 30, 10],
+    ]);
+  });
+
+  it("never breaks the call when the recorder throws", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const sink = { recordLlmCall: () => { throw new Error("recorder bug"); } };
+    const client = instrumentOpenAI(fakeOpenAI(async () => chatResponse()), sink);
+    const out = (await client.chat.completions.create({ model: "gpt-4o-mini", messages: [] })) as { id: string };
+    expect(out.id).toBe("chatcmpl-1");
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("tolerates a client without the resources", () => {
+    const mem = new AgentMemory("a");
+    const bare = {};
+    expect(instrumentOpenAI(bare, mem)).toBe(bare);
+  });
+
+  it("preserves `this` for SDK methods that rely on it", async () => {
+    const mem = new AgentMemory("a");
+    class Completions {
+      tag = "real";
+      async create(_params: unknown) {
+        return { model: `from-${this.tag}`, usage: { prompt_tokens: 1, completion_tokens: 1 } };
+      }
+    }
+    const client = { chat: { completions: new Completions() } };
+    instrumentOpenAI(client, mem);
+    await client.chat.completions.create({ model: "x" });
+    expect(mem.sessionLlmCalls[0].model).toBe("from-real");
+  });
+});
+
+describe("instrumentAnthropic", () => {
+  it("records messages.create, plain and streaming", async () => {
+    const mem = new AgentMemory("a");
+    const message = {
+      id: "msg_1", model: "claude-3-5-haiku-20241022", stop_reason: "end_turn",
+      usage: { input_tokens: 50, output_tokens: 25 }, content: [{ type: "text", text: "ok" }],
+    };
+    const events = [
+      { type: "message_start", message: { id: "msg_2", model: "claude-3-5-haiku-20241022", usage: { input_tokens: 8, output_tokens: 1 } } },
+      { type: "content_block_delta", delta: { type: "text_delta", text: "h" } },
+      { type: "message_delta", delta: { stop_reason: "max_tokens" }, usage: { output_tokens: 6 } },
+      { type: "message_stop" },
+    ];
+    const create = vi.fn(async (params: { stream?: boolean }) => (params.stream ? stream(events) : message));
+    const client = instrumentAnthropic({ messages: { create } }, mem);
+    expect(instrumentAnthropic(client, mem)).toBe(client);
+
+    const out = (await client.messages.create({ model: "claude-3-5-haiku-20241022", max_tokens: 100, messages: [] })) as typeof message;
+    expect(out.content[0].text).toBe("ok");
+    const s = (await client.messages.create({ model: "claude-3-5-haiku-20241022", max_tokens: 8, messages: [], stream: true })) as AsyncIterable<unknown>;
+    for await (const _ of s) { /* drain */ }
+
+    expect(mem.sessionLlmCalls.map((c) => [c.provider, c.model, c.input_tokens, c.output_tokens])).toEqual([
+      ["anthropic", "claude-3-5-haiku-20241022", 50, 25],
+      ["anthropic", "claude-3-5-haiku-20241022", 8, 6],
+    ]);
+  });
+});

--- a/packages/sdk-typescript/src/__tests__/session.test.ts
+++ b/packages/sdk-typescript/src/__tests__/session.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  AgentMemory,
+  HttpAdapter,
+  OutcomeType,
+  toDecisionTrace,
+  validateSessionAttributes,
+} from "../index.js";
+
+function mockFetch(responses: Array<{ status?: number; body: unknown }>) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fn = vi.fn(async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    const next = responses.shift() ?? { body: {} };
+    const status = next.status ?? 200;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => next.body,
+      text: async () => JSON.stringify(next.body),
+    } as unknown as Response;
+  });
+  vi.stubGlobal("fetch", fn);
+  return { calls, fn };
+}
+
+function body(call: { init?: RequestInit }): Record<string, unknown> {
+  return JSON.parse(String(call.init?.body)) as Record<string, unknown>;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("validateSessionAttributes", () => {
+  it("lowercases and trims keys and keeps scalars", () => {
+    expect(validateSessionAttributes({ " Customer ": "acme", N: 3, ok: true, f: 1.5 })).toEqual({
+      customer: "acme",
+      n: 3,
+      ok: true,
+      f: 1.5,
+    });
+    expect(validateSessionAttributes(undefined)).toEqual({});
+    expect(validateSessionAttributes(null)).toEqual({});
+  });
+
+  it("rejects rather than trims", () => {
+    expect(() => validateSessionAttributes([] as unknown)).toThrow(TypeError);
+    expect(() => validateSessionAttributes({ nested: { a: 1 } })).toThrow(TypeError);
+    expect(() => validateSessionAttributes({ nil: null })).toThrow(TypeError);
+    expect(() => validateSessionAttributes({ nan: Number.NaN })).toThrow(RangeError);
+    expect(() => validateSessionAttributes({ "": "x" })).toThrow(RangeError);
+    expect(() => validateSessionAttributes({ ["k".repeat(65)]: "x" })).toThrow(/64 characters/);
+    expect(() => validateSessionAttributes({ v: "x".repeat(257) })).toThrow(/256 characters/);
+    const many = Object.fromEntries(Array.from({ length: 21 }, (_, i) => [`k${i}`, i]));
+    expect(() => validateSessionAttributes(many)).toThrow(/at most 20/);
+  });
+});
+
+describe("AgentMemory session metadata", () => {
+  it("setSessionAttributes merges and validates", () => {
+    const mem = new AgentMemory("deploy-agent");
+    expect(mem.setSessionAttributes({ Customer: "acme" })).toEqual({ customer: "acme" });
+    expect(mem.setSessionAttributes({ task_type: "deploy" })).toEqual({
+      customer: "acme",
+      task_type: "deploy",
+    });
+    expect(() => mem.setSessionAttributes({ bad: [1] as unknown as string })).toThrow(TypeError);
+    // A rejected bag leaves the good one untouched, and the getter is a copy.
+    expect(mem.sessionAttributes).toEqual({ customer: "acme", task_type: "deploy" });
+    mem.sessionAttributes.customer = "mutated";
+    expect(mem.sessionAttributes.customer).toBe("acme");
+  });
+
+  it("recordLlmCall writes the wire record", () => {
+    const mem = new AgentMemory("deploy-agent");
+    const before = Date.now();
+    const rec = mem.recordLlmCall({
+      model: "gpt-4o-mini",
+      inputTokens: 100,
+      outputTokens: 20.9,
+      costUsd: 0.00003,
+      latencyMs: 412,
+      provider: "openai",
+    });
+    expect(rec).toMatchObject({
+      model: "gpt-4o-mini",
+      provider: "openai",
+      input_tokens: 100,
+      output_tokens: 20,
+      cost_usd: 0.00003,
+      latency_ms: 412,
+    });
+    expect(typeof rec.call_id).toBe("string");
+    expect(rec.call_id.length).toBeGreaterThan(8);
+    expect(Date.parse(rec.started_at)).toBeGreaterThanOrEqual(before - 1);
+    expect(Object.keys(rec).sort()).toEqual([
+      "call_id", "cost_usd", "input_tokens", "latency_ms", "model", "output_tokens",
+      "provider", "started_at",
+    ]);
+
+    const minimal = mem.recordLlmCall({ model: "claude-3-5-haiku", inputTokens: 1, outputTokens: 2 });
+    expect(minimal.cost_usd).toBeNull(); // unknown, not zero
+    expect(minimal.latency_ms).toBeNull();
+    expect(minimal.provider).toBe("");
+    expect(mem.sessionLlmCalls).toHaveLength(2);
+    expect(mem.sessionLlmCalls[0].call_id).toBe(rec.call_id);
+  });
+
+  it("recordLlmCall validates", () => {
+    const mem = new AgentMemory("deploy-agent");
+    expect(() => mem.recordLlmCall({ model: "", inputTokens: 1, outputTokens: 1 })).toThrow(TypeError);
+    expect(() =>
+      mem.recordLlmCall({ model: "m", inputTokens: -1, outputTokens: 1 }),
+    ).toThrow(RangeError);
+    expect(() =>
+      mem.recordLlmCall({ model: "m", inputTokens: "1" as unknown as number, outputTokens: 1 }),
+    ).toThrow(TypeError);
+    expect(() =>
+      mem.recordLlmCall({ model: "m", inputTokens: 1, outputTokens: 1, costUsd: -0.1 }),
+    ).toThrow(RangeError);
+    expect(() =>
+      mem.recordLlmCall({ model: "m", inputTokens: 1, outputTokens: 1, latencyMs: Number.NaN }),
+    ).toThrow(RangeError);
+    expect(mem.sessionLlmCalls).toEqual([]);
+  });
+
+  it("local commitOutcome accepts attributes and clears the session bag", () => {
+    const mem = new AgentMemory("deploy-agent");
+    mem.setSessionAttributes({ customer: "acme" });
+    mem.recordLlmCall({ model: "m", inputTokens: 1, outputTokens: 1 });
+    mem.commitOutcome("deploy-1", OutcomeType.SUCCESS, [], { attributes: { task_type: "deploy" } });
+    expect(mem.sessionAttributes).toEqual({});
+    expect(mem.sessionLlmCalls).toEqual([]);
+  });
+
+  it("commitOutcomeAsync sends attributes and llm_calls as session_metadata", async () => {
+    const { calls } = mockFetch([{ body: { ok: true } }, { body: { ok: true } }]);
+    const adapter = new HttpAdapter({ url: "http://amfs.test", apiKey: "k", agentId: "deploy-agent" });
+    const mem = new AgentMemory("deploy-agent", { adapter });
+
+    mem.setSessionAttributes({ customer: "acme" });
+    const call = mem.recordLlmCall({
+      model: "gpt-4o-mini", inputTokens: 10, outputTokens: 5, provider: "openai", latencyMs: 12,
+    });
+    await mem.commitOutcomeAsync("deploy-42", OutcomeType.SUCCESS, {
+      attributes: { Task_Type: "deploy" },
+    });
+
+    expect(calls[0].url).toBe("http://amfs.test/api/v1/outcomes");
+    const sent = body(calls[0]);
+    expect(sent.outcome_ref).toBe("deploy-42");
+    expect(sent.outcome_type).toBe("success");
+    expect(sent.session_metadata).toEqual({
+      attributes: { customer: "acme", task_type: "deploy" },
+      llm_calls: [call],
+    });
+
+    // Consumed by the commit: the next one describes a new run.
+    expect(mem.sessionAttributes).toEqual({});
+    expect(mem.sessionLlmCalls).toEqual([]);
+    await mem.commitOutcomeAsync("deploy-43", OutcomeType.FAILURE);
+    expect(body(calls[1])).not.toHaveProperty("session_metadata");
+  });
+
+  it("commitOutcomeAsync clears the bag even when the request fails", async () => {
+    mockFetch([{ status: 500, body: { detail: "boom" } }]);
+    const adapter = new HttpAdapter({ url: "http://amfs.test", apiKey: "k", agentId: "a" });
+    const mem = new AgentMemory("a", { adapter });
+    mem.setSessionAttributes({ customer: "acme" });
+    await expect(mem.commitOutcomeAsync("x", OutcomeType.SUCCESS)).rejects.toThrow();
+    expect(mem.sessionAttributes).toEqual({});
+  });
+
+  it("commitOutcomeAsync rejects a bad attribute bag before sending anything", async () => {
+    const { fn } = mockFetch([]);
+    const adapter = new HttpAdapter({ url: "http://amfs.test", apiKey: "k", agentId: "a" });
+    const mem = new AgentMemory("a", { adapter });
+    await expect(
+      mem.commitOutcomeAsync("x", OutcomeType.SUCCESS, { attributes: { nested: {} as never } }),
+    ).rejects.toThrow(TypeError);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+describe("toDecisionTrace session metadata", () => {
+  it("surfaces attributes and llm_calls from the wire", () => {
+    const trace = toDecisionTrace({
+      id: "t", agent_id: "a", session_id: "s", outcome_ref: "o", outcome_type: "success",
+      tool_calls: [], causal_entries: [], external_contexts: [], query_events: [], error_events: [],
+      created_at: "2026-09-05T00:00:00Z",
+      session_metadata: {
+        model: "gpt-4o",
+        attributes: { customer: "acme", n: 2, skip: { nested: true } },
+        llm_calls: [{ call_id: "c1", model: "gpt-4o", input_tokens: 1, output_tokens: 2 }],
+      },
+    });
+    expect(trace.sessionMetadata?.attributes).toEqual({ customer: "acme", n: 2 });
+    expect(trace.sessionMetadata?.llmCalls).toEqual([
+      { call_id: "c1", model: "gpt-4o", input_tokens: 1, output_tokens: 2 },
+    ]);
+  });
+
+  it("defaults them when an older server omits them", () => {
+    const trace = toDecisionTrace({
+      id: "t", agent_id: "a", session_id: "s", outcome_ref: "o", outcome_type: "success",
+      created_at: "2026-09-05T00:00:00Z", session_metadata: { model: "gpt-4o" },
+    });
+    expect(trace.sessionMetadata).toMatchObject({ model: "gpt-4o", attributes: {}, llmCalls: [] });
+  });
+});

--- a/packages/sdk-typescript/src/__tests__/session.test.ts
+++ b/packages/sdk-typescript/src/__tests__/session.test.ts
@@ -161,13 +161,63 @@ describe("AgentMemory session metadata", () => {
     expect(body(calls[1])).not.toHaveProperty("session_metadata");
   });
 
-  it("commitOutcomeAsync clears the bag even when the request fails", async () => {
-    mockFetch([{ status: 500, body: { detail: "boom" } }]);
+  it("commitOutcomeAsync keeps the bag when the server refuses the commit", async () => {
+    // A 422 for the bag, then a 5xx, then success: the attributes and LLM
+    // calls must survive both refusals and go out with the retry that lands.
+    const { calls } = mockFetch([
+      { status: 422, body: { detail: "session_metadata.attributes: bad" } },
+      { status: 500, body: { detail: "boom" } },
+      { body: { ok: true } },
+    ]);
     const adapter = new HttpAdapter({ url: "http://amfs.test", apiKey: "k", agentId: "a" });
     const mem = new AgentMemory("a", { adapter });
     mem.setSessionAttributes({ customer: "acme" });
+    const call = mem.recordLlmCall({ model: "m", inputTokens: 1, outputTokens: 1 });
+
     await expect(mem.commitOutcomeAsync("x", OutcomeType.SUCCESS)).rejects.toThrow();
+    expect(mem.sessionAttributes).toEqual({ customer: "acme" });
+    expect(mem.sessionLlmCalls).toEqual([call]);
+    await expect(mem.commitOutcomeAsync("x", OutcomeType.SUCCESS)).rejects.toThrow();
+    expect(mem.sessionAttributes).toEqual({ customer: "acme" });
+    expect(mem.sessionLlmCalls).toEqual([call]);
+
+    await mem.commitOutcomeAsync("x", OutcomeType.SUCCESS);
+    expect(body(calls[2]).session_metadata).toEqual({
+      attributes: { customer: "acme" },
+      llm_calls: [call],
+    });
     expect(mem.sessionAttributes).toEqual({});
+    expect(mem.sessionLlmCalls).toEqual([]);
+  });
+
+  it("setSessionAttributes caps the merged bag, not each call", () => {
+    const mem = new AgentMemory("a");
+    const first = Object.fromEntries(Array.from({ length: 15 }, (_, i) => [`a${i}`, i]));
+    mem.setSessionAttributes(first);
+    expect(() =>
+      mem.setSessionAttributes(Object.fromEntries(Array.from({ length: 15 }, (_, i) => [`b${i}`, i]))),
+    ).toThrow(RangeError);
+    expect(mem.sessionAttributes).toEqual(first);
+    // Keys already in the bag do not count twice.
+    expect(Object.keys(mem.setSessionAttributes({ a0: 99, a1: 98 }))).toHaveLength(15);
+    expect(
+      Object.keys(mem.setSessionAttributes(Object.fromEntries(Array.from({ length: 5 }, (_, i) => [`c${i}`, i])))),
+    ).toHaveLength(20);
+    expect(() => mem.setSessionAttributes({ one_too_many: true })).toThrow(/at most 20/);
+  });
+
+  it("commitOutcomeAsync rejects an over-cap merge before sending anything", async () => {
+    const { fn } = mockFetch([]);
+    const adapter = new HttpAdapter({ url: "http://amfs.test", apiKey: "k", agentId: "a" });
+    const mem = new AgentMemory("a", { adapter });
+    mem.setSessionAttributes(Object.fromEntries(Array.from({ length: 15 }, (_, i) => [`s${i}`, i])));
+    await expect(
+      mem.commitOutcomeAsync("x", OutcomeType.SUCCESS, {
+        attributes: Object.fromEntries(Array.from({ length: 15 }, (_, i) => [`c${i}`, i])),
+      }),
+    ).rejects.toThrow(RangeError);
+    expect(fn).not.toHaveBeenCalled();
+    expect(Object.keys(mem.sessionAttributes)).toHaveLength(15);
   });
 
   it("commitOutcomeAsync rejects a bad attribute bag before sending anything", async () => {

--- a/packages/sdk-typescript/src/__tests__/traces.test.ts
+++ b/packages/sdk-typescript/src/__tests__/traces.test.ts
@@ -89,6 +89,8 @@ describe("toDecisionTrace", () => {
       toolsAvailable: ["amfs_write", "deploy_rollback"],
       mcpClientId: "c1",
       mcpSessionId: null,
+      attributes: {},
+      llmCalls: [],
     });
     // The rest still goes through the generic converter.
     expect(trace.causalEntries[0].entityPath).toBe("shop/checkout");

--- a/packages/sdk-typescript/src/adapters/http.ts
+++ b/packages/sdk-typescript/src/adapters/http.ts
@@ -234,6 +234,11 @@ export class HttpAdapter implements AmfsAdapter {
     causalEntryKeys?: string[];
     causalConfidence?: number;
     agentId?: string;
+    /**
+     * Already in wire shape (`attributes`, `llm_calls`, ...); the server lifts
+     * these onto the trace it seals for this outcome.
+     */
+    sessionMetadata?: Record<string, unknown>;
   }): Promise<unknown> {
     const agentId = record.agentId ?? this.agentId;
     return this.fetch("/api/v1/outcomes", {
@@ -245,6 +250,9 @@ export class HttpAdapter implements AmfsAdapter {
         ...(record.causalEntryKeys?.length ? { causal_entry_keys: record.causalEntryKeys } : {}),
         ...(record.causalConfidence != null ? { causal_confidence: record.causalConfidence } : {}),
         ...(agentId ? { agent_id: agentId } : {}),
+        ...(record.sessionMetadata && Object.keys(record.sessionMetadata).length
+          ? { session_metadata: record.sessionMetadata }
+          : {}),
       }),
     });
   }
@@ -519,6 +527,10 @@ export interface SessionMetadata {
   toolsAvailable: string[];
   mcpClientId?: string | null;
   mcpSessionId?: string | null;
+  /** The run's dimensions (`customer`, `task_type`, ...), when any were set. */
+  attributes: Record<string, string | number | boolean>;
+  /** LLM calls recorded for the run, in wire shape (snake_case keys). */
+  llmCalls: Array<Record<string, unknown>>;
 }
 
 export interface DecisionTrace {
@@ -612,7 +624,18 @@ function toSessionMetadata(raw: unknown): SessionMetadata | null {
     toolsAvailable: Array.isArray(r.tools_available) ? r.tools_available.map(String) : [],
     mcpClientId: (r.mcp_client_id as string | null | undefined) ?? null,
     mcpSessionId: (r.mcp_session_id as string | null | undefined) ?? null,
+    attributes: toAttributeBag(r.attributes),
+    // Caller-owned records: keys stay as the wire has them.
+    llmCalls: Array.isArray(r.llm_calls) ? r.llm_calls.map(asRecord) : [],
   };
+}
+
+function toAttributeBag(raw: unknown): Record<string, string | number | boolean> {
+  const out: Record<string, string | number | boolean> = {};
+  for (const [k, v] of Object.entries(asRecord(raw))) {
+    if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") out[k] = v;
+  }
+  return out;
 }
 
 /**

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -17,6 +17,20 @@ export type {
   ToolCall,
   SessionMetadata,
 } from "./adapters/http.js";
+export {
+  validateSessionAttributes,
+  SESSION_ATTRIBUTES_MAX_KEYS,
+  SESSION_ATTRIBUTE_KEY_MAX_LEN,
+  SESSION_ATTRIBUTE_VALUE_MAX_LEN,
+} from "./session.js";
+export type {
+  AttributeValue,
+  SessionAttributes,
+  RecordLlmCallInput,
+  LlmCallRecord,
+} from "./session.js";
+export { instrumentOpenAI, instrumentAnthropic } from "./instrument/index.js";
+export type { LlmCallSink } from "./instrument/index.js";
 export { CausalTagger, CoWEngine } from "./engine.js";
 export { ReadTracker } from "./tracker.js";
 export type { ExternalContext } from "./tracker.js";

--- a/packages/sdk-typescript/src/instrument/anthropic.ts
+++ b/packages/sdk-typescript/src/instrument/anthropic.ts
@@ -1,0 +1,53 @@
+/**
+ * `instrumentAnthropic(client, memory)` — every `messages.create` on the
+ * `@anthropic-ai/sdk` client is recorded with `memory.recordLlmCall`.
+ *
+ * Streaming calls (`stream: true`) are recorded when the stream ends: input
+ * tokens come from `message_start`, output tokens from the final
+ * `message_delta`. The `messages.stream()` helper is not patched; iterate
+ * `create({ stream: true })` or call `memory.recordLlmCall` by hand.
+ * `@anthropic-ai/sdk` is an optional peer and is not imported here.
+ */
+
+import type { Extractor, LlmCallSink, Usage } from "./common.js";
+import { asInt, get, isInstrumented, markInstrumented, patchMethod, resolve } from "./common.js";
+
+const PROVIDER = "anthropic";
+
+function readUsage(u: unknown, usage: Usage, outputOnly = false): void {
+  if (!u) return;
+  if (!outputOnly) {
+    const inTok = asInt(get(u, "input_tokens"));
+    if (inTok !== undefined) usage.inputTokens = inTok;
+  }
+  const outTok = asInt(get(u, "output_tokens"));
+  if (outTok !== undefined) usage.outputTokens = outTok;
+}
+
+export const extractMessage: Extractor = (message, usage) => {
+  const model = get(message, "model");
+  if (typeof model === "string" && model) usage.model = model;
+  readUsage(get(message, "usage"), usage);
+};
+
+export const extractMessageEvent: Extractor = (event, usage) => {
+  const type = String(get(event, "type") ?? "");
+  if (type === "message_start") extractMessage(get(event, "message"), usage);
+  else if (type === "message_delta") readUsage(get(event, "usage"), usage, true);
+};
+
+/** Instrument an Anthropic client in place and return it. Idempotent. */
+export function instrumentAnthropic<C>(client: C, memory: LlmCallSink): C {
+  if (isInstrumented(client)) return client;
+  const messages = resolve(client, ["messages"]);
+  if (messages) {
+    patchMethod(messages, "create", {
+      provider: PROVIDER,
+      sink: memory,
+      extract: extractMessage,
+      onChunk: extractMessageEvent,
+    });
+  }
+  markInstrumented(client);
+  return client;
+}

--- a/packages/sdk-typescript/src/instrument/common.ts
+++ b/packages/sdk-typescript/src/instrument/common.ts
@@ -1,0 +1,206 @@
+/**
+ * Shared machinery for the provider instrumentations.
+ *
+ * Each `instrument*` function replaces a client method on the *instance* with a
+ * wrapper that times the call, reads token usage off the response (or, for a
+ * stream, accumulates it while the caller iterates and records when the stream
+ * ends) and hands the result to `memory.recordLlmCall`. The wrapped call is
+ * never altered: an instrumentation failure is logged and swallowed, an error
+ * from the provider is recorded as a failed call and re-thrown unchanged.
+ *
+ * Responses are read by duck typing, so neither `openai` nor `@anthropic-ai/sdk`
+ * is imported — they are optional peers — and tests drive the wrappers with
+ * plain objects.
+ */
+
+import type { RecordLlmCallInput } from "../session.js";
+
+/** The one method of `AgentMemory` the instrumentations need. */
+export interface LlmCallSink {
+  recordLlmCall(call: RecordLlmCallInput, startedAt?: Date): unknown;
+}
+
+export interface Usage {
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+export type Extractor = (response: unknown, usage: Usage) => void;
+
+const FLAG = "__amfsInstrumented";
+
+export function isInstrumented(target: unknown): boolean {
+  return Boolean((target as Record<string, unknown> | null)?.[FLAG]);
+}
+
+export function markInstrumented(target: unknown): void {
+  try {
+    Object.defineProperty(target, FLAG, { value: true, enumerable: false, configurable: true });
+  } catch {
+    // frozen or proxy — nothing to do
+  }
+}
+
+export function get(obj: unknown, key: string): unknown {
+  if (obj === null || obj === undefined) return undefined;
+  return (obj as Record<string, unknown>)[key];
+}
+
+export function asInt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.trunc(value);
+}
+
+export function resolve(target: unknown, path: string[]): unknown {
+  let obj = target;
+  for (const hop of path) {
+    obj = get(obj, hop);
+    if (obj === null || obj === undefined) return undefined;
+  }
+  return obj;
+}
+
+function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as Record<PropertyKey, unknown>)[Symbol.asyncIterator] === "function"
+  );
+}
+
+function warn(message: string, err: unknown): void {
+  try {
+    console.warn(`[amfs] ${message}`, err);
+  } catch {
+    // no console — stay silent
+  }
+}
+
+class Call {
+  readonly startedAt = new Date();
+  private readonly t0 = performance.now();
+  private done = false;
+
+  constructor(
+    private readonly sink: LlmCallSink,
+    private readonly provider: string,
+    private readonly requestedModel: string | undefined,
+  ) {}
+
+  record(usage: Usage, error?: unknown): void {
+    if (this.done) return;
+    this.done = true;
+    const latencyMs = performance.now() - this.t0;
+    try {
+      const model = usage.model || this.requestedModel || "";
+      if (!model) return; // nothing to attribute the call to
+      this.sink.recordLlmCall(
+        {
+          model,
+          provider: this.provider,
+          inputTokens: usage.inputTokens ?? 0,
+          outputTokens: usage.outputTokens ?? 0,
+          latencyMs,
+          ...(error !== undefined ? { error: String(error) } : {}),
+        },
+        this.startedAt,
+      );
+    } catch (err) {
+      warn(`${this.provider} instrumentation: could not record call`, err);
+    }
+  }
+}
+
+/**
+ * Wrap an async iterable so its chunks are observed and the call is recorded
+ * once the stream is exhausted, breaks, or is returned early. Every other
+ * property (e.g. `controller`, `finalMessage()`) is forwarded to the original.
+ */
+function proxyStream(inner: AsyncIterable<unknown>, call: Call, onChunk: Extractor): unknown {
+  const usage: Usage = {};
+  const iterate = async function* () {
+    try {
+      for await (const chunk of inner) {
+        try {
+          onChunk(chunk, usage);
+        } catch (err) {
+          warn("stream chunk extraction failed", err);
+        }
+        yield chunk;
+      }
+      call.record(usage);
+    } catch (err) {
+      call.record(usage, err);
+      throw err;
+    } finally {
+      call.record(usage); // early `return()` / `break` lands here
+    }
+  };
+  return new Proxy(inner as object, {
+    get(target, prop, receiver) {
+      if (prop === Symbol.asyncIterator) return () => iterate();
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+export interface PatchOptions {
+  provider: string;
+  sink: LlmCallSink;
+  /** Reads usage from a complete response. */
+  extract: Extractor;
+  /** Reads usage from one stream chunk, accumulating into the usage. */
+  onChunk: Extractor;
+}
+
+/**
+ * Replace `owner[method]` with an instrumented wrapper. Returns whether anything
+ * was patched (`false` when the method is missing or already wrapped).
+ *
+ * The provider SDKs return a promise-like (`APIPromise`) from `create`; the
+ * wrapper awaits it, so callers always get a plain `Promise`. `stream: true`
+ * calls resolve to an async iterable, which is proxied.
+ */
+export function patchMethod(owner: unknown, method: string, options: PatchOptions): boolean {
+  if (owner === null || typeof owner !== "object") return false;
+  const holder = owner as Record<string, unknown>;
+  const original = holder[method];
+  if (typeof original !== "function" || isInstrumented(original)) return false;
+
+  const wrapper = async function (this: unknown, ...args: unknown[]): Promise<unknown> {
+    const params = (args[0] ?? {}) as Record<string, unknown>;
+    const call = new Call(
+      options.sink,
+      options.provider,
+      typeof params.model === "string" ? params.model : undefined,
+    );
+    let result: unknown;
+    try {
+      result = await (original as (...a: unknown[]) => unknown).apply(this ?? owner, args);
+    } catch (err) {
+      call.record({}, err);
+      throw err;
+    }
+    try {
+      if (params.stream === true && isAsyncIterable(result)) {
+        return proxyStream(result, call, options.onChunk);
+      }
+      const usage: Usage = {};
+      options.extract(result, usage);
+      call.record(usage);
+    } catch (err) {
+      warn(`${options.provider} instrumentation failed; call unaffected`, err);
+    }
+    return result;
+  };
+  markInstrumented(wrapper);
+  try {
+    holder[method] = wrapper;
+  } catch (err) {
+    warn(`${options.provider} instrumentation: cannot patch ${method}`, err);
+    return false;
+  }
+  return true;
+}

--- a/packages/sdk-typescript/src/instrument/index.ts
+++ b/packages/sdk-typescript/src/instrument/index.ts
@@ -1,0 +1,3 @@
+export { instrumentOpenAI } from "./openai.js";
+export { instrumentAnthropic } from "./anthropic.js";
+export type { LlmCallSink } from "./common.js";

--- a/packages/sdk-typescript/src/instrument/openai.ts
+++ b/packages/sdk-typescript/src/instrument/openai.ts
@@ -1,0 +1,86 @@
+/**
+ * `instrumentOpenAI(client, memory)` — every `chat.completions.create` and
+ * `responses.create` on the `openai` package's client is recorded with
+ * `memory.recordLlmCall` (model, tokens, latency, provider).
+ *
+ * Streaming calls (`stream: true`) are recorded when the stream ends; the Chat
+ * Completions API only sends token counts on the final chunk when the request
+ * has `stream_options: { include_usage: true }` — without it the call is still
+ * recorded, with a model and latency but zero tokens. `openai` is an optional
+ * peer and is not imported here.
+ */
+
+import type { Extractor, LlmCallSink, Usage } from "./common.js";
+import { asInt, get, isInstrumented, markInstrumented, patchMethod, resolve } from "./common.js";
+
+const PROVIDER = "openai";
+
+export const extractChatCompletion: Extractor = (response, usage) => {
+  const model = get(response, "model");
+  if (typeof model === "string" && model) usage.model = model;
+  const u = get(response, "usage");
+  if (u) {
+    const inTok = asInt(get(u, "prompt_tokens"));
+    const outTok = asInt(get(u, "completion_tokens"));
+    if (inTok !== undefined) usage.inputTokens = inTok;
+    if (outTok !== undefined) usage.outputTokens = outTok;
+  }
+};
+
+export const extractResponse: Extractor = (response, usage) => {
+  const model = get(response, "model");
+  if (typeof model === "string" && model) usage.model = model;
+  const u = get(response, "usage");
+  if (u) {
+    const inTok = asInt(get(u, "input_tokens"));
+    const outTok = asInt(get(u, "output_tokens"));
+    if (inTok !== undefined) usage.inputTokens = inTok;
+    if (outTok !== undefined) usage.outputTokens = outTok;
+  }
+};
+
+/** Responses API stream: the terminal event carries the whole response. */
+export const extractResponseEvent: Extractor = (event, usage: Usage) => {
+  const type = String(get(event, "type") ?? "");
+  if (type === "response.completed" || type === "response.incomplete" || type === "response.failed") {
+    extractResponse(get(event, "response"), usage);
+  } else if (type === "response.created") {
+    const model = get(get(event, "response"), "model");
+    if (typeof model === "string" && model) usage.model = model;
+  }
+};
+
+/**
+ * Instrument an OpenAI (or AzureOpenAI) client in place and return it. Every
+ * call made through it is recorded on `memory` until the next
+ * `commitOutcomeAsync`, which ships the calls with the outcome. Idempotent.
+ *
+ * ```ts
+ * const openai = instrumentOpenAI(new OpenAI(), memory);
+ * const r = await openai.chat.completions.create({ model: "gpt-4o-mini", messages });
+ * await memory.commitOutcomeAsync("deploy-42", OutcomeType.SUCCESS);
+ * ```
+ */
+export function instrumentOpenAI<C>(client: C, memory: LlmCallSink): C {
+  if (isInstrumented(client)) return client;
+  const completions = resolve(client, ["chat", "completions"]);
+  if (completions) {
+    patchMethod(completions, "create", {
+      provider: PROVIDER,
+      sink: memory,
+      extract: extractChatCompletion,
+      onChunk: extractChatCompletion,
+    });
+  }
+  const responses = resolve(client, ["responses"]);
+  if (responses) {
+    patchMethod(responses, "create", {
+      provider: PROVIDER,
+      sink: memory,
+      extract: extractResponse,
+      onChunk: extractResponseEvent,
+    });
+  }
+  markInstrumented(client);
+  return client;
+}

--- a/packages/sdk-typescript/src/memory.ts
+++ b/packages/sdk-typescript/src/memory.ts
@@ -18,6 +18,7 @@ import { OutcomeType } from "./models.js";
 import { OutcomeBackPropagator } from "./outcome.js";
 import {
   buildSessionMetadata,
+  SESSION_ATTRIBUTES_MAX_KEYS,
   toLlmCallRecord,
   validateSessionAttributes,
 } from "./session.js";
@@ -434,9 +435,20 @@ export class AgentMemory {
    * boolean), at most 20 keys of up to 64 characters, string values up to 256
    * characters; anything else throws. Keys are lowercased. Cleared when the
    * outcome is committed.
+   *
+   * The key cap applies to the bag as merged, not to each call: a merge that
+   * would take it past 20 keys throws a `RangeError` and leaves the bag as it
+   * was.
    */
   setSessionAttributes(attributes: SessionAttributes): SessionAttributes {
-    Object.assign(this._sessionAttributes, validateSessionAttributes(attributes));
+    const merged = { ...this._sessionAttributes, ...validateSessionAttributes(attributes) };
+    const size = Object.keys(merged).length;
+    if (size > SESSION_ATTRIBUTES_MAX_KEYS) {
+      throw new RangeError(
+        `at most ${SESSION_ATTRIBUTES_MAX_KEYS} session attributes are allowed (the bag would hold ${size})`,
+      );
+    }
+    this._sessionAttributes = merged;
     return { ...this._sessionAttributes };
   }
 
@@ -689,8 +701,9 @@ export class AgentMemory {
    *
    * The session's attributes (from {@link setSessionAttributes} and
    * `options.attributes`) and recorded LLM calls travel as `session_metadata`
-   * and are cleared once the request has been sent, so each commit describes
-   * one run.
+   * and are cleared once the server has accepted them, so each commit
+   * describes one run. A refused commit — a 422 for a bad bag, a 5xx — leaves
+   * them in place: the run still happened, and a retry should carry them.
    */
   async commitOutcomeAsync(
     outcomeRef: string,
@@ -705,19 +718,17 @@ export class AgentMemory {
     const keys = options?.causalEntryKeys ?? this.readTracker.causalKeys;
     if (options?.attributes) this.setSessionAttributes(options.attributes);
     const sessionMetadata = buildSessionMetadata(this._sessionAttributes, this._sessionLlmCalls);
-    try {
-      return await this.requireHttp("commitOutcomeAsync").commitOutcomeAsync({
-        outcomeRef,
-        outcomeType: String(outcomeType),
-        entityPath: options?.entityPath,
-        causalEntryKeys: keys,
-        causalConfidence: options?.causalConfidence,
-        agentId: this.agentId,
-        sessionMetadata,
-      });
-    } finally {
-      this.resetSessionMetadata();
-    }
+    const result = await this.requireHttp("commitOutcomeAsync").commitOutcomeAsync({
+      outcomeRef,
+      outcomeType: String(outcomeType),
+      entityPath: options?.entityPath,
+      causalEntryKeys: keys,
+      causalConfidence: options?.causalConfidence,
+      agentId: this.agentId,
+      sessionMetadata,
+    });
+    this.resetSessionMetadata();
+    return result;
   }
 
   /** Version history of a key from the remote server. */

--- a/packages/sdk-typescript/src/memory.ts
+++ b/packages/sdk-typescript/src/memory.ts
@@ -16,6 +16,12 @@ import { CausalTagger, CoWEngine } from "./engine.js";
 import type { AMFSConfig, Commit, MemoryEntry, RecallConfig, ScopeInfo, ScoredEntry } from "./models.js";
 import { OutcomeType } from "./models.js";
 import { OutcomeBackPropagator } from "./outcome.js";
+import {
+  buildSessionMetadata,
+  toLlmCallRecord,
+  validateSessionAttributes,
+} from "./session.js";
+import type { LlmCallRecord, RecordLlmCallInput, SessionAttributes } from "./session.js";
 import { ReadTracker } from "./tracker.js";
 
 export interface AgentMemoryOptions {
@@ -57,6 +63,9 @@ export class AgentMemory {
 
   private engine: CoWEngine;
   private propagator: OutcomeBackPropagator;
+  /** Cleared when an outcome is committed; see {@link setSessionAttributes}. */
+  private _sessionAttributes: SessionAttributes = {};
+  private _sessionLlmCalls: LlmCallRecord[] = [];
 
   constructor(agentId: string, options?: AgentMemoryOptions) {
     const config = options?.config ?? defaultConfig();
@@ -394,7 +403,7 @@ export class AgentMemory {
     outcomeRef: string,
     outcomeType: OutcomeType,
     causalEntryKeys?: string[],
-    options?: { causalConfidence?: number }
+    options?: { causalConfidence?: number; attributes?: SessionAttributes }
   ): MemoryEntry[] {
     const keys = causalEntryKeys ?? this.readTracker.causalKeys;
     const record = OutcomeBackPropagator.makeRecord(
@@ -404,7 +413,62 @@ export class AgentMemory {
       this.agentId,
       { causalConfidence: options?.causalConfidence }
     );
+    // Local adapters propagate confidence but build no trace, so the session
+    // bag has nowhere to go here; it is still validated and consumed so the
+    // next run starts clean, as on the HTTP path.
+    if (options?.attributes) this.setSessionAttributes(options.attributes);
+    this.resetSessionMetadata();
     return this.propagator.propagate(record);
+  }
+
+  // ------------------------------------------------------------------
+  // Session metadata — attributes and LLM calls for the next trace
+  // ------------------------------------------------------------------
+
+  /**
+   * Merge `attributes` into the bag the next committed outcome stamps on its
+   * trace (`session_metadata.attributes`); returns the bag as it now stands.
+   *
+   * Attributes are the dimensions a run is later filtered and grouped by —
+   * `customer`, `task_type`, `environment`. Scalars only (string, number,
+   * boolean), at most 20 keys of up to 64 characters, string values up to 256
+   * characters; anything else throws. Keys are lowercased. Cleared when the
+   * outcome is committed.
+   */
+  setSessionAttributes(attributes: SessionAttributes): SessionAttributes {
+    Object.assign(this._sessionAttributes, validateSessionAttributes(attributes));
+    return { ...this._sessionAttributes };
+  }
+
+  /** The attribute bag waiting for the next commit. */
+  get sessionAttributes(): SessionAttributes {
+    return { ...this._sessionAttributes };
+  }
+
+  /**
+   * Record one LLM call for the trace the next committed outcome builds.
+   *
+   * Token counts and cost are only ever known if the agent reports them, so
+   * this is what makes a trace's token and cost figures real rather than
+   * blank. `instrumentOpenAI` / `instrumentAnthropic` call this for you.
+   * Stored in `session_metadata.llm_calls` as
+   * `{call_id, model, provider, input_tokens, output_tokens, cost_usd, latency_ms, started_at}`.
+   * Returns the record as stored. Cleared when the outcome is committed.
+   */
+  recordLlmCall(call: RecordLlmCallInput, startedAt?: Date): LlmCallRecord {
+    const record = toLlmCallRecord(call, startedAt);
+    this._sessionLlmCalls.push(record);
+    return { ...record };
+  }
+
+  /** The LLM calls waiting for the next commit. */
+  get sessionLlmCalls(): LlmCallRecord[] {
+    return this._sessionLlmCalls.map((c) => ({ ...c }));
+  }
+
+  private resetSessionMetadata(): void {
+    this._sessionAttributes = {};
+    this._sessionLlmCalls = [];
   }
 
   // ------------------------------------------------------------------
@@ -620,21 +684,40 @@ export class AgentMemory {
     return this.requireHttp("briefingAsync").briefingAsync(options);
   }
 
-  /** Commit an outcome remotely, snapshotting the session's causal chain. */
+  /**
+   * Commit an outcome remotely, snapshotting the session's causal chain.
+   *
+   * The session's attributes (from {@link setSessionAttributes} and
+   * `options.attributes`) and recorded LLM calls travel as `session_metadata`
+   * and are cleared once the request has been sent, so each commit describes
+   * one run.
+   */
   async commitOutcomeAsync(
     outcomeRef: string,
     outcomeType: OutcomeType,
-    options?: { entityPath?: string; causalEntryKeys?: string[]; causalConfidence?: number }
+    options?: {
+      entityPath?: string;
+      causalEntryKeys?: string[];
+      causalConfidence?: number;
+      attributes?: SessionAttributes;
+    }
   ): Promise<unknown> {
     const keys = options?.causalEntryKeys ?? this.readTracker.causalKeys;
-    return this.requireHttp("commitOutcomeAsync").commitOutcomeAsync({
-      outcomeRef,
-      outcomeType: String(outcomeType),
-      entityPath: options?.entityPath,
-      causalEntryKeys: keys,
-      causalConfidence: options?.causalConfidence,
-      agentId: this.agentId,
-    });
+    if (options?.attributes) this.setSessionAttributes(options.attributes);
+    const sessionMetadata = buildSessionMetadata(this._sessionAttributes, this._sessionLlmCalls);
+    try {
+      return await this.requireHttp("commitOutcomeAsync").commitOutcomeAsync({
+        outcomeRef,
+        outcomeType: String(outcomeType),
+        entityPath: options?.entityPath,
+        causalEntryKeys: keys,
+        causalConfidence: options?.causalConfidence,
+        agentId: this.agentId,
+        sessionMetadata,
+      });
+    } finally {
+      this.resetSessionMetadata();
+    }
   }
 
   /** Version history of a key from the remote server. */

--- a/packages/sdk-typescript/src/session.ts
+++ b/packages/sdk-typescript/src/session.ts
@@ -1,0 +1,154 @@
+/**
+ * Session metadata the SDK collects for a trace: the attribute bag a run is
+ * filtered and grouped by, and the LLM calls that give it real token and cost
+ * figures. Both travel in `session_metadata` when the outcome is committed —
+ * `attributes` and `llm_calls`, the same shape the Python SDK and MCP server
+ * write, so the server treats every producer alike.
+ */
+
+export type AttributeValue = string | number | boolean;
+export type SessionAttributes = Record<string, AttributeValue>;
+
+/** Attributes are indexed server-side, so the bag is kept small and flat. */
+export const SESSION_ATTRIBUTES_MAX_KEYS = 20;
+export const SESSION_ATTRIBUTE_KEY_MAX_LEN = 64;
+export const SESSION_ATTRIBUTE_VALUE_MAX_LEN = 256;
+
+/**
+ * The validated form of an attribute bag, or a thrown `TypeError` / `RangeError`.
+ *
+ * Keys are trimmed and lowercased (the server indexes them that way, so two
+ * spellings of one dimension would otherwise never group together). Values
+ * must be string, finite number or boolean; at most 20 keys of up to 64
+ * characters, string values up to 256 characters. Rejected rather than
+ * trimmed: a silently shortened customer id is worse than an error at the
+ * call site.
+ */
+export function validateSessionAttributes(attributes: unknown): SessionAttributes {
+  if (attributes === null || attributes === undefined) return {};
+  if (typeof attributes !== "object" || Array.isArray(attributes)) {
+    throw new TypeError("attributes must be an object of scalar values");
+  }
+  const entries = Object.entries(attributes as Record<string, unknown>);
+  if (entries.length > SESSION_ATTRIBUTES_MAX_KEYS) {
+    throw new RangeError(
+      `at most ${SESSION_ATTRIBUTES_MAX_KEYS} session attributes are allowed (got ${entries.length})`,
+    );
+  }
+  const out: SessionAttributes = {};
+  for (const [rawKey, value] of entries) {
+    const key = String(rawKey).trim().toLowerCase();
+    if (!key) throw new RangeError("attribute keys must be non-empty strings");
+    if (key.length > SESSION_ATTRIBUTE_KEY_MAX_LEN) {
+      throw new RangeError(
+        `attribute key '${key.slice(0, 20)}...' exceeds ${SESSION_ATTRIBUTE_KEY_MAX_LEN} characters`,
+      );
+    }
+    if (typeof value === "string") {
+      if (value.length > SESSION_ATTRIBUTE_VALUE_MAX_LEN) {
+        throw new RangeError(
+          `attribute '${key}' exceeds ${SESSION_ATTRIBUTE_VALUE_MAX_LEN} characters`,
+        );
+      }
+      out[key] = value;
+    } else if (typeof value === "number") {
+      if (!Number.isFinite(value)) throw new RangeError(`attribute '${key}' must be a finite number`);
+      out[key] = value;
+    } else if (typeof value === "boolean") {
+      out[key] = value;
+    } else {
+      throw new TypeError(
+        `attribute '${key}' must be a string, number or boolean, not ${value === null ? "null" : typeof value}`,
+      );
+    }
+  }
+  return out;
+}
+
+/** What {@link AgentMemory.recordLlmCall} takes. */
+export interface RecordLlmCallInput {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  /** USD; omit when unknown — a blank cost is honest, a zero one is not. */
+  costUsd?: number | null;
+  latencyMs?: number | null;
+  provider?: string | null;
+  callId?: string | null;
+  /** Set when the call failed; the record still counts the attempt. */
+  error?: string | null;
+}
+
+/**
+ * One LLM call as stored in `session_metadata.llm_calls` (wire shape, snake_case).
+ * Mirrors the record the Python SDK's `record_llm_call` writes.
+ */
+export interface LlmCallRecord {
+  call_id: string;
+  model: string;
+  provider: string;
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number | null;
+  latency_ms: number | null;
+  started_at: string;
+  [extra: string]: unknown;
+}
+
+function nonNegativeInt(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new TypeError(`${label} must be a number`);
+  }
+  const n = Math.trunc(value);
+  if (n < 0) throw new RangeError(`${label} must be non-negative`);
+  return n;
+}
+
+function optionalNonNegative(value: unknown, label: string): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new RangeError(`${label} must be a non-negative number or null`);
+  }
+  return value;
+}
+
+function newCallId(): string {
+  const c = globalThis.crypto as { randomUUID?: () => string } | undefined;
+  if (c?.randomUUID) return c.randomUUID();
+  // Fallback for runtimes without WebCrypto: time + random, unique enough per session.
+  return `${Date.now().toString(16)}-${Math.random().toString(16).slice(2, 14)}`;
+}
+
+/** Validate and normalise a call into the wire record. Throws on bad input. */
+export function toLlmCallRecord(input: RecordLlmCallInput, startedAt?: Date): LlmCallRecord {
+  if (typeof input?.model !== "string" || !input.model) {
+    throw new TypeError("model must be a non-empty string");
+  }
+  const record: LlmCallRecord = {
+    call_id: input.callId || newCallId(),
+    model: input.model,
+    provider: input.provider ?? "",
+    input_tokens: nonNegativeInt(input.inputTokens, "inputTokens"),
+    output_tokens: nonNegativeInt(input.outputTokens, "outputTokens"),
+    cost_usd: optionalNonNegative(input.costUsd, "costUsd"),
+    latency_ms: optionalNonNegative(input.latencyMs, "latencyMs"),
+    started_at: (startedAt ?? new Date()).toISOString(),
+  };
+  if (input.error) record.error = String(input.error);
+  return record;
+}
+
+/**
+ * The `session_metadata` object sent with an outcome: the two collections when
+ * they have content, nothing otherwise (so a server that predates them sees
+ * the request it always saw).
+ */
+export function buildSessionMetadata(
+  attributes: SessionAttributes,
+  llmCalls: LlmCallRecord[],
+): Record<string, unknown> | undefined {
+  const out: Record<string, unknown> = {};
+  if (Object.keys(attributes).length) out.attributes = { ...attributes };
+  if (llmCalls.length) out.llm_calls = llmCalls.map((c) => ({ ...c }));
+  return Object.keys(out).length ? out : undefined;
+}

--- a/tests/unit/test_session_metadata_extras.py
+++ b/tests/unit/test_session_metadata_extras.py
@@ -1,0 +1,327 @@
+"""Session attributes and LLM calls: the two things a trace cannot know unless
+the SDK is told.
+
+A run's cost and token counts exist only if the agent's LLM calls are recorded;
+its dimensions (customer, task type) only if the developer passes them. Both
+travel in ``DecisionTrace.session_metadata`` under ``attributes`` / ``llm_calls``,
+which the server lifts into the sealed trace. These tests pin that contract for
+the Python SDK: what ``set_session_attributes`` / ``record_llm_call`` /
+``commit_outcome(attributes=..., llm_calls=...)`` accept, the exact shape they
+write, that the shape survives the HTTP adapter's ``model_dump``, and that the
+buffers reset once a trace is built.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from amfs import AgentMemory
+from amfs.memory import (
+    SESSION_ATTRIBUTES_KEY,
+    SESSION_LLM_CALLS_KEY,
+    validate_session_attributes,
+)
+from amfs_core.models import DecisionTrace, OutcomeType, SessionMetadata
+from amfs_filesystem.adapter import FilesystemAdapter
+
+
+@pytest.fixture
+def mem(tmp_path) -> AgentMemory:
+    return AgentMemory(agent_id="deploy-agent", adapter=FilesystemAdapter(tmp_path / "amfs"))
+
+
+# ---------------------------------------------------------------------------
+# SessionMetadata keeps extras
+# ---------------------------------------------------------------------------
+
+
+def test_session_metadata_keeps_and_serialises_extra_keys() -> None:
+    meta = SessionMetadata(model="gpt-4o", attributes={"customer": "acme"}, spans=[{"a": 1}])
+    dumped = meta.model_dump(mode="json")
+    assert dumped["attributes"] == {"customer": "acme"}
+    assert dumped["spans"] == [{"a": 1}]
+
+    # Through the trace too — this is the HTTP adapter's wire form.
+    trace = DecisionTrace(agent_id="a", session_id="s", session_metadata=meta)
+    wire = trace.model_dump(mode="json")["session_metadata"]
+    assert wire["attributes"] == {"customer": "acme"}
+    assert wire["spans"] == [{"a": 1}]
+
+    # And back from a dict, which is how the server reads a posted body.
+    again = DecisionTrace.model_validate(
+        {"agent_id": "a", "session_id": "s", "session_metadata": wire}
+    )
+    assert again.session_metadata is not None
+    assert again.session_metadata.model_dump()["attributes"] == {"customer": "acme"}
+
+
+# ---------------------------------------------------------------------------
+# validate_session_attributes
+# ---------------------------------------------------------------------------
+
+
+def test_validate_attributes_accepts_scalars_and_lowercases_keys() -> None:
+    out = validate_session_attributes({" Customer ": "acme", "retries": 3, "ok": True, "p": 0.5})
+    assert out == {"customer": "acme", "retries": 3, "ok": True, "p": 0.5}
+
+
+@pytest.mark.parametrize(
+    "bad, exc",
+    [
+        ({"customer": ["acme"]}, TypeError),
+        ({"customer": {"id": 1}}, TypeError),
+        ({"customer": None}, TypeError),
+        ({"": "x"}, ValueError),
+        ({"k" * 65: "x"}, ValueError),
+        ({"customer": "x" * 257}, ValueError),
+        ({f"k{i}": i for i in range(21)}, ValueError),
+        ({"nan": float("nan")}, ValueError),
+        ("not-a-dict", TypeError),
+    ],
+)
+def test_validate_attributes_rejects_bad_input(bad, exc) -> None:
+    with pytest.raises(exc):
+        validate_session_attributes(bad)
+
+
+def test_validate_attributes_none_is_empty() -> None:
+    assert validate_session_attributes(None) == {}
+
+
+# ---------------------------------------------------------------------------
+# set_session_attributes / record_llm_call
+# ---------------------------------------------------------------------------
+
+
+def test_set_session_attributes_merges_and_returns_bag(mem) -> None:
+    assert mem.set_session_attributes({"customer": "acme"}) == {"customer": "acme"}
+    bag = mem.set_session_attributes({"task_type": "deploy", "customer": "globex"})
+    assert bag == {"customer": "globex", "task_type": "deploy"}
+    assert mem.session_attributes == bag
+
+
+def test_set_session_attributes_raises_and_leaves_bag_untouched(mem) -> None:
+    mem.set_session_attributes({"customer": "acme"})
+    with pytest.raises(TypeError):
+        mem.set_session_attributes({"bad": object()})
+    assert mem.session_attributes == {"customer": "acme"}
+
+
+def test_record_llm_call_writes_the_llm_call_shape(mem) -> None:
+    rec = mem.record_llm_call(
+        "gpt-4o", 120, 30, cost_usd=0.0006, latency_ms=412.5, provider="openai", call_id="c1",
+    )
+    assert rec == {
+        "call_id": "c1",
+        "model": "gpt-4o",
+        "provider": "openai",
+        "input_tokens": 120,
+        "output_tokens": 30,
+        "cost_usd": 0.0006,
+        "latency_ms": 412.5,
+        "started_at": rec["started_at"],
+    }
+    assert isinstance(rec["started_at"], str) and rec["started_at"].endswith("+00:00")
+    assert mem.session_llm_calls == [rec]
+
+
+def test_record_llm_call_defaults(mem) -> None:
+    rec = mem.record_llm_call("claude-3.5-sonnet", 10, 5)
+    assert rec["provider"] == ""
+    assert rec["cost_usd"] is None
+    assert rec["latency_ms"] is None
+    assert rec["call_id"]  # generated
+
+
+@pytest.mark.parametrize(
+    "kwargs, exc",
+    [
+        (dict(model="", input_tokens=1, output_tokens=1), ValueError),
+        (dict(model="m", input_tokens="x", output_tokens=1), TypeError),
+        (dict(model="m", input_tokens=-1, output_tokens=1), ValueError),
+        (dict(model="m", input_tokens=1, output_tokens=1, cost_usd=-0.1), ValueError),
+        (dict(model="m", input_tokens=1, output_tokens=1, latency_ms="fast"), ValueError),
+    ],
+)
+def test_record_llm_call_validates(mem, kwargs, exc) -> None:
+    with pytest.raises(exc):
+        mem.record_llm_call(**kwargs)
+    assert mem.session_llm_calls == []
+
+
+# ---------------------------------------------------------------------------
+# commit_outcome merges everything into session_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_commit_outcome_merges_attributes_and_llm_calls_into_session_metadata(mem) -> None:
+    mem.session_metadata = SessionMetadata(model="claude-4-opus")
+    mem.set_session_attributes({"customer": "acme", "task_type": "deploy"})
+    mem.record_llm_call("gpt-4o", 100, 20, cost_usd=0.001, provider="openai")
+
+    mem.commit_outcome(
+        "deploy-42",
+        OutcomeType.SUCCESS,
+        attributes={"task_type": "rollback", "region": "eu"},
+        llm_calls=[{"model": "gpt-4o-mini", "input_tokens": 5, "output_tokens": 2}],
+    )
+
+    trace = mem._last_trace
+    meta = trace.session_metadata
+    assert isinstance(meta, SessionMetadata)
+    assert meta.model == "claude-4-opus"  # base fields kept
+    dumped = meta.model_dump(mode="json")
+    # commit_outcome(attributes=) wins over set_session_attributes.
+    assert dumped[SESSION_ATTRIBUTES_KEY] == {
+        "customer": "acme", "task_type": "rollback", "region": "eu",
+    }
+    calls = dumped[SESSION_LLM_CALLS_KEY]
+    assert [c["model"] for c in calls] == ["gpt-4o", "gpt-4o-mini"]
+    # The explicit call was normalised into the same shape as the recorded one.
+    assert set(calls[1]) >= {
+        "call_id", "model", "provider", "input_tokens", "output_tokens",
+        "cost_usd", "latency_ms", "started_at",
+    }
+    assert calls[1]["provider"] == ""
+
+    # Session timing is on the trace regardless of adapter.
+    assert trace.session_started_at is not None
+    assert trace.session_ended_at is not None
+    assert trace.session_duration_ms is not None and trace.session_duration_ms >= 0
+
+    # Buffers reset for the next window.
+    assert mem.session_attributes == {}
+    assert mem.session_llm_calls == []
+    # ... but the session's own metadata instance was not mutated.
+    assert "attributes" not in mem.session_metadata.model_dump()
+
+
+def test_commit_outcome_with_nothing_extra_leaves_metadata_none(mem) -> None:
+    mem.commit_outcome("t-1", OutcomeType.SUCCESS)
+    assert mem._last_trace.session_metadata is None
+
+
+def test_commit_outcome_preserves_extras_already_on_the_metadata(mem) -> None:
+    """A Pro recorder puts its span tree on the metadata as an extra key; the
+    merge must carry it, and merge into — not replace — an attribute bag it set."""
+    meta = SessionMetadata()
+    meta.spans = [{"span_id": "s1", "name": "root", "kind": "session"}]
+    meta.attributes = {"agent_kind": "deploy"}
+    mem.session_metadata = meta
+    mem.set_session_attributes({"customer": "acme"})
+
+    mem.commit_outcome("t-2", OutcomeType.SUCCESS)
+
+    dumped = mem._last_trace.session_metadata.model_dump(mode="json")
+    assert dumped["spans"] == [{"span_id": "s1", "name": "root", "kind": "session"}]
+    assert dumped["attributes"] == {"agent_kind": "deploy", "customer": "acme"}
+
+
+def test_commit_outcome_rejects_bad_attributes_before_writing(mem) -> None:
+    with pytest.raises(TypeError):
+        mem.commit_outcome("t-3", OutcomeType.SUCCESS, attributes={"x": object()})
+    assert getattr(mem, "_last_trace", None) is None
+
+
+def test_commit_outcome_skips_unusable_explicit_llm_calls(mem) -> None:
+    mem.commit_outcome(
+        "t-4", OutcomeType.SUCCESS,
+        llm_calls=["nope", {"foo": "bar"}, {"model": "m", "input_tokens": "x"}],
+    )
+    assert mem._last_trace.session_metadata is None
+
+
+def test_the_shape_survives_the_http_adapters_wire_form(mem) -> None:
+    """``HttpAdapter.save_trace`` posts ``trace.model_dump(mode="json")``; the
+    extras must be in it — a subclass instance would have lost them here."""
+    mem.set_session_attributes({"customer": "acme"})
+    mem.record_llm_call("gpt-4o", 1, 1, provider="openai")
+    mem.commit_outcome("t-5", OutcomeType.SUCCESS)
+
+    wire = mem._last_trace.model_dump(mode="json")
+    assert wire["session_metadata"]["attributes"] == {"customer": "acme"}
+    assert wire["session_metadata"]["llm_calls"][0]["model"] == "gpt-4o"
+    assert wire["session_started_at"] and wire["session_ended_at"]
+    assert wire["session_duration_ms"] is not None
+
+
+# ---------------------------------------------------------------------------
+# The HTTP server relays a remote client's session_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_outcomes_endpoint_passes_client_session_metadata_to_commit_outcome() -> None:
+    """The TypeScript SDK commits through ``POST /api/v1/outcomes``; the trace is
+    built server-side from the shared handle, so the client's attributes and
+    LLM calls only reach it if the endpoint hands them to ``commit_outcome``."""
+    from amfs_http import server as http_server
+    from amfs_http.models import OutcomeRequest
+
+    seen: dict[str, object] = {}
+
+    def _commit(outcome_ref, otype, **kwargs):
+        seen.update(kwargs, outcome_ref=outcome_ref)
+        return []
+
+    mem = SimpleNamespace(
+        commit_outcome=_commit,
+        _tagger=SimpleNamespace(agent_id="server"),
+        _adapter=SimpleNamespace(ensure_agent=lambda *a, **k: None),
+        namespace="default",
+        _last_trace=None,
+    )
+    originals = (
+        http_server._get_memory, http_server._link_agent_owner_once,
+        http_server._audit_log, http_server._auto_seal_trace,
+    )
+    http_server._get_memory = lambda: mem  # type: ignore[assignment]
+    http_server._link_agent_owner_once = lambda *a, **k: None  # type: ignore[assignment]
+    http_server._audit_log = lambda *a, **k: None  # type: ignore[assignment]
+    http_server._auto_seal_trace = lambda *a, **k: None  # type: ignore[assignment]
+    try:
+        req = OutcomeRequest(
+            outcome_ref="ts-1",
+            outcome_type="success",
+            agent_id="ts-agent",
+            session_metadata={
+                "attributes": {"Customer": "acme"},
+                "llm_calls": [{"model": "gpt-4o", "input_tokens": 3, "output_tokens": 1}],
+            },
+        )
+        request = SimpleNamespace(client=None)
+        asyncio.run(http_server.commit_outcome(req, request, None))
+    finally:
+        (
+            http_server._get_memory, http_server._link_agent_owner_once,
+            http_server._audit_log, http_server._auto_seal_trace,
+        ) = originals  # type: ignore[assignment]
+
+    assert seen["attributes"] == {"customer": "acme"}
+    assert seen["llm_calls"] == [{"model": "gpt-4o", "input_tokens": 3, "output_tokens": 1}]
+
+
+def test_outcomes_endpoint_rejects_bad_client_attributes_with_422() -> None:
+    from amfs_http import server as http_server
+    from amfs_http.models import OutcomeRequest
+    from fastapi import HTTPException
+
+    mem = SimpleNamespace(
+        commit_outcome=lambda *a, **k: pytest.fail("must not commit"),
+        _tagger=SimpleNamespace(agent_id="server"),
+        _adapter=SimpleNamespace(ensure_agent=lambda *a, **k: None),
+        namespace="default",
+    )
+    original = http_server._get_memory
+    http_server._get_memory = lambda: mem  # type: ignore[assignment]
+    try:
+        req = OutcomeRequest(
+            outcome_ref="ts-2", outcome_type="success",
+            session_metadata={"attributes": {"customer": ["acme"]}},
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(http_server.commit_outcome(req, SimpleNamespace(client=None), None))
+    finally:
+        http_server._get_memory = original  # type: ignore[assignment]
+    assert exc_info.value.status_code == 422

--- a/tests/unit/test_session_metadata_extras.py
+++ b/tests/unit/test_session_metadata_extras.py
@@ -14,6 +14,7 @@ buffers reset once a trace is built.
 from __future__ import annotations
 
 import asyncio
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -107,6 +108,20 @@ def test_set_session_attributes_raises_and_leaves_bag_untouched(mem) -> None:
     with pytest.raises(TypeError):
         mem.set_session_attributes({"bad": object()})
     assert mem.session_attributes == {"customer": "acme"}
+
+
+def test_set_session_attributes_caps_the_merged_bag_not_each_call(mem) -> None:
+    """Two batches of 15 are each under the cap; the bag they build is not."""
+    first = {f"a{i}": i for i in range(15)}
+    mem.set_session_attributes(first)
+    with pytest.raises(ValueError, match="at most 20"):
+        mem.set_session_attributes({f"b{i}": i for i in range(15)})
+    assert mem.session_attributes == first
+    # Re-setting keys already in the bag does not count towards the cap.
+    assert len(mem.set_session_attributes({"a0": 99, "a1": 98})) == 15
+    assert len(mem.set_session_attributes({f"c{i}": i for i in range(5)})) == 20
+    with pytest.raises(ValueError, match="at most 20"):
+        mem.set_session_attributes({"one_too_many": True})
 
 
 def test_record_llm_call_writes_the_llm_call_shape(mem) -> None:
@@ -225,6 +240,29 @@ def test_commit_outcome_rejects_bad_attributes_before_writing(mem) -> None:
     assert getattr(mem, "_last_trace", None) is None
 
 
+def test_commit_outcome_caps_the_bag_merged_from_all_three_sources(mem) -> None:
+    """Identity metadata, ``set_session_attributes`` and ``attributes=`` are each
+    within the cap; their union is not, and nothing may be written for it."""
+    meta = SessionMetadata()
+    meta.attributes = {f"m{i}": i for i in range(8)}
+    mem.session_metadata = meta
+    mem.set_session_attributes({f"s{i}": i for i in range(8)})
+    with pytest.raises(ValueError, match="at most 20"):
+        mem.commit_outcome(
+            "t-3b", OutcomeType.SUCCESS, attributes={f"c{i}": i for i in range(8)}
+        )
+    assert getattr(mem, "_last_trace", None) is None
+    assert mem._adapter.list_outcomes() == []
+    # The session bag survives a refused commit so the caller can trim and retry.
+    assert len(mem.session_attributes) == 8
+    # Overlapping keys collapse in the merge, so this one fits: 8 + 8 + 4 new.
+    mem.commit_outcome(
+        "t-3c", OutcomeType.SUCCESS,
+        attributes={**{f"s{i}": i for i in range(4)}, **{f"c{i}": i for i in range(4)}},
+    )
+    assert len(mem._last_trace.session_metadata.model_dump()["attributes"]) == 20
+
+
 def test_commit_outcome_skips_unusable_explicit_llm_calls(mem) -> None:
     mem.commit_outcome(
         "t-4", OutcomeType.SUCCESS,
@@ -245,6 +283,75 @@ def test_the_shape_survives_the_http_adapters_wire_form(mem) -> None:
     assert wire["session_metadata"]["llm_calls"][0]["model"] == "gpt-4o"
     assert wire["session_started_at"] and wire["session_ended_at"]
     assert wire["session_duration_ms"] is not None
+
+
+def _http_memory():
+    """An ``AgentMemory`` over an ``HttpAdapter`` whose transport records every
+    request body and answers with an empty 200."""
+    import httpx
+    from amfs_adapter_http.adapter import HttpAdapter
+
+    calls: list[dict[str, object]] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content) if request.content else None
+        calls.append({"method": request.method, "path": request.url.path, "body": body})
+        return httpx.Response(200, json={})
+
+    adapter = HttpAdapter.__new__(HttpAdapter)
+    adapter._base = "http://test"
+    adapter._api_key = "k"
+    adapter._client = httpx.Client(
+        base_url="http://test", headers={"X-AMFS-API-Key": "k"},
+        transport=httpx.MockTransport(_handler),
+    )
+    return AgentMemory(agent_id="deploy-agent", adapter=adapter), calls
+
+
+def test_http_commit_outcome_carries_session_metadata_on_the_outcome_request() -> None:
+    """The server seals its trace from ``POST /api/v1/outcomes`` and reads the
+    bag from that body. A bag that only travelled on the later ``/traces`` post
+    sealed a trace with no attributes and no token or cost figures."""
+    mem, calls = _http_memory()
+    mem.session_metadata = SessionMetadata(model="claude-4-opus")
+    mem.set_session_attributes({"customer": "acme"})
+    mem.record_llm_call("gpt-4o", 100, 20, cost_usd=0.001, provider="openai", call_id="c1")
+
+    mem.commit_outcome(
+        "deploy-42", OutcomeType.SUCCESS,
+        attributes={"task_type": "deploy"},
+        llm_calls=[{"model": "gpt-4o-mini", "input_tokens": 5, "output_tokens": 2}],
+    )
+
+    outcome_posts = [c for c in calls if c["path"] == "/api/v1/outcomes"]
+    assert len(outcome_posts) == 1
+    meta = outcome_posts[0]["body"]["session_metadata"]
+    assert meta["model"] == "claude-4-opus"
+    assert meta[SESSION_ATTRIBUTES_KEY] == {"customer": "acme", "task_type": "deploy"}
+    assert [c["model"] for c in meta[SESSION_LLM_CALLS_KEY]] == ["gpt-4o", "gpt-4o-mini"]
+    assert meta[SESSION_LLM_CALLS_KEY][0]["call_id"] == "c1"
+    assert meta[SESSION_LLM_CALLS_KEY][0]["cost_usd"] == 0.001
+    # The outcome went out before the trace, and the trace carries the same bag.
+    trace_posts = [c for c in calls if c["path"] == "/api/v1/traces"]
+    assert calls.index(outcome_posts[0]) < calls.index(trace_posts[0])
+    assert trace_posts[0]["body"]["session_metadata"][SESSION_ATTRIBUTES_KEY] == meta[
+        SESSION_ATTRIBUTES_KEY
+    ]
+
+
+def test_http_commit_outcome_omits_session_metadata_when_there_is_none() -> None:
+    mem, calls = _http_memory()
+    mem.commit_outcome("t-6", OutcomeType.SUCCESS)
+    (post,) = [c for c in calls if c["path"] == "/api/v1/outcomes"]
+    assert "session_metadata" not in post["body"]
+
+
+def test_http_commit_outcome_sends_nothing_when_the_merged_bag_is_over_the_cap() -> None:
+    mem, calls = _http_memory()
+    mem.set_session_attributes({f"s{i}": i for i in range(15)})
+    with pytest.raises(ValueError, match="at most 20"):
+        mem.commit_outcome("t-7", OutcomeType.SUCCESS, attributes={f"c{i}": i for i in range(15)})
+    assert [c for c in calls if c["method"] == "POST"] == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Companion to raia-live/amfs-internal `feat/eval-complete` (private CI checks out this branch by name).

## What
- `SessionMetadata` keeps extra keys (`attributes`, `llm_calls`) through validation and HTTP serialisation — previously dropped twice.
- Python SDK: `AgentMemory.set_session_attributes()`, `record_llm_call()`, `commit_outcome(..., attributes=)`.
- `POST /api/v1/outcomes` accepts `session_metadata`; attributes validated (422 on bad bag).
- TypeScript SDK: `setSessionAttributes`, `recordLlmCall`, `commitOutcome({attributes})`, `instrumentOpenAI` / `instrumentAnthropic` (optional peers).
- Docs: "Capturing runs for the Behavior section"; parity rows in `docs/editions.md`.

## Why
Runs in the Behavior section showed blank duration, `$0.0000` cost and no attributes because nothing put that data on the wire. This is the minimal, generic OSS half; everything eval-specific lives in the private repo.

## Verification
`pytest tests/unit` 992 passed · `npm run typecheck` · vitest 73 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the outcome-commit and trace-sealing contract across SDKs, HTTP adapter, and server; incorrect handling could still drop metadata on sealed traces, but validation and tests reduce that risk.
> 
> **Overview**
> **Traces and the dashboard Behavior section can now get real grouping dimensions, token counts, and cost** because the SDKs attach `session_metadata.attributes` and `session_metadata.llm_calls` on the same path the server uses to seal traces—not only on a later trace save.
> 
> **Python (OSS):** `AgentMemory` adds `set_session_attributes`, `record_llm_call`, and `commit_outcome(..., attributes=, llm_calls=)` with validation (scalar bags, 20-key cap on merged bags) and buffers cleared after commit. `SessionMetadata` uses `extra="allow"` so `attributes` / `llm_calls` survive validation and JSON; `OutcomeRecord` carries `session_metadata` through `HttpAdapter.commit_outcome`.
> 
> **HTTP API:** `POST /api/v1/outcomes` accepts `session_metadata`, validates `attributes` (422 on bad bags), and forwards attributes and LLM calls into `commit_outcome` for stateless remote clients.
> 
> **TypeScript:** Matching session APIs, `commitOutcome` / `commitOutcomeAsync` with `session_metadata` on the wire, `toDecisionTrace` mapping for attributes and `llm_calls`, plus optional `instrumentOpenAI` / `instrumentAnthropic` peers that record calls without breaking provider errors or streams.
> 
> **Docs** expand editions and SDK–MCP parity (Behavior capture table, Pro tracing pointers). **Tests** lock the contract end-to-end (HTTP body, server handler, instrumentation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 862b3190b8c748ebc7496bf898d63a02fdc14068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->