### PR TITLE
Sync main into dev (#370, #371, #373) ahead of the dev → main promotion

### DIFF
--- a/packages/adapters/postgres/src/amfs_postgres/schema.sql
+++ b/packages/adapters/postgres/src/amfs_postgres/schema.sql
@@ -470,6 +470,19 @@ BEGIN
             AFTER INSERT ON amfs_outcomes
             FOR EACH ROW EXECUTE FUNCTION amfs_propagate_outcome();
     END IF;
+EXCEPTION WHEN duplicate_object THEN
+    -- Another process got there between the check and the CREATE, which the
+    -- drop-then-create pair tolerated by construction and a bare check does
+    -- not. Containers start in parallel and each applies this file, so the
+    -- window is reached in practice on a database being bootstrapped: both see
+    -- no trigger, the second blocks on the first's lock, and inherits an
+    -- already-existing trigger the moment it is granted.
+    --
+    -- Swallowing it is the whole point. _apply_schema retries only errors
+    -- mentioning a lock or a deadlock, so this one would propagate and leave
+    -- that container unable to boot -- and the outcome it is complaining about
+    -- is the one wanted anyway: the trigger exists.
+    NULL;
 END $$;
 
 -- LISTEN/NOTIFY trigger: notify on new entry writes for watch()
@@ -507,6 +520,9 @@ BEGIN
             AFTER INSERT ON amfs_memory_entries
             FOR EACH ROW EXECUTE FUNCTION amfs_notify_write();
     END IF;
+EXCEPTION WHEN duplicate_object THEN
+    -- Concurrent bootstrap; see trg_propagate_outcome.
+    NULL;
 END $$;
 
 -- Compiled digests table (Memory Cortex)
@@ -553,6 +569,9 @@ BEGIN
             AFTER INSERT OR UPDATE ON amfs_digests
             FOR EACH ROW EXECUTE FUNCTION amfs_notify_digest();
     END IF;
+EXCEPTION WHEN duplicate_object THEN
+    -- Concurrent bootstrap; see trg_propagate_outcome.
+    NULL;
 END $$;
 
 -- ──────────────────────────────────────────────────────────────────────

--- a/packages/adapters/postgres/src/amfs_postgres/schema.sql
+++ b/packages/adapters/postgres/src/amfs_postgres/schema.sql
@@ -440,10 +440,37 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS trg_propagate_outcome ON amfs_outcomes;
-CREATE TRIGGER trg_propagate_outcome
-    AFTER INSERT ON amfs_outcomes
-    FOR EACH ROW EXECUTE FUNCTION amfs_propagate_outcome();
+-- Created only when absent, rather than dropped and recreated every time.
+--
+-- This file is not run once. The adapter applies it on server startup, and CI
+-- applies it on every deploy, so an unconditional DROP TRIGGER took ACCESS
+-- EXCLUSIVE on these tables at each of those moments. That lock conflicts with
+-- reads, and Postgres queues later lock requests behind a pending exclusive
+-- one, so every query arriving while it waited queued behind it. Two
+-- production outages came out of that, the second with fifteen sessions
+-- blocked behind a single statement on amfs_memory_entries.
+--
+-- Dropping first was never doing anything anyway: the trigger is recreated
+-- identically, so on all but the first run the pair is an expensive no-op.
+--
+-- What a trigger *does* still updates normally, because the logic is in the
+-- function and CREATE OR REPLACE FUNCTION above needs no lock on the table.
+-- Only the binding itself -- which table, which events -- is frozen by this,
+-- and changing that is rare enough to belong in migrations/ where existing
+-- databases pick it up, which is how every other change to them travels.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgname = 'trg_propagate_outcome'
+          AND tgrelid = 'amfs_outcomes'::regclass
+          AND NOT tgisinternal
+    ) THEN
+        CREATE TRIGGER trg_propagate_outcome
+            AFTER INSERT ON amfs_outcomes
+            FOR EACH ROW EXECUTE FUNCTION amfs_propagate_outcome();
+    END IF;
+END $$;
 
 -- LISTEN/NOTIFY trigger: notify on new entry writes for watch()
 
@@ -464,10 +491,23 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS trg_notify_write ON amfs_memory_entries;
-CREATE TRIGGER trg_notify_write
-    AFTER INSERT ON amfs_memory_entries
-    FOR EACH ROW EXECUTE FUNCTION amfs_notify_write();
+-- Conditional for the reason given at trg_propagate_outcome. This is the one
+-- that did the damage: amfs_memory_entries is the busiest table here, so it is
+-- where an exclusive lock is least likely to be granted quickly and most
+-- expensive to wait for.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgname = 'trg_notify_write'
+          AND tgrelid = 'amfs_memory_entries'::regclass
+          AND NOT tgisinternal
+    ) THEN
+        CREATE TRIGGER trg_notify_write
+            AFTER INSERT ON amfs_memory_entries
+            FOR EACH ROW EXECUTE FUNCTION amfs_notify_write();
+    END IF;
+END $$;
 
 -- Compiled digests table (Memory Cortex)
 
@@ -500,10 +540,20 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS trg_notify_digest ON amfs_digests;
-CREATE TRIGGER trg_notify_digest
-    AFTER INSERT OR UPDATE ON amfs_digests
-    FOR EACH ROW EXECUTE FUNCTION amfs_notify_digest();
+-- Conditional for the reason given at trg_propagate_outcome.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgname = 'trg_notify_digest'
+          AND tgrelid = 'amfs_digests'::regclass
+          AND NOT tgisinternal
+    ) THEN
+        CREATE TRIGGER trg_notify_digest
+            AFTER INSERT OR UPDATE ON amfs_digests
+            FOR EACH ROW EXECUTE FUNCTION amfs_notify_digest();
+    END IF;
+END $$;
 
 -- ──────────────────────────────────────────────────────────────────────
 -- Commits — atomic groups of writes

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -218,23 +218,30 @@ def _getting_started() -> dict[str, str]:
 
 _toolset = os.environ.get("AMFS_TOOLSET", "all").lower()
 
+# Reported as serverInfo.name and shown to users by MCP clients, so it carries
+# the product name rather than the package name. Matches what the hosted
+# endpoint at mcp.sense-lab.ai already answers.
+_SERVER_NAME = "SenseLab Memory"
+
 
 def _create_server(toolset: str) -> FastMCP:
     """Build FastMCP with tag filtering, compatible with v2 and v3+."""
     instructions = _build_instructions()
     if toolset != "all":
         try:
-            server = FastMCP(name="amfs", instructions=instructions, include_tags={"core"})
+            server = FastMCP(
+                name=_SERVER_NAME, instructions=instructions, include_tags={"core"}
+            )
         except TypeError:
-            server = FastMCP(name="amfs", instructions=instructions)
+            server = FastMCP(name=_SERVER_NAME, instructions=instructions)
             server.enable(tags={"core"}, only=True)
         logger.info(
-            "AMFS toolset: core (essential tools incl. amfs_retrieve). "
-            "Set AMFS_TOOLSET=all to expose all 36 tools."
+            "SenseLab toolset: core (essential tools incl. amfs_retrieve). "
+            "Set AMFS_TOOLSET=all to expose every tool."
         )
     else:
-        server = FastMCP(name="amfs", instructions=instructions)
-        logger.info("AMFS toolset: all (36 tools)")
+        server = FastMCP(name=_SERVER_NAME, instructions=instructions)
+        logger.info("SenseLab toolset: all")
     return server
 
 

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -219,9 +219,8 @@ def _getting_started() -> dict[str, str]:
 _toolset = os.environ.get("AMFS_TOOLSET", "all").lower()
 
 # Reported as serverInfo.name and shown to users by MCP clients, so it carries
-# the product name rather than the package name. Matches what the hosted
-# endpoint at mcp.sense-lab.ai already answers.
-_SERVER_NAME = "SenseLab Memory"
+# the product name rather than the package name.
+_SERVER_NAME = "SenseLab"
 
 
 def _create_server(toolset: str) -> FastMCP:


### PR DESCRIPTION
## Why

`main` has three PRs that never came back to `dev`: #370 (the RLS/pooling promotion merge), #371 (server reports itself as `SenseLab`), #373 (notify triggers created only when absent, tolerating a concurrent bootstrap). `dev` is 13 commits ahead of `main`. Merging `main` back first means the later `dev → main` promotion is a fast-forward of code that has already run on the dev deploy.

Companion to raia-live/amfs-internal#708. Nothing here touches `main`.

## What's in the merge

Merge commit of `origin/main` into `origin/dev`. No conflicts; git auto-merged two files:

- `packages/mcp-server/src/amfs_mcp/server.py` — `_SERVER_NAME = "SenseLab"` and the renamed log lines from #371, on top of dev's version.
- `packages/adapters/postgres/src/amfs_postgres/schema.sql` — the `DO $$ ... IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = ...)` guards from #373 around `trg_propagate_outcome`, `trg_notify_write`, `trg_notify_digest`, on top of dev's schema.

Both read coherently; `server.py` parses. I could not run the OSS unit suite against this exact tree locally (the venv's editable install pins to a different checkout), so `test-python.yml` on this PR is the check that matters.

## Side effect to expect on merge

`trigger-deploy.yml` fires `oss-updated-dev` on push to `dev`, so merging this redeploys the internal dev environment against the synced OSS tree. That is the point of step 2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Postgres trigger DDL behavior changes on every deploy/startup (lower lock risk, but binding changes now require migrations); MCP display name only is low risk.
> 
> **Overview**
> Brings **`main` into `dev`** so upcoming promotion is a fast-forward, folding in three fixes that were only on `main`.
> 
> **Postgres schema (`schema.sql`):** Replaces unconditional **`DROP TRIGGER` + `CREATE TRIGGER`** on `trg_propagate_outcome`, `trg_notify_write`, and `trg_notify_digest` with **`DO` blocks that create each trigger only if it is missing**, plus **`duplicate_object` handling** for parallel container bootstrap. Because `schema.sql` runs on every adapter startup and deploy, the old pattern repeatedly took **ACCESS EXCLUSIVE** locks (notably on busy `amfs_memory_entries`), which had caused production query pile-ups. Trigger **function** bodies still update via `CREATE OR REPLACE FUNCTION` without rebinding triggers every time.
> 
> **MCP server (`server.py`):** Sets FastMCP **`serverInfo.name`** to **`SenseLab`** via `_SERVER_NAME` and updates startup log lines from “AMFS toolset” to “SenseLab toolset” so clients show the product name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d30d7c3dadf4cd20ddc3f51e075cd27f69154ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->