### PR TITLE
Promote dev to main: the gap report, capture, and 26 commits of continual-learning work

### DIFF
--- a/docs/editions.md
+++ b/docs/editions.md
@@ -569,6 +569,10 @@ Extends the OSS MCP server with additional tools:
 | `amfs_graph_path` | Find shortest trust-weighted path between two entities in the knowledge graph |
 | `amfs_graph_query` | Flexible graph edge search by relation, entity type, or confidence range |
 
+### Agent evaluation surfaces (Pro, hosted only)
+
+Pro adds an evaluation layer on top of sealed traces: LLM **judges** (versioned rubrics with sampling, budgets and dry runs), **verdicts** with evidence, **behaviors** mined from or authored against traces, **incidents** when a behavior breaks from baseline, blast-radius and dimension **segmentation**, **attribution** of failures to the memory entries that caused them, a **fix loop** that hands a coding agent a reproduction-and-tests payload, and an **investigator** that answers questions across runs. All of it runs on the hosted `/api/v1/eval` service and is reached three ways — the Pro MCP server's `amfs_judge_*` / `amfs_verdicts` / `amfs_behavior*` / `amfs_incident` / `amfs_propose_fix` / `amfs_investigate` tools (which refuse with `"mode": "local"` without `AMFS_HTTP_URL`), the private `amfs_pro` Python client (`ProClient` / `AsyncProClient`, dist `amfs-sdk-pro`), and the `amfs-pro` CLI (`eval`, `behaviors`, `incidents`, `fixes`, `cases`, `traces`, `investigate`; `--json` everywhere, `--fail-on-fail` for CI). None of these are in the OSS SDKs; the column map lives in [SDK ↔ MCP Parity]({{ site.baseurl }}/reference/sdk-mcp-parity/#agent-evaluation-pro-hosted-only).
+
 ---
 
 ## Architecture

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -407,7 +407,8 @@ recorder = TraceRecorder(memory, store, account_id=acct.id)
 recorder.memory.read("svc", "retry-pattern")
 recorder.memory.record_context("pagerduty", "3 SEV-1", source="PagerDuty API")
 
-# Record LLM calls for token/cost tracking
+# Record LLM calls for token/cost tracking (Pro: amfs_traces / amfs_record_llm_call;
+# the OSS MCP server does not expose this tool)
 recorder.record_llm_call(
     model="gpt-4o", provider="openai",
     prompt_tokens=1200, completion_tokens=450,
@@ -564,7 +565,7 @@ Extends the OSS MCP server with additional tools:
 | `amfs_retrain` | Train the learned ranking model from outcome data |
 | `amfs_calibrate` | Learn optimal confidence multipliers from outcome history |
 | `amfs_export_training_data` | Export decision traces as SFT/DPO/reward model datasets |
-| `amfs_record_llm_call` | Record an LLM call with model, tokens, cost, and latency |
+| `amfs_record_llm_call` | Record an LLM call with model, tokens, cost, and latency. **Pro only** — not registered by the OSS MCP server |
 | `amfs_graph_path` | Find shortest trust-weighted path between two entities in the knowledge graph |
 | `amfs_graph_query` | Flexible graph edge search by relation, entity type, or confidence range |
 

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -110,6 +110,11 @@ AMFS is GitHub for agent memory, split into two layers. The open-source core giv
 | Session-level causal explainability (`explain`) | Yes | Yes |
 | Enriched decision traces (query events, error events, state diff) | Yes | Yes |
 | Session timing and per-operation latency tracking | Yes | Yes |
+| Session attributes on traces (`set_session_attributes` / `setSessionAttributes`, `commit_outcome(attributes=...)`) | Yes | Yes |
+| Manual LLM call recording (`record_llm_call` / `recordLlmCall`) — tokens, cost, latency on the trace | Yes | Yes |
+| Automatic LLM call capture (`instrumentOpenAI` / `instrumentAnthropic`, TypeScript) | Yes | Yes |
+| Automatic LLM call capture with cost estimation and `llm` spans (`amfs_pro.tracing.instrument_openai` / `instrument_anthropic` / `instrument_litellm`, Python) | — | Yes |
+| Span tree per run (`trace_session`, `span()`, `@traced`; memory ops auto-mirrored as spans) | — | Yes |
 | Per-agent memory graph and activity timeline | Yes | Yes |
 | Composite recall scoring | Yes | Yes |
 | Multi-scope search | Yes | Yes |
@@ -390,6 +395,8 @@ The OSS `explain()` only works within the active session and captures enriched t
 - **Error events** — any errors during reads, writes, or tool calls
 - **State diff** — entries created, updated, and confidence changes during the session
 - **Full entry snapshots** — `value`, `memory_type`, and `written_by` captured at read time
+- **Session attributes** — `set_session_attributes({"customer": "acme"})` / `commit_outcome(..., attributes=...)` (TS: `setSessionAttributes`, `commitOutcome({attributes})`) stamp the dimensions a run is filtered and grouped by onto `session_metadata["attributes"]`
+- **LLM calls** — `record_llm_call(model, input_tokens, output_tokens, cost_usd=..., latency_ms=...)` (TS: `recordLlmCall`, or `instrumentOpenAI(client, memory)` / `instrumentAnthropic` to capture them automatically) fill `session_metadata["llm_calls"]`, which is the only way a trace gets real token and cost figures
 
 **Pro immutable traces** add:
 
@@ -397,6 +404,7 @@ The OSS `explain()` only works within the active session and captures enriched t
 - **LLM call spans** — model, provider, prompt/completion token counts, cost, latency, temperature, finish reason
 - **Write events, tool calls, agent interactions** — full record of every action
 - **Token and cost aggregates** — `total_llm_calls`, `total_tokens`, `total_cost_usd` per trace
+- **Span trees from the SDK** — `amfs_pro.tracing`: `trace_session(mem, attributes=...)` opens a root span and mirrors the memory's reads/writes/actions/contexts as child spans; `span()` / `@traced` add your own steps; `instrument_openai` / `instrument_anthropic` / `instrument_litellm` turn LLM calls into `llm` spans with estimated cost
 
 ```python
 from amfs_traces import TraceRecorder, InMemoryTraceStore
@@ -659,6 +667,7 @@ The Pro API layer wraps `AgentMemory` and `CoWEngine` with authentication, tenan
 | Enriched decision traces with error/query events and session timing | OSS |
 | Per-agent memory graph and activity timeline | OSS |
 | Immutable, cryptographically signed traces | **Pro** |
+| Session attributes and manually recorded LLM calls on traces | OSS |
 | LLM call span tracking with token/cost analytics | **Pro** |
 | OpenTelemetry export for existing observability stacks | **Pro** |
 | Auto entity/relationship extraction from traces | **Pro** |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -860,7 +860,7 @@ Paginated list endpoints return the existing list key plus `next_cursor` (opaque
 
 | Method | Path | Description |
 |:-------|:-----|:------------|
-| `GET` | `/api/v1/traces` | List decision traces (supports `?outcome_type=`, `?agent_id=`, `?entity_path=`, `?limit=`, `?offset=`, `?cursor=`). Returns `traces`, `next_cursor`, `has_more` |
+| `GET` | `/api/v1/traces` | List decision traces (supports `?outcome_type=`, `?agent_id=`, `?entity_path=`, `?limit=`, `?offset=`, `?cursor=`, `?since=` (inclusive), `?until=` (exclusive), ISO-8601). Returns `traces`, `next_cursor`, `has_more` |
 | `GET` | `/api/v1/traces/{trace_id}` | Get full trace detail with causal entries, external contexts, query/error events, state diff |
 
 ### Observability

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -844,8 +844,10 @@ All entry endpoints accept a `branch` parameter (query param for GET, body field
 |:-------|:-----|:------------|
 | `GET` | `/api/v1/agents` | List agents with entry counts, entities touched, and last active time |
 | `GET` | `/api/v1/agents/{agent_id}/memory-graph` | Get agent's memory graph (entities and entries touched) |
-| `GET` | `/api/v1/agents/{agent_id}/activity` | Get agent's activity timeline (writes, outcomes, traces) |
-| `GET` | `/api/v1/agents/{agent_id}/timeline` | Git-like event log (every write, outcome, read, brief) |
+| `GET` | `/api/v1/agents/{agent_id}/activity` | Get agent's activity timeline (writes, outcomes, traces). Keyset-paginated: `?limit=`, `?cursor=`, `?since=`, `?until=` |
+| `GET` | `/api/v1/agents/{agent_id}/timeline` | Git-like event log (every write, outcome, read, brief). Keyset-paginated: `?limit=`, `?cursor=`, `?since=`, `?until=`, `?event_type=` |
+
+Paginated list endpoints return the existing list key plus `next_cursor` (opaque string, `null` on the last page) and `has_more`. Pass `next_cursor` back as `?cursor=` to fetch the next page; `offset` is still honoured when no cursor is given. Page size is capped at 1000.
 
 ### Outcomes
 
@@ -858,7 +860,7 @@ All entry endpoints accept a `branch` parameter (query param for GET, body field
 
 | Method | Path | Description |
 |:-------|:-----|:------------|
-| `GET` | `/api/v1/traces` | List decision traces (supports `?outcome_type=`, `?agent_id=`, `?limit=`) |
+| `GET` | `/api/v1/traces` | List decision traces (supports `?outcome_type=`, `?agent_id=`, `?entity_path=`, `?limit=`, `?offset=`, `?cursor=`). Returns `traces`, `next_cursor`, `has_more` |
 | `GET` | `/api/v1/traces/{trace_id}` | Get full trace detail with causal entries, external contexts, query/error events, state diff |
 
 ### Observability
@@ -1016,6 +1018,8 @@ amfs_export_training_data(
 Export decision traces as fine-tuning datasets. Format options: `"sft"` (supervised fine-tuning), `"dpo"` (direct preference optimization), `"reward_model"` (reward model training). See the [ML Layer guide](/amfs/guides/ml-layer/) for format details.
 
 ### amfs_record_llm_call
+
+> **Pro only.** This tool is implemented only in the private AMFS Pro MCP server. The OSS `amfs-mcp-server` package does not register it; calling it there returns an unknown-tool error.
 
 ```
 amfs_record_llm_call(

--- a/docs/reference/sdk-mcp-parity.md
+++ b/docs/reference/sdk-mcp-parity.md
@@ -49,6 +49,21 @@ AMFS exposes memory three ways: the **MCP server** (for agents), the **Python SD
 | List traces | `amfs_list_traces` | `list_traces` | `listTracesAsync` |
 | Get trace | `amfs_get_trace` | `get_trace` | `getTraceAsync` |
 
+### Spans & trace navigation (Pro)
+
+These ship in the **Pro MCP server** (`amfs-mcp-server-pro`) only. The recording tools write into the current session through the span recorder and are sealed by `amfs_commit_outcome`, so they work against any adapter — local or HTTP. The navigation tools read sealed traces: with `AMFS_HTTP_URL` set they proxy to `/api/v1/pro/traces/...` (indexed, semantic search); without it they fall back to the local adapter's `list_traces` plus the trace the process committed last (`trace_id="last"`), filter in Python, and answer with `"mode": "local"`.
+
+| Capability | MCP tool (Pro) | Python SDK | TypeScript SDK |
+|:--|:--|:--|:--|
+| Record a completed span | `amfs_record_span` | `SpanRecorder.record_span` (`amfs_traces`) | — |
+| Open / close a span | `amfs_start_span` / `amfs_end_span` | `SpanRecorder.start_span` / `end_span`, `with recorder.span(...)` | — |
+| Trace attribute bag | `amfs_set_trace_attributes` | `SpanRecorder.set_attributes` | — |
+| Record an LLM call (also emits an `llm` span) | `amfs_record_llm_call` | `SpanRecorder.record_llm_call` | — |
+| Search traces by content, attributes, span name/kind, errors | `amfs_trace_search` | — (HTTP `POST /api/v1/pro/traces/search`) | — |
+| Span tree with text outline | `amfs_trace_spans` | — (HTTP `GET /api/v1/pro/traces/{id}/spans`) | — |
+| One span's input/output payloads | `amfs_span_payload` | — (HTTP `GET /api/v1/pro/traces/{id}/spans/{span_id}`) | — |
+| Compare two traces span by span | `amfs_trace_compare` | — (HTTP `POST /api/v1/pro/traces/compare`) | — |
+
 {: .note }
 The TypeScript SDK's `*Async` methods route through the `HttpAdapter` to a remote AMFS server. The synchronous methods operate on the in-process adapter. Construct `AgentMemory` with an `HttpAdapter` to use the async surface — the intended path for a Node orchestrator or a disposable sandbox pointing at hosted SenseLab.
 
@@ -66,6 +81,8 @@ These MCP tools are **not** mirrored 1:1 in the SDKs, by design. They are either
 |:--|:--|:--|
 | `amfs_consolidate`, `amfs_consolidation_status/proposals/candidates` | Pro (HTTP-proxied) | Backed by the Cortex consolidation API, not the OSS adapter ABC. The TypeScript `HttpAdapter` exposes `consolidation*Async` passthroughs; the Python SDK reaches them via the HTTP API directly. See the caveat below. |
 | `amfs_export_training_data` | Pro (HTTP-proxied) | Calls `GET /api/v1/pro/export`. Exposed on the TS `HttpAdapter` as `exportTrainingDataAsync`; Python calls the endpoint directly. |
+| `amfs_record_span`, `amfs_start_span`, `amfs_end_span`, `amfs_set_trace_attributes`, `amfs_record_llm_call` | Pro (works locally and over HTTP) | Spans live on the Pro `ImmutableDecisionTrace`; the OSS `DecisionTrace` carries them only as `session_metadata` extras that the seal path lifts out. The Python side is the `amfs_traces.spans.SpanRecorder` in the private repo, not an `AgentMemory` method; the TS SDK has no span recorder yet. |
+| `amfs_trace_search`, `amfs_trace_spans`, `amfs_span_payload`, `amfs_trace_compare` | Pro (HTTP-proxied, local fallback) | Backed by the Pro traces API (`/api/v1/pro/traces/search`, `/{id}/spans`, `/{id}/spans/{span_id}`, `/compare`). The local fallback has no semantic search or paging and can only see traces the adapter persists plus the last one committed in-process. No SDK methods yet; call the endpoints through the `HttpAdapter`. |
 | `amfs_room_*`, `amfs_negotiate_*` | Pro (rooms backend) | Multi-agent rooms/negotiation require the Pro rooms service. The TS SDK has `room*`/`negotiate*` methods; `amfs_negotiate_cancel` has **no OSS backend endpoint**, so it's not added as an SDK method (it would be a broken stub). |
 | `amfs_verify`, `amfs_commit_batch`, `amfs_merge_base` | SDK-covered | Present in the Python SDK (`verify`, `transaction`, `common_ancestor`) and TS SDK (`verify`, `transaction`, `commonAncestor`). |
 | `amfs_export` | MCP-only | Spools full untruncated values to a **local file** on the MCP client's machine — a file-system convenience that only makes sense in-process. SDK callers already have `list`/`read` returning full values with no truncation, so there is nothing to mirror. |

--- a/docs/reference/sdk-mcp-parity.md
+++ b/docs/reference/sdk-mcp-parity.md
@@ -46,7 +46,7 @@ AMFS exposes memory three ways: the **MCP server** (for agents), the **Python SD
 | Record action | `amfs_record_action` | `record_action` | `recordAction` (tracker) |
 | Explain session | `amfs_explain` | `explain` | `explain` |
 | Timeline | `amfs_timeline` | `timeline` | `timelineAsync` |
-| List traces | `amfs_list_traces` | `list_traces` | `listTracesAsync` |
+| List traces | `amfs_list_traces` | `list_traces` (cursor / since / until) | `listTracesAsync`, `listTracesPageAsync` (`{traces, nextCursor, hasMore}`) |
 | Get trace | `amfs_get_trace` | `get_trace` | `getTraceAsync` |
 
 ### Spans & trace navigation (Pro)
@@ -67,6 +67,40 @@ These ship in the **Pro MCP server** (`amfs-mcp-server-pro`) only. The recording
 {: .note }
 The TypeScript SDK's `*Async` methods route through the `HttpAdapter` to a remote AMFS server. The synchronous methods operate on the in-process adapter. Construct `AgentMemory` with an `HttpAdapter` to use the async surface — the intended path for a Node orchestrator or a disposable sandbox pointing at hosted SenseLab.
 
+{: .note }
+**Paging traces in TypeScript.** `listTracesAsync` accepts `{ cursor, since, until, limit, offset, entityPath, agentId, outcomeType }` and still returns a flat array. `listTracesPageAsync` takes the same options and returns `{ traces, nextCursor, hasMore }`, matching the OSS server's `GET /api/v1/traces` page shape — follow `nextCursor` while `hasMore` is true. `DecisionTrace` now carries `taskInput`, `responseText`, `toolCalls[]` (with the caller's `arguments` keys left as-is) and `sessionMetadata`, mapped from the server's snake_case fields; the mappers are exported as `toDecisionTrace` / `toDecisionTracePage`.
+
+### Agent evaluation (Pro, hosted only)
+
+Judges, verdicts, behaviors, incidents, the fix loop and the investigator are **Pro, hosted-only** surfaces served by `/api/v1/eval` on SenseLab Cloud. They ship in three developer-facing forms, none of which live in the OSS SDKs:
+
+- **Pro MCP tools** (`amfs-mcp-server-pro`, `tags={"extended"}`): proxy to the hosted API when `AMFS_HTTP_URL` is set and refuse with `{"error": "...requires the hosted API (AMFS_HTTP_URL)...", "mode": "local"}` otherwise. They are excluded from the builder profile.
+- **`amfs_pro` Python client** (private dist `amfs-sdk-pro`): `ProClient(base_url=None, api_key=None)` reads `AMFS_HTTP_URL` / `AMFS_API_KEY`, sends `X-AMFS-API-Key`, and exposes `client.eval` and `client.traces`; `AsyncProClient` mirrors it on `httpx.AsyncClient`. List calls return `Page[...]` (`items`, `next_cursor`, `has_more`) and have `iter*` helpers that follow cursors.
+- **`amfs-pro` CLI** (installed with `amfs-sdk-pro`): every command takes `--json` for CI; `eval backfill` and `cases run` exit non-zero with `--fail-on-fail`.
+
+| Capability | MCP tool (Pro) | `amfs_pro` client | `amfs-pro` CLI |
+|:--|:--|:--|:--|
+| Grade one trace now | `amfs_judge_trace` | `eval.judge` | `eval judge <trace_id> <judge_id>` |
+| Define a judge (optionally dry-run first) | `amfs_judge_define` | `eval.judges.create` / `.update` / `.dry_run` / `.history` / `.diff` | `eval judges create --id --name --prompt [--dry-run]`, `eval judges dry-run <agent> <judge>` |
+| List judges | `amfs_judges` | `eval.judges.list` / `.get` / `.delete` / `.detection_rate` | `eval judges list <agent>` |
+| Install the starter pack | `amfs_seed_starter_judges` | `eval.judges.seed_starter_pack` | `eval judges seed <agent>` |
+| Browse verdicts | `amfs_verdicts` | `eval.verdicts.list` / `.iter` / `.get` / `.for_trace` | — (use `--json` on `eval judge` / `backfill`) |
+| Agent summary | `amfs_eval_summary` | `eval.summary` | `eval summary <agent> [--window]` |
+| Backfill past traces (spends budget) | `amfs_backfill` | `eval.backfill` / `eval.backfill_status` | `eval backfill <agent> <judge> [--since --until --limit --sampling-rate --wait --fail-on-fail]` |
+| Judge budget | — | `eval.budget.get` / `.set` | — |
+| Behaviors | `amfs_behaviors`, `amfs_behavior_define`, `amfs_behavior_from_trace` | `eval.behaviors.list` / `.create` / `.from_trace` / `.get` / `.update` / `.delete` / `.traces` | `behaviors list <agent>`, `behaviors from-trace <trace_id>` |
+| Blast radius of a behavior | `amfs_blast_radius` | `eval.behaviors.blast_radius` | — |
+| Incidents | `amfs_incident` (list / get / `action=acknowledge\|resolve\|mute`) | `eval.incidents.list` / `.get` / `.acknowledge` / `.resolve` / `.mute` | `incidents list [--agent --status]`, `incidents ack <id>`, `incidents mute <id> [--until]` |
+| Segment by dimension | `amfs_segment`, `amfs_dimensions` | `eval.segment`, `eval.dimensions` | — |
+| Attribute a failure to memory entries | `amfs_attribute_failure` | `eval.attribution` | — |
+| Fix loop | `amfs_propose_fix` (propose, then returns the handoff), `amfs_fixes`, `amfs_approve_fix_memory` | `eval.fixes.propose` / `.handoff` / `.list` / `.get` / `.approve_memory` / `.dismiss` / `.prevention` / `.prevention_for` | `fixes list <agent>`, `fixes propose <agent> --verdict\|--behavior`, `fixes handoff <fix_id>` (prints `instructions` markdown for piping into a coding agent) |
+| Regression cases | — | `eval.cases.sets` / `.create_set` / `.get_set` / `.cases` / `.run` (inline or queued) / `.get_run` / `.runs` / `.compare` | `cases run <set_id> --label [--since --compare-to --fail-on-fail]` |
+| Investigate a question across runs | `amfs_investigate` (non-streaming) | `eval.investigate`, `eval.investigate_stream` (SSE events) | `investigate <agent> "<question>" [--trace --max-steps --no-stream]` (streams steps) |
+| Alerts | `amfs_alerts` | `eval.alerts.list` / `.ack` / `.mute` / `.rules` | — |
+| Sealed traces | `amfs_trace_search`, `amfs_trace_spans`, `amfs_span_payload`, `amfs_trace_compare` | `traces.search` / `.iter_search` / `.get` / `.spans` / `.span` / `.compare` / `.otlp_export` | `traces search [--query --agent --since --until --has-error --outcome --limit --cursor]` |
+
+Where the Python SDK column above says "—", the same routes are reachable by any HTTP client with the `X-AMFS-API-Key` header; the `amfs_pro` client is the supported wrapper.
+
 ## Identity
 
 Agent identity in the SDKs is set via the `AgentMemory` constructor (`agent_id`). **Sticky identity** (`amfs_set_identity` / `amfs_whoami` / `amfs_reset_identity`) is an MCP-server concept: it persists the last identity to `~/.amfs/.identity-<client>` so a fresh MCP process auto-restores it. The SDKs don't own that on-disk state, so they intentionally don't expose set/whoami/reset — pass `agent_id` explicitly instead.
@@ -83,6 +117,7 @@ These MCP tools are **not** mirrored 1:1 in the SDKs, by design. They are either
 | `amfs_export_training_data` | Pro (HTTP-proxied) | Calls `GET /api/v1/pro/export`. Exposed on the TS `HttpAdapter` as `exportTrainingDataAsync`; Python calls the endpoint directly. |
 | `amfs_record_span`, `amfs_start_span`, `amfs_end_span`, `amfs_set_trace_attributes`, `amfs_record_llm_call` | Pro (works locally and over HTTP) | Spans live on the Pro `ImmutableDecisionTrace`; the OSS `DecisionTrace` carries them only as `session_metadata` extras that the seal path lifts out. The Python side is the `amfs_traces.spans.SpanRecorder` in the private repo, not an `AgentMemory` method; the TS SDK has no span recorder yet. |
 | `amfs_trace_search`, `amfs_trace_spans`, `amfs_span_payload`, `amfs_trace_compare` | Pro (HTTP-proxied, local fallback) | Backed by the Pro traces API (`/api/v1/pro/traces/search`, `/{id}/spans`, `/{id}/spans/{span_id}`, `/compare`). The local fallback has no semantic search or paging and can only see traces the adapter persists plus the last one committed in-process. No SDK methods yet; call the endpoints through the `HttpAdapter`. |
+| `amfs_judge_trace`, `amfs_judge_define`, `amfs_judges`, `amfs_seed_starter_judges`, `amfs_verdicts`, `amfs_eval_summary`, `amfs_backfill`, `amfs_behaviors`, `amfs_behavior_define`, `amfs_behavior_from_trace`, `amfs_blast_radius`, `amfs_incident`, `amfs_segment`, `amfs_dimensions`, `amfs_attribute_failure`, `amfs_propose_fix`, `amfs_fixes`, `amfs_approve_fix_memory`, `amfs_investigate`, `amfs_alerts` | Pro (HTTP-proxied, **no local mode**) | Agent evaluation runs on the hosted `/api/v1/eval` service (LLM judges, budgets, behavior mining). Without `AMFS_HTTP_URL` the tools answer `{"mode": "local"}` and do nothing. The OSS SDKs have no methods for these; use the private `amfs_pro` client or the `amfs-pro` CLI (see *Agent evaluation* above). |
 | `amfs_room_*`, `amfs_negotiate_*` | Pro (rooms backend) | Multi-agent rooms/negotiation require the Pro rooms service. The TS SDK has `room*`/`negotiate*` methods; `amfs_negotiate_cancel` has **no OSS backend endpoint**, so it's not added as an SDK method (it would be a broken stub). |
 | `amfs_verify`, `amfs_commit_batch`, `amfs_merge_base` | SDK-covered | Present in the Python SDK (`verify`, `transaction`, `common_ancestor`) and TS SDK (`verify`, `transaction`, `commonAncestor`). |
 | `amfs_export` | MCP-only | Spools full untruncated values to a **local file** on the MCP client's machine — a file-system convenience that only makes sense in-process. SDK callers already have `list`/`read` returning full values with no truncation, so there is nothing to mirror. |

--- a/docs/reference/sdk-mcp-parity.md
+++ b/docs/reference/sdk-mcp-parity.md
@@ -48,6 +48,45 @@ AMFS exposes memory three ways: the **MCP server** (for agents), the **Python SD
 | Timeline | `amfs_timeline` | `timeline` | `timelineAsync` |
 | List traces | `amfs_list_traces` | `list_traces` (cursor / since / until) | `listTracesAsync`, `listTracesPageAsync` (`{traces, nextCursor, hasMore}`) |
 | Get trace | `amfs_get_trace` | `get_trace` | `getTraceAsync` |
+| Session attributes on the trace | `amfs_set_trace_attributes` (Pro) | `set_session_attributes`, `commit_outcome(attributes=...)` | `setSessionAttributes`, `commitOutcome(..., {attributes})`, `commitOutcomeAsync(..., {attributes})` |
+| Record an LLM call by hand | `amfs_record_llm_call` (Pro) | `record_llm_call` | `recordLlmCall` |
+| Record LLM calls automatically | — | `amfs_pro.tracing.instrument_openai` / `instrument_anthropic` / `instrument_litellm` (Pro) | `instrumentOpenAI`, `instrumentAnthropic` |
+
+### Capturing runs for the Behavior section
+
+The dashboard's Behavior section shows, per run, a duration, a span tree, token counts, a cost and the attributes the run can be grouped by. None of that exists unless the SDK sends it: a trace committed by an uninstrumented agent reaches the server flat — blank duration, no spans, no attributes, and a cost it cannot know. What each figure needs:
+
+| Figure | Captured | How |
+|:--|:--|:--|
+| Session duration (`session_started_at` / `session_ended_at` / `session_duration_ms`) | **Automatically** | Every `commit_outcome` / `commitOutcomeAsync` — the session starts at the first memory operation. |
+| Memory operations as spans (reads, writes, `record_action`, `record_context`) | **Automatically inside `trace_session`** (Python, Pro) | `with trace_session(mem): ...` — the recorder mirrors the memory's own operations as `memory_read` / `memory_write` / `tool` / `context` spans under a `session` root, so even a run that records nothing else gets a real tree and duration. The Pro MCP server does the same for MCP agents. |
+| LLM calls — model, tokens, latency | **One line** | Python (Pro): `client = instrument_openai(OpenAI())` / `instrument_anthropic(Anthropic())` / `instrument_litellm()`. TypeScript: `const openai = instrumentOpenAI(new OpenAI(), memory)` / `instrumentAnthropic(client, memory)`. Sync, async and streaming calls are all recorded; an instrumentation failure never breaks the call. Any other provider: `record_llm_call(model, input_tokens, output_tokens, ...)` / `memory.recordLlmCall({...})`. |
+| Cost | **Only when LLM calls are recorded** | The Python instrumentation estimates `cost_usd` from a small price table (`AMFS_LLM_PRICE_TABLE` overrides it; LiteLLM's registry is used when `litellm` is already imported); a model it cannot price records `None`. The TypeScript SDK records tokens and leaves `cost_usd` null unless you pass `costUsd`. A run with no recorded LLM calls has an **unknown** cost, shown as a dash — never `$0.00`. |
+| Your own steps (`plan`, `pagerduty.list_incidents`, ...) | **By the developer** (Python, Pro) | `with span("plan", kind="agent"):` / `@traced("fetch", kind="tool")`; exceptions mark the span `error` and propagate. Payloads are redacted and capped at 32 000 characters (`AMFS_SPAN_PAYLOAD_MAX_CHARS`). |
+| Attributes (`customer`, `task_type`, `environment`, ...) | **By the developer** | `trace_session(mem, attributes={...})`, `mem.set_session_attributes({...})`, `mem.commit_outcome(..., attributes={...})`; TS: `memory.setSessionAttributes({...})` or `commitOutcomeAsync(..., { attributes })`. Scalars only, at most 20 keys of up to 64 characters, string values up to 256 characters; keys are lowercased. `source`, `model`, `client` and `outcome_type` are reserved and stamped by the server. |
+
+```python
+from amfs import AgentMemory
+from amfs_core.models import OutcomeType
+from amfs_pro.tracing import trace_session, span, instrument_openai
+
+client = instrument_openai(OpenAI())
+with trace_session(mem, attributes={"customer": "acme", "task_type": "deploy"}):
+    with span("plan", kind="agent"):
+        plan = client.chat.completions.create(model="gpt-4o-mini", messages=[...])
+    with span("pagerduty.list_incidents", kind="tool", input={"service": "checkout"}) as s:
+        s.set_output(incidents)
+    mem.commit_outcome("deploy-42", OutcomeType.SUCCESS, task_input="roll back checkout")
+```
+
+```ts
+const openai = instrumentOpenAI(new OpenAI(), memory);
+memory.setSessionAttributes({ customer: "acme", task_type: "deploy" });
+const r = await openai.chat.completions.create({ model: "gpt-4o-mini", messages });
+await memory.commitOutcomeAsync("deploy-42", OutcomeType.SUCCESS);
+```
+
+Everything travels in `DecisionTrace.session_metadata` — `attributes` (a flat bag), `llm_calls` (`{call_id, model, provider, input_tokens, output_tokens, cost_usd, latency_ms, started_at}`) and, from `amfs_pro.tracing`, `spans` — and the server lifts those keys onto the sealed trace. OSS keeps only the generic parts: the two `AgentMemory` methods, the `attributes` argument, and the TypeScript instrumentation; cost estimation, span trees and the Python instrumentation are `amfs-sdk-pro`. Inspect the result with `amfs-pro traces show <trace_id>` or `amfs-pro traces search --agent X --attr customer=acme`.
 
 ### Spans & trace navigation (Pro)
 
@@ -55,12 +94,13 @@ These ship in the **Pro MCP server** (`amfs-mcp-server-pro`) only. The recording
 
 | Capability | MCP tool (Pro) | Python SDK | TypeScript SDK |
 |:--|:--|:--|:--|
-| Record a completed span | `amfs_record_span` | `SpanRecorder.record_span` (`amfs_traces`) | — |
-| Open / close a span | `amfs_start_span` / `amfs_end_span` | `SpanRecorder.start_span` / `end_span`, `with recorder.span(...)` | — |
-| Trace attribute bag | `amfs_set_trace_attributes` | `SpanRecorder.set_attributes` | — |
-| Record an LLM call (also emits an `llm` span) | `amfs_record_llm_call` | `SpanRecorder.record_llm_call` | — |
-| Search traces by content, attributes, span name/kind, errors | `amfs_trace_search` | — (HTTP `POST /api/v1/pro/traces/search`) | — |
-| Span tree with text outline | `amfs_trace_spans` | — (HTTP `GET /api/v1/pro/traces/{id}/spans`) | — |
+| Trace one run (root `session` span, memory ops mirrored as child spans) | — (the Pro MCP server does this per session) | `amfs_pro.tracing.trace_session(mem, attributes=...)` | — |
+| Record a completed span | `amfs_record_span` | `SessionRecorder.record_span` (`amfs_pro.tracing`), `SpanRecorder.record_span` (`amfs_traces`) | — |
+| Open / close a span | `amfs_start_span` / `amfs_end_span` | `with span("plan", kind="agent")`, `@traced(name, kind)` (`amfs_pro.tracing`); `SpanRecorder.start_span` / `end_span` | — |
+| Trace attribute bag | `amfs_set_trace_attributes` | `trace_session(..., attributes=)`, `session.set_attributes`; OSS `set_session_attributes` | `setSessionAttributes` (OSS) |
+| Record an LLM call (also emits an `llm` span) | `amfs_record_llm_call` | `amfs_pro.tracing.record_llm_call`, `instrument_openai` / `instrument_anthropic` / `instrument_litellm`; OSS `record_llm_call` (no span) | `recordLlmCall`, `instrumentOpenAI` / `instrumentAnthropic` (OSS, no span) |
+| Search traces by content, attributes, span name/kind, errors | `amfs_trace_search` | `ProClient.traces.search(attributes=..., span_kind=...)`; CLI `amfs-pro traces search --agent X --attr customer=acme` | — |
+| Span tree with text outline | `amfs_trace_spans` | `ProClient.traces.spans`; CLI `amfs-pro traces show <trace_id>` | — |
 | One span's input/output payloads | `amfs_span_payload` | — (HTTP `GET /api/v1/pro/traces/{id}/spans/{span_id}`) | — |
 | Compare two traces span by span | `amfs_trace_compare` | — (HTTP `POST /api/v1/pro/traces/compare`) | — |
 
@@ -97,7 +137,7 @@ Judges, verdicts, behaviors, incidents, the fix loop and the investigator are **
 | Regression cases | — | `eval.cases.sets` / `.create_set` / `.get_set` / `.cases` / `.run` (inline or queued) / `.get_run` / `.runs` / `.compare` | `cases run <set_id> --label [--since --compare-to --fail-on-fail]` |
 | Investigate a question across runs | `amfs_investigate` (non-streaming) | `eval.investigate`, `eval.investigate_stream` (SSE events) | `investigate <agent> "<question>" [--trace --max-steps --no-stream]` (streams steps) |
 | Alerts | `amfs_alerts` | `eval.alerts.list` / `.ack` / `.mute` / `.rules` | — |
-| Sealed traces | `amfs_trace_search`, `amfs_trace_spans`, `amfs_span_payload`, `amfs_trace_compare` | `traces.search` / `.iter_search` / `.get` / `.spans` / `.span` / `.compare` / `.otlp_export` | `traces search [--query --agent --since --until --has-error --outcome --limit --cursor]` |
+| Sealed traces | `amfs_trace_search`, `amfs_trace_spans`, `amfs_span_payload`, `amfs_trace_compare` | `traces.search` / `.iter_search` / `.get` / `.spans` / `.span` / `.compare` / `.otlp_export` | `traces search [--query --agent --attr key=value --span-name --span-kind --since --until --has-error --outcome --limit --cursor]`, `traces show <trace_id>` (span tree with durations, tokens, cost, attributes; unknown cost and duration print as `—`) |
 
 Where the Python SDK column above says "—", the same routes are reachable by any HTTP client with the `X-AMFS-API-Key` header; the `amfs_pro` client is the supported wrapper.
 
@@ -115,7 +155,7 @@ These MCP tools are **not** mirrored 1:1 in the SDKs, by design. They are either
 |:--|:--|:--|
 | `amfs_consolidate`, `amfs_consolidation_status/proposals/candidates` | Pro (HTTP-proxied) | Backed by the Cortex consolidation API, not the OSS adapter ABC. The TypeScript `HttpAdapter` exposes `consolidation*Async` passthroughs; the Python SDK reaches them via the HTTP API directly. See the caveat below. |
 | `amfs_export_training_data` | Pro (HTTP-proxied) | Calls `GET /api/v1/pro/export`. Exposed on the TS `HttpAdapter` as `exportTrainingDataAsync`; Python calls the endpoint directly. |
-| `amfs_record_span`, `amfs_start_span`, `amfs_end_span`, `amfs_set_trace_attributes`, `amfs_record_llm_call` | Pro (works locally and over HTTP) | Spans live on the Pro `ImmutableDecisionTrace`; the OSS `DecisionTrace` carries them only as `session_metadata` extras that the seal path lifts out. The Python side is the `amfs_traces.spans.SpanRecorder` in the private repo, not an `AgentMemory` method; the TS SDK has no span recorder yet. |
+| `amfs_record_span`, `amfs_start_span`, `amfs_end_span`, `amfs_set_trace_attributes`, `amfs_record_llm_call` | Pro (works locally and over HTTP) | Spans live on the Pro `ImmutableDecisionTrace`; the OSS `DecisionTrace` carries them only as `session_metadata` extras that the seal path lifts out. The Python side is `amfs_pro.tracing` (`trace_session`, `span`, `traced`, `record_llm_call`, `instrument_*`) in the private `amfs-sdk-pro` dist; OSS `AgentMemory` has only the generic `set_session_attributes` / `record_llm_call` / `commit_outcome(attributes=...)`. The TS SDK has `setSessionAttributes`, `recordLlmCall` and `instrumentOpenAI` / `instrumentAnthropic` but no span recorder. |
 | `amfs_trace_search`, `amfs_trace_spans`, `amfs_span_payload`, `amfs_trace_compare` | Pro (HTTP-proxied, local fallback) | Backed by the Pro traces API (`/api/v1/pro/traces/search`, `/{id}/spans`, `/{id}/spans/{span_id}`, `/compare`). The local fallback has no semantic search or paging and can only see traces the adapter persists plus the last one committed in-process. No SDK methods yet; call the endpoints through the `HttpAdapter`. |
 | `amfs_judge_trace`, `amfs_judge_define`, `amfs_judges`, `amfs_seed_starter_judges`, `amfs_verdicts`, `amfs_eval_summary`, `amfs_backfill`, `amfs_behaviors`, `amfs_behavior_define`, `amfs_behavior_from_trace`, `amfs_blast_radius`, `amfs_incident`, `amfs_segment`, `amfs_dimensions`, `amfs_attribute_failure`, `amfs_propose_fix`, `amfs_fixes`, `amfs_approve_fix_memory`, `amfs_investigate`, `amfs_alerts` | Pro (HTTP-proxied, **no local mode**) | Agent evaluation runs on the hosted `/api/v1/eval` service (LLM judges, budgets, behavior mining). Without `AMFS_HTTP_URL` the tools answer `{"mode": "local"}` and do nothing. The OSS SDKs have no methods for these; use the private `amfs_pro` client or the `amfs-pro` CLI (see *Agent evaluation* above). |
 | `amfs_room_*`, `amfs_negotiate_*` | Pro (rooms backend) | Multi-agent rooms/negotiation require the Pro rooms service. The TS SDK has `room*`/`negotiate*` methods; `amfs_negotiate_cancel` has **no OSS backend endpoint**, so it's not added as an SDK method (it would be a broken stub). |

--- a/packages/adapters/filesystem/src/amfs_filesystem/adapter.py
+++ b/packages/adapters/filesystem/src/amfs_filesystem/adapter.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import heapq
 import json
 import os
 import logging
+from collections.abc import Iterator
+from datetime import datetime, timezone, UTC
 from pathlib import Path
 from typing import Callable
 
@@ -237,6 +240,71 @@ class FilesystemAdapter(AdapterABC):
                     except Exception:
                         logger.warning("Skipping unreadable file: %s", f)
         return entries
+
+    def _iter_current_entries(self) -> Iterator[MemoryEntry]:
+        """Yield current entries one file at a time, never holding them all."""
+        layout = self._layout
+        for ep in layout.all_entity_paths():
+            for key in layout.all_keys(ep):
+                for f in layout.all_version_files(ep, key, include_superseded=False):
+                    try:
+                        yield self._read_entry(f)
+                    except Exception:
+                        logger.warning("Skipping unreadable file: %s", f)
+
+    def list_entries_for_agent(
+        self,
+        agent_id: str,
+        *,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        cursor: str | None = None,
+        limit: int = 100,
+        exclude_prefixes: tuple[str, ...] = ("_system/",),
+    ) -> list[MemoryEntry]:
+        """Stream the store once and keep only the ``limit`` newest matches.
+
+        The base implementation materialises ``list()`` first; here a bounded
+        heap holds at most *limit* entries at any point, so the memory cost
+        is the page, not the store. Ordering and the cursor tiebreak match
+        the base implementation exactly.
+        """
+        from amfs_core.pagination import decode_cursor, entry_tiebreak
+
+        limit = max(1, int(limit))
+        cursor_key: tuple[datetime, str] | None = None
+        if cursor:
+            ts, tiebreak = decode_cursor(cursor)
+            cursor_key = (ts, json.dumps(tiebreak, default=str, sort_keys=True))
+
+        def sort_key(e: MemoryEntry) -> tuple[datetime, str]:
+            ts = e.provenance.written_at
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=UTC)
+            return ts, json.dumps(entry_tiebreak(e), default=str, sort_keys=True)
+
+        heap: list[tuple[tuple[datetime, str], int, MemoryEntry]] = []
+        seq = 0
+        for e in self._iter_current_entries():
+            if e.provenance.agent_id != agent_id:
+                continue
+            if any(e.entity_path.startswith(p) for p in exclude_prefixes):
+                continue
+            written = e.provenance.written_at
+            if since is not None and written < since:
+                continue
+            if until is not None and written >= until:
+                continue
+            key = sort_key(e)
+            if cursor_key is not None and key >= cursor_key:
+                continue
+            seq += 1
+            if len(heap) < limit:
+                heapq.heappush(heap, (key, seq, e))
+            elif key > heap[0][0]:
+                heapq.heapreplace(heap, (key, seq, e))
+
+        return [e for _, _, e in sorted(heap, key=lambda h: h[0], reverse=True)]
 
     # ------------------------------------------------------------------
     # watch

--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -406,17 +406,16 @@ class HttpAdapter(AdapterABC):
             params["cursor"] = cursor
         elif offset:
             params["offset"] = offset
-        # since/until are not query parameters on the server; applied here
-        # so the contract matches the other adapters.
+        # The window is applied by the server's query, not to the page after
+        # the fact: filtering a page here would empty it whenever the window
+        # excludes the newest traces, and the cursor walk in _iter_traces
+        # stops on an empty page — so older matches would never be reached.
+        if since is not None:
+            params["since"] = since.isoformat()
+        if until is not None:
+            params["until"] = until.isoformat()
         data = self._get("/api/v1/traces", **params)
         traces = [DecisionTrace.model_validate(t) for t in data.get("traces", [])]
-        if since is not None or until is not None:
-            traces = [
-                t
-                for t in traces
-                if (since is None or t.created_at >= since)
-                and (until is None or t.created_at < until)
-            ]
         return traces, data.get("next_cursor"), bool(data.get("has_more", False))
 
     def _iter_traces(self, *, max_rows: int, **filters: Any) -> list[DecisionTrace]:

--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -345,12 +345,15 @@ class HttpAdapter(AdapterABC):
         entity_path: str | None = None,
         since: datetime | None = None,
         limit: int = 1000,
+        outcome_ref: str | None = None,
     ) -> list[OutcomeRecord]:
         params: dict[str, Any] = {"limit": limit}
         if entity_path:
             params["entity_path"] = entity_path
         if since:
             params["since"] = since.isoformat()
+        if outcome_ref:
+            params["outcome_ref"] = outcome_ref
         data = self._get("/api/v1/outcomes", **params)
         return [OutcomeRecord.model_validate(o) for o in data.get("outcomes", [])]
 
@@ -361,15 +364,105 @@ class HttpAdapter(AdapterABC):
         agent_id: str | None = None,
         outcome_type: str | None = None,
         limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
     ) -> list[DecisionTrace]:
-        data = self._get(
-            "/api/v1/traces",
+        """One page of traces. The server caps a page at 1,000 rows; callers
+        that need more than that follow cursors (see :meth:`_iter_traces`)."""
+        data = self.list_traces_page(
             entity_path=entity_path,
             agent_id=agent_id,
             outcome_type=outcome_type,
             limit=limit,
+            offset=offset,
+            cursor=cursor,
+            since=since,
+            until=until,
         )
-        return [DecisionTrace.model_validate(t) for t in data.get("traces", [])]
+        return data[0]
+
+    def list_traces_page(
+        self,
+        *,
+        entity_path: str | None = None,
+        agent_id: str | None = None,
+        outcome_type: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> tuple[list[DecisionTrace], str | None, bool]:
+        """``(traces, next_cursor, has_more)`` straight from the server's page."""
+        params: dict[str, Any] = {
+            "entity_path": entity_path,
+            "agent_id": agent_id,
+            "outcome_type": outcome_type,
+            "limit": limit,
+        }
+        if cursor:
+            params["cursor"] = cursor
+        elif offset:
+            params["offset"] = offset
+        # since/until are not query parameters on the server; applied here
+        # so the contract matches the other adapters.
+        data = self._get("/api/v1/traces", **params)
+        traces = [DecisionTrace.model_validate(t) for t in data.get("traces", [])]
+        if since is not None or until is not None:
+            traces = [
+                t
+                for t in traces
+                if (since is None or t.created_at >= since)
+                and (until is None or t.created_at < until)
+            ]
+        return traces, data.get("next_cursor"), bool(data.get("has_more", False))
+
+    def _iter_traces(self, *, max_rows: int, **filters: Any) -> list[DecisionTrace]:
+        """Follow cursors until *max_rows* traces have been read or the list ends."""
+        out: list[DecisionTrace] = []
+        cursor: str | None = None
+        while len(out) < max_rows:
+            page, cursor, has_more = self.list_traces_page(
+                limit=min(1000, max_rows - len(out)), cursor=cursor, **filters
+            )
+            out.extend(page)
+            if not has_more or not cursor or not page:
+                break
+        return out
+
+    def count_traces(
+        self,
+        *,
+        entity_path: str | None = None,
+        agent_id: str | None = None,
+        outcome_type: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> int:
+        from amfs_core.pagination import max_scan_rows
+
+        return len(
+            self._iter_traces(
+                max_rows=max_scan_rows(),
+                entity_path=entity_path,
+                agent_id=agent_id,
+                outcome_type=outcome_type,
+                since=since,
+                until=until,
+            )
+        )
+
+    def trace_read_counts(self, agent_id: str) -> dict[str, dict[str, int]]:
+        from amfs_core.pagination import max_scan_rows
+
+        counts: dict[str, dict[str, int]] = {}
+        for t in self._iter_traces(max_rows=max_scan_rows(), agent_id=agent_id):
+            for ce in t.causal_entries:
+                per_entity = counts.setdefault(ce.entity_path, {})
+                per_entity[ce.key] = per_entity.get(ce.key, 0) + 1
+        return counts
 
     def save_trace(self, trace: DecisionTrace) -> DecisionTrace:
         data = self._post("/api/v1/traces", trace.model_dump(mode="json"))
@@ -559,6 +652,9 @@ class HttpAdapter(AdapterABC):
         event_type: str | None = None,
         since: datetime | None = None,
         limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        until: datetime | None = None,
     ) -> list[Event]:
         params: dict[str, Any] = {"limit": limit}
         if branch:
@@ -567,8 +663,18 @@ class HttpAdapter(AdapterABC):
             params["event_type"] = event_type
         if since:
             params["since"] = since.isoformat()
+        if until:
+            params["until"] = until.isoformat()
+        if cursor:
+            params["cursor"] = cursor
+        elif offset:
+            params["offset"] = offset
         data = self._get(f"/api/v1/agents/{agent_id}/timeline", **params)
-        return [Event.model_validate(e) for e in data.get("events", [])]
+        events = [Event.model_validate(e) for e in data.get("events", [])]
+        if until is not None:
+            # Older servers ignore the parameter; keep the bound exact locally.
+            events = [e for e in events if e.created_at < until]
+        return events
 
     def upsert_graph_edge(
         self,

--- a/packages/adapters/http/src/amfs_adapter_http/adapter.py
+++ b/packages/adapters/http/src/amfs_adapter_http/adapter.py
@@ -213,6 +213,12 @@ class HttpAdapter(AdapterABC):
             body["response_text"] = record.response_text
         if record.tool_calls:
             body["tool_calls"] = record.tool_calls
+        # Same story for the session's attribute bag and LLM calls: the server
+        # reads ``session_metadata.attributes`` / ``.llm_calls`` from this body
+        # when it seals, so a bag sent only with the trace never reached the
+        # sealed copy.
+        if record.session_metadata:
+            body["session_metadata"] = record.session_metadata
         data = self._post("/api/v1/outcomes", body)
         return [_parse_entry(e) for e in data.get("entries", [])]
 

--- a/packages/adapters/postgres/src/amfs_postgres/adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/adapter.py
@@ -252,9 +252,14 @@ def _tables_created_by(sql: str) -> frozenset[str]:
     bootstrap runs is covered without anyone remembering to update a second
     place — which is the kind of upkeep that silently stops happening.
     """
+    # Partitions (``CREATE TABLE x PARTITION OF parent``) are excluded: they
+    # exist only once the parent is partitioned, which on a database where the
+    # partitioning migration was deliberately skipped is never, and a table
+    # that can never be present would make the schema never "current" and
+    # re-run the DDL on every start — the convoy this check exists to stop.
     return frozenset(
         re.findall(
-            r"CREATE TABLE IF NOT EXISTS\s+([A-Za-z_][A-Za-z0-9_]*)",
+            r"CREATE TABLE IF NOT EXISTS\s+([A-Za-z_][A-Za-z0-9_]*)\b(?!\s+PARTITION\s+OF\b)",
             sql,
             re.IGNORECASE,
         )
@@ -478,6 +483,13 @@ class PostgresAdapter(AdapterABC):
         self._pool = _TenantRLSPoolWrapper(self._pool)
         if auto_schema:
             self._apply_schema()
+            # Every start, not only when the schema changes: the partitions
+            # that need to exist move forward one month at a time and the
+            # schema marker does not. One catalog query on a warm database.
+            try:
+                self.ensure_trace_partitions()
+            except Exception:  # noqa: BLE001
+                logger.warning("trace partitioning: partition upkeep skipped", exc_info=True)
         self._detect_optional_columns()
         self._listen_thread: threading.Thread | None = None
         self._listen_stop = threading.Event()
@@ -551,7 +563,13 @@ class PostgresAdapter(AdapterABC):
         try:
             import inspect
 
-            return inspect.getsource(type(self)._apply_migrations)
+            from amfs_postgres import trace_partitions
+
+            # The partitioning and retention DDL lives in its own module, and a
+            # change there is a schema change just as much as one in here.
+            return inspect.getsource(type(self)._apply_migrations) + inspect.getsource(
+                trace_partitions
+            )
         except Exception:  # noqa: BLE001
             return None
 
@@ -634,8 +652,11 @@ class PostgresAdapter(AdapterABC):
                         cur.execute("SET lock_timeout = '5s'")
                         try:
                             cur.execute(_SCHEMA_SQL)
-                            self._apply_migrations(cur)
-                            if fingerprint:
+                            complete = self._apply_migrations(cur)
+                            # A migration that failed for a transient reason
+                            # reports False so the marker is withheld and the
+                            # next start tries again; everything else is done.
+                            if fingerprint and complete is not False:
                                 self._record_schema_fingerprint(cur, fingerprint)
                         finally:
                             cur.execute("SET lock_timeout = DEFAULT")
@@ -686,7 +707,7 @@ class PostgresAdapter(AdapterABC):
                         SELECT count(*) AS present
                         FROM pg_catalog.pg_class c
                         JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-                        WHERE c.relkind = 'r'
+                        WHERE c.relkind IN ('r', 'p')
                           AND n.nspname = ANY (current_schemas(false))
                           AND c.relname = ANY (%s)
                         """,
@@ -745,8 +766,14 @@ class PostgresAdapter(AdapterABC):
         )
 
     @staticmethod
-    def _apply_migrations(cur: psycopg.Cursor) -> None:
-        """Additive migrations for columns added after initial schema."""
+    def _apply_migrations(cur: psycopg.Cursor) -> bool:
+        """Additive migrations for columns added after initial schema.
+
+        Returns False when a migration could not be applied for a reason that
+        may clear on its own, so ``_apply_schema`` withholds the schema marker
+        and the next start retries. True (or None, from older code paths)
+        means the database is at this build's schema.
+        """
         cur.execute("""
             ALTER TABLE amfs_memory_entries
             ADD COLUMN IF NOT EXISTS shared BOOLEAN NOT NULL DEFAULT TRUE
@@ -1209,6 +1236,14 @@ class PostgresAdapter(AdapterABC):
             ON amfs_memory_entries (namespace, branch, entity_path, key)
             WHERE superseded_at IS NULL
         """)
+        # The per-agent activity listing: current entries by one agent, newest
+        # first, keyset-paged on written_at. Without this it is a scan of every
+        # current entry in the namespace filtered by agent afterwards.
+        cur.execute("""
+            CREATE INDEX IF NOT EXISTS idx_entries_agent_written
+            ON amfs_memory_entries (namespace, agent_id, written_at DESC)
+            WHERE superseded_at IS NULL
+        """)
 
         cur.execute("""
             ALTER TABLE amfs_api_keys
@@ -1258,6 +1293,91 @@ class PostgresAdapter(AdapterABC):
                 PRIMARY KEY (account_id, cluster_id)
             )
         """)
+
+        # Decision traces at volume: monthly range partitioning by created_at,
+        # then the GIN index the entity_path filter needs. The partitioning
+        # step is a one-time table rebuild inside its own transaction (see
+        # trace_partitions.migrate_to_partitioned for the approach and its
+        # rollback). It comes after every ALTER above so the parent is built
+        # from a table that already has every column; the index comes after
+        # the partitioning so it is created once, on the parent, rather than
+        # on a table about to be rebuilt.
+        from amfs_postgres import trace_partitions
+
+        complete = True
+        try:
+            trace_partitions.migrate_to_partitioned(cur)
+        except Exception:  # noqa: BLE001
+            # Already rolled back and logged. Not re-raised: a failed rebuild
+            # must not stop the process booting, since the flat table still
+            # works. Reported as incomplete so the next start tries again.
+            complete = False
+        trace_partitions.create_causal_entries_index(cur)
+        try:
+            trace_partitions.ensure_partitions(cur)
+        except Exception:  # noqa: BLE001
+            logger.warning("trace partitioning: could not create partitions ahead", exc_info=True)
+        return complete
+
+    # ------------------------------------------------------------------
+    # decision-trace partition upkeep and retention
+    # ------------------------------------------------------------------
+
+    def ensure_trace_partitions(self, months_ahead: int = 2) -> list[str]:
+        """Create trace partitions for this month and *months_ahead* more.
+
+        Runs at adapter start and is safe to call any time: it reads the
+        catalog and creates only what is missing, so on a warm database it is
+        one query and no DDL. Returns the partition names it created. A no-op
+        when the table is not partitioned.
+        """
+        from amfs_postgres import trace_partitions
+
+        with self._maintenance_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SET lock_timeout = '5s'")
+                try:
+                    return trace_partitions.ensure_partitions(cur, months_ahead=months_ahead)
+                finally:
+                    cur.execute("SET lock_timeout = DEFAULT")
+
+    def apply_trace_retention(
+        self,
+        *,
+        hot_days: int = 30,
+        strip_payloads: bool = True,
+        drop_after_days: int | None = None,
+    ) -> dict[str, Any]:
+        """Age decision traces out of the hot tier; see ``trace_partitions.apply_retention``.
+
+        Payload stripping is scoped to this adapter's namespace and keeps every
+        trace, its causal entries, contexts and metadata; only ``task_input``,
+        ``response_text``, ``tool_calls``, ``query_events`` and ``error_events``
+        are cleared for traces older than *hot_days*. *drop_after_days*, when
+        set, drops whole monthly partitions older than that — across every
+        namespace, since a partition is a month, not a tenant — so it is off
+        by default. Nothing schedules this; call it from a job or the
+        ``python -m amfs_postgres.retention`` entry point.
+
+        Runs on the maintenance checkout, which carries no tenant, so on a
+        deployment that scopes traces with row-level security it runs as the
+        table owner or not at all.
+        """
+        from amfs_postgres import trace_partitions
+
+        with self._maintenance_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SET lock_timeout = '5s'")
+                try:
+                    return trace_partitions.apply_retention(
+                        cur,
+                        namespace=self._namespace,
+                        hot_days=hot_days,
+                        strip_payloads=strip_payloads,
+                        drop_after_days=drop_after_days,
+                    )
+                finally:
+                    cur.execute("SET lock_timeout = DEFAULT")
 
     def _detect_optional_columns(self) -> None:
         """Check whether optional columns (embedding, search_tsv) exist.
@@ -2772,13 +2892,13 @@ class PostgresAdapter(AdapterABC):
     # list_outcomes
     # ------------------------------------------------------------------
 
-    def list_outcomes(
+    def _outcome_conditions(
         self,
         *,
-        entity_path: str | None = None,
-        since: datetime | None = None,
-        limit: int = 1000,
-    ) -> list[OutcomeRecord]:
+        entity_path: str | None,
+        since: datetime | None,
+        outcome_ref: str | None = None,
+    ) -> tuple[str, list[Any]]:
         conditions = ["namespace = %s"]
         params: list[Any] = [self._namespace]
 
@@ -2792,7 +2912,37 @@ class PostgresAdapter(AdapterABC):
             conditions.append("committed_at >= %s")
             params.append(since)
 
-        where = " AND ".join(conditions)
+        if outcome_ref is not None:
+            conditions.append("outcome_ref = %s")
+            params.append(outcome_ref)
+
+        return " AND ".join(conditions), params
+
+    def count_outcomes(
+        self,
+        *,
+        entity_path: str | None = None,
+        since: datetime | None = None,
+    ) -> int:
+        """``COUNT(*)`` over outcomes, so the number is right past any page cap."""
+        where, params = self._outcome_conditions(entity_path=entity_path, since=since)
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(f"SELECT count(*) AS cnt FROM amfs_outcomes WHERE {where}", params)
+                row = cur.fetchone()
+        return int(row["cnt"]) if row else 0
+
+    def list_outcomes(
+        self,
+        *,
+        entity_path: str | None = None,
+        since: datetime | None = None,
+        limit: int = 1000,
+        outcome_ref: str | None = None,
+    ) -> list[OutcomeRecord]:
+        where, params = self._outcome_conditions(
+            entity_path=entity_path, since=since, outcome_ref=outcome_ref
+        )
         sql = f"""
             SELECT outcome_ref, outcome_type, causal_confidence,
                    committed_at, causal_entry_keys, agent_id
@@ -2906,6 +3056,69 @@ class PostgresAdapter(AdapterABC):
                 row = cur.fetchone()
         return trace.model_copy(update={"id": str(row["id"]), "created_at": row["created_at"]})
 
+    @staticmethod
+    def _trace_conditions(
+        namespace: str,
+        *,
+        entity_path: str | None = None,
+        agent_id: str | None = None,
+        outcome_type: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        cursor: str | None = None,
+    ) -> tuple[str, list[Any]]:
+        """WHERE clause shared by the trace list and count queries.
+
+        Shared between the sync and async adapters, which is why it is static:
+        the two must agree on what a page contains or a cursor issued by one
+        would mean something else to the other.
+        """
+        conditions = ["namespace = %s"]
+        params: list[Any] = [namespace]
+
+        if entity_path is not None:
+            # Containment rather than ``jsonb_array_elements``: ``@>`` is what
+            # the jsonb_path_ops GIN index on causal_entries can serve, and it
+            # asks the same question — is there an element whose entity_path
+            # is this string.
+            conditions.append("causal_entries @> %s::jsonb")
+            params.append(json.dumps([{"entity_path": entity_path}]))
+        if agent_id is not None:
+            conditions.append("agent_id = %s")
+            params.append(agent_id)
+        if outcome_type is not None:
+            conditions.append("outcome_type = %s")
+            params.append(outcome_type)
+        if since is not None:
+            conditions.append("created_at >= %s")
+            params.append(since)
+        if until is not None:
+            conditions.append("created_at < %s")
+            params.append(until)
+        if cursor:
+            from amfs_core.pagination import decode_cursor
+
+            cursor_ts, cursor_id = decode_cursor(cursor)
+            # The row comparison is the keyset step; the plain ``created_at <=``
+            # beside it is redundant for correctness but is a single-column
+            # predicate the planner can use to prune partitions, which the
+            # row comparison is not.
+            conditions.append("created_at <= %s")
+            params.append(cursor_ts)
+            conditions.append("(created_at, id) < (%s, %s::uuid)")
+            params.extend([cursor_ts, str(cursor_id)])
+
+        return " AND ".join(conditions), params
+
+    _TRACE_COLUMNS = """
+        id, agent_id, session_id, outcome_ref, outcome_type,
+        decision_summary, task_input, response_text, tool_calls,
+        causal_entries, external_contexts,
+        query_events, session_started_at, session_ended_at,
+        session_duration_ms,
+        error_events, state_diff, session_metadata, created_at
+    """
+
     def list_traces(
         self,
         *,
@@ -2913,37 +3126,31 @@ class PostgresAdapter(AdapterABC):
         agent_id: str | None = None,
         outcome_type: str | None = None,
         limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
     ) -> list[DecisionTrace]:
-        conditions = ["namespace = %s"]
-        params: list[Any] = [self._namespace]
-
-        if entity_path is not None:
-            conditions.append(
-                "EXISTS (SELECT 1 FROM jsonb_array_elements(causal_entries) AS ce "
-                "WHERE ce->>'entity_path' = %s)"
-            )
-            params.append(entity_path)
-        if agent_id is not None:
-            conditions.append("agent_id = %s")
-            params.append(agent_id)
-        if outcome_type is not None:
-            conditions.append("outcome_type = %s")
-            params.append(outcome_type)
-
-        where = " AND ".join(conditions)
+        where, params = self._trace_conditions(
+            self._namespace,
+            entity_path=entity_path,
+            agent_id=agent_id,
+            outcome_type=outcome_type,
+            since=since,
+            until=until,
+            cursor=cursor,
+        )
         sql = f"""
-            SELECT id, agent_id, session_id, outcome_ref, outcome_type,
-                   decision_summary, task_input, response_text, tool_calls,
-                   causal_entries, external_contexts,
-                   query_events, session_started_at, session_ended_at,
-                   session_duration_ms,
-                   error_events, state_diff, session_metadata, created_at
+            SELECT {self._TRACE_COLUMNS}
             FROM amfs_decision_traces
             WHERE {where}
-            ORDER BY created_at DESC
+            ORDER BY created_at DESC, id DESC
             LIMIT %s
         """
         params.append(limit)
+        if not cursor and offset > 0:
+            sql += " OFFSET %s"
+            params.append(offset)
 
         with self._pool.connection() as conn:
             with conn.cursor() as cur:
@@ -2951,6 +3158,132 @@ class PostgresAdapter(AdapterABC):
                 rows = cur.fetchall()
 
         return [self._row_to_trace(row) for row in rows]
+
+    def count_traces(
+        self,
+        *,
+        entity_path: str | None = None,
+        agent_id: str | None = None,
+        outcome_type: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> int:
+        where, params = self._trace_conditions(
+            self._namespace,
+            entity_path=entity_path,
+            agent_id=agent_id,
+            outcome_type=outcome_type,
+            since=since,
+            until=until,
+        )
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"SELECT count(*) AS cnt FROM amfs_decision_traces WHERE {where}", params
+                )
+                row = cur.fetchone()
+        return int(row["cnt"]) if row else 0
+
+    _TRACE_READ_COUNTS_SQL = """
+        SELECT ce->>'entity_path' AS entity_path, ce->>'key' AS key, COUNT(*) AS cnt
+        FROM amfs_decision_traces t
+        CROSS JOIN LATERAL jsonb_array_elements(t.causal_entries) AS ce
+        WHERE t.namespace = %s AND t.agent_id = %s
+        GROUP BY ce->>'entity_path', ce->>'key'
+    """
+
+    @staticmethod
+    def _read_counts_from_rows(rows: list[dict[str, Any]]) -> dict[str, dict[str, int]]:
+        counts: dict[str, dict[str, int]] = {}
+        for r in rows:
+            ep, key = r["entity_path"], r["key"]
+            if ep is None or key is None:
+                continue
+            counts.setdefault(ep, {})[key] = int(r["cnt"])
+        return counts
+
+    def trace_read_counts(self, agent_id: str) -> dict[str, dict[str, int]]:
+        """Per-entry read counts across an agent's traces, aggregated in SQL."""
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(self._TRACE_READ_COUNTS_SQL, (self._namespace, agent_id))
+                rows = cur.fetchall()
+        return self._read_counts_from_rows(rows)
+
+    _ENTRIES_FOR_AGENT_ORDER = "ORDER BY written_at DESC, entity_path DESC, key DESC, version DESC"
+
+    @staticmethod
+    def _entries_for_agent_conditions(
+        namespace: str,
+        agent_id: str,
+        *,
+        since: datetime | None,
+        until: datetime | None,
+        cursor: str | None,
+        exclude_prefixes: tuple[str, ...],
+    ) -> tuple[str, list[Any]]:
+        conditions = [
+            "namespace = %s",
+            "agent_id = %s",
+            "superseded_at IS NULL",
+            "branch = 'main'",
+        ]
+        params: list[Any] = [namespace, agent_id]
+        for prefix in exclude_prefixes:
+            conditions.append("entity_path NOT LIKE %s")
+            params.append(prefix.replace("%", r"\%").replace("_", r"\_") + "%")
+        if since is not None:
+            conditions.append("written_at >= %s")
+            params.append(since)
+        if until is not None:
+            conditions.append("written_at < %s")
+            params.append(until)
+        if cursor:
+            from amfs_core.pagination import decode_cursor
+
+            cursor_ts, tiebreak = decode_cursor(cursor)
+            try:
+                ep, key, version = tiebreak
+            except (TypeError, ValueError) as exc:
+                from amfs_core.pagination import InvalidCursorError
+
+                raise InvalidCursorError("cursor does not belong to this listing") from exc
+            conditions.append(
+                "(written_at, entity_path, key, version) < (%s, %s, %s, %s)"
+            )
+            params.extend([cursor_ts, ep, key, int(version)])
+        return " AND ".join(conditions), params
+
+    def list_entries_for_agent(
+        self,
+        agent_id: str,
+        *,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        cursor: str | None = None,
+        limit: int = 100,
+        exclude_prefixes: tuple[str, ...] = ("_system/",),
+    ) -> list[MemoryEntry]:
+        where, params = self._entries_for_agent_conditions(
+            self._namespace,
+            agent_id,
+            since=since,
+            until=until,
+            cursor=cursor,
+            exclude_prefixes=exclude_prefixes,
+        )
+        sql = f"""
+            SELECT * FROM amfs_memory_entries
+            WHERE {where}
+            {self._ENTRIES_FOR_AGENT_ORDER}
+            LIMIT %s
+        """
+        params.append(limit)
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+                rows = cur.fetchall()
+        return [self._row_to_entry(r) for r in rows]
 
     def list_traces_for_entry(
         self,
@@ -4074,15 +4407,59 @@ class PostgresAdapter(AdapterABC):
         event_type: str | None = None,
         since: datetime | None = None,
         limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        until: datetime | None = None,
     ) -> list[Event]:
+        where, params = self._event_conditions(
+            namespace,
+            agent_id,
+            account_id=self._get_current_account_id(),
+            branch=branch,
+            event_type=event_type,
+            since=since,
+            until=until,
+            cursor=cursor,
+        )
+        sql = f"""
+            SELECT id, namespace, agent_id, branch, event_type,
+                   summary, details, actor_agent_id, created_at
+            FROM amfs_events
+            WHERE {where}
+            ORDER BY created_at DESC, id DESC
+            LIMIT %s
+        """
+        params.append(limit)
+        if not cursor and offset > 0:
+            sql += " OFFSET %s"
+            params.append(offset)
+
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+                rows = cur.fetchall()
+
+        return [self._row_to_event(r) for r in rows]
+
+    @staticmethod
+    def _event_conditions(
+        namespace: str,
+        agent_id: str,
+        *,
+        account_id: str | None,
+        branch: str | None,
+        event_type: str | None,
+        since: datetime | None,
+        until: datetime | None,
+        cursor: str | None,
+    ) -> tuple[str, list[Any]]:
+        """WHERE clause for the timeline, shared with the async adapter."""
         conditions = ["namespace = %s", "agent_id = %s"]
         params: list[Any] = [namespace, agent_id]
 
-        account_id = self._get_current_account_id()
         if account_id:
             conditions.append("account_id = %s")
             params.append(account_id)
-
         if branch is not None:
             conditions.append("branch = %s")
             params.append(branch)
@@ -4092,24 +4469,16 @@ class PostgresAdapter(AdapterABC):
         if since is not None:
             conditions.append("created_at >= %s")
             params.append(since)
+        if until is not None:
+            conditions.append("created_at < %s")
+            params.append(until)
+        if cursor:
+            from amfs_core.pagination import decode_cursor
 
-        where = " AND ".join(conditions)
-        sql = f"""
-            SELECT id, namespace, agent_id, branch, event_type,
-                   summary, details, actor_agent_id, created_at
-            FROM amfs_events
-            WHERE {where}
-            ORDER BY created_at DESC
-            LIMIT %s
-        """
-        params.append(limit)
-
-        with self._pool.connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(sql, params)
-                rows = cur.fetchall()
-
-        return [self._row_to_event(r) for r in rows]
+            cursor_ts, cursor_id = decode_cursor(cursor)
+            conditions.append("(created_at, id) < (%s, %s::uuid)")
+            params.extend([cursor_ts, str(cursor_id)])
+        return " AND ".join(conditions), params
 
     def get_event(self, event_id: str, namespace: str = "default") -> Event | None:
         """Fetch one event by id, scoped to the caller's account.

--- a/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
+++ b/packages/adapters/postgres/src/amfs_postgres/async_adapter.py
@@ -25,6 +25,7 @@ from amfs_core.exceptions import VersionConflictError
 from amfs_core.models import (
     Agent,
     ArtifactRef,
+    DecisionTrace,
     Event,
     EventType,
     GraphEdge,
@@ -739,6 +740,179 @@ class AsyncPostgresAdapter:
             last_seen=row["last_seen"],
             provenance=row["provenance"],
         )
+
+    # ──────────────────────────────────────────────────────────────
+    # 7b. decision traces, agent activity, timeline
+    # ──────────────────────────────────────────────────────────────
+    #
+    # The trace list, trace detail, activity and timeline routes used to call
+    # the sync adapter from inside the event loop, so every page of traces
+    # was a blocking round-trip that stalled every other request. These share
+    # the WHERE builders and row mappers with the sync adapter, so a cursor
+    # issued by one is honoured identically by the other.
+
+    def _row_to_trace(self, row: dict[str, Any]) -> DecisionTrace:
+        # The sync mapper reads only ``self._namespace`` from its instance,
+        # which this adapter also carries under the same name.
+        return PostgresAdapter._row_to_trace(self, row)  # type: ignore[arg-type]
+
+    async def get_trace(self, trace_id: str) -> DecisionTrace | None:
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    f"""
+                    SELECT {PostgresAdapter._TRACE_COLUMNS}
+                    FROM amfs_decision_traces
+                    WHERE id = %s AND namespace = %s
+                    """,
+                    (trace_id, self._namespace),
+                )
+                row = await cur.fetchone()
+        return self._row_to_trace(row) if row is not None else None
+
+    async def list_traces(
+        self,
+        *,
+        entity_path: str | None = None,
+        agent_id: str | None = None,
+        outcome_type: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> list[DecisionTrace]:
+        where, params = PostgresAdapter._trace_conditions(
+            self._namespace,
+            entity_path=entity_path,
+            agent_id=agent_id,
+            outcome_type=outcome_type,
+            since=since,
+            until=until,
+            cursor=cursor,
+        )
+        sql = f"""
+            SELECT {PostgresAdapter._TRACE_COLUMNS}
+            FROM amfs_decision_traces
+            WHERE {where}
+            ORDER BY created_at DESC, id DESC
+            LIMIT %s
+        """
+        params.append(limit)
+        if not cursor and offset > 0:
+            sql += " OFFSET %s"
+            params.append(offset)
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(sql, params)
+                rows = await cur.fetchall()
+        return [self._row_to_trace(r) for r in rows]
+
+    async def count_traces(
+        self,
+        *,
+        entity_path: str | None = None,
+        agent_id: str | None = None,
+        outcome_type: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> int:
+        where, params = PostgresAdapter._trace_conditions(
+            self._namespace,
+            entity_path=entity_path,
+            agent_id=agent_id,
+            outcome_type=outcome_type,
+            since=since,
+            until=until,
+        )
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    f"SELECT count(*) AS cnt FROM amfs_decision_traces WHERE {where}", params
+                )
+                row = await cur.fetchone()
+        return int(row["cnt"]) if row else 0
+
+    async def trace_read_counts(self, agent_id: str) -> dict[str, dict[str, int]]:
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    PostgresAdapter._TRACE_READ_COUNTS_SQL, (self._namespace, agent_id)
+                )
+                rows = await cur.fetchall()
+        return PostgresAdapter._read_counts_from_rows(rows)
+
+    async def list_entries_for_agent(
+        self,
+        agent_id: str,
+        *,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        cursor: str | None = None,
+        limit: int = 100,
+        exclude_prefixes: tuple[str, ...] = ("_system/",),
+    ) -> list[MemoryEntry]:
+        where, params = PostgresAdapter._entries_for_agent_conditions(
+            self._namespace,
+            agent_id,
+            since=since,
+            until=until,
+            cursor=cursor,
+            exclude_prefixes=exclude_prefixes,
+        )
+        sql = f"""
+            SELECT * FROM amfs_memory_entries
+            WHERE {where}
+            {PostgresAdapter._ENTRIES_FOR_AGENT_ORDER}
+            LIMIT %s
+        """
+        params.append(limit)
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(sql, params)
+                rows = await cur.fetchall()
+        return [self._row_to_entry(r) for r in rows]
+
+    async def list_events(
+        self,
+        agent_id: str,
+        namespace: str = "default",
+        *,
+        branch: str | None = None,
+        event_type: str | None = None,
+        since: datetime | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        until: datetime | None = None,
+    ) -> list[Event]:
+        where, params = PostgresAdapter._event_conditions(
+            namespace,
+            agent_id,
+            account_id=self._get_current_account_id(),
+            branch=branch,
+            event_type=event_type,
+            since=since,
+            until=until,
+            cursor=cursor,
+        )
+        sql = f"""
+            SELECT id, namespace, agent_id, branch, event_type,
+                   summary, details, actor_agent_id, created_at
+            FROM amfs_events
+            WHERE {where}
+            ORDER BY created_at DESC, id DESC
+            LIMIT %s
+        """
+        params.append(limit)
+        if not cursor and offset > 0:
+            sql += " OFFSET %s"
+            params.append(offset)
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(sql, params)
+                rows = await cur.fetchall()
+        return [PostgresAdapter._row_to_event(r) for r in rows]
 
     # ──────────────────────────────────────────────────────────────
     # 8. increment_recall_count

--- a/packages/adapters/postgres/src/amfs_postgres/retention.py
+++ b/packages/adapters/postgres/src/amfs_postgres/retention.py
@@ -1,0 +1,93 @@
+"""Operator entry point for decision-trace retention.
+
+Nothing schedules retention on its own; run this from a cron job, a Kubernetes
+CronJob or by hand::
+
+    python -m amfs_postgres.retention --hot-days 30
+    python -m amfs_postgres.retention --hot-days 30 --drop-after-days 365
+    python -m amfs_postgres.retention --ensure-partitions --dry-run
+
+The DSN comes from ``--dsn`` or ``AMFS_POSTGRES_DSN``; the namespace from
+``--namespace`` or ``AMFS_NAMESPACE``. See
+:meth:`amfs_postgres.adapter.PostgresAdapter.apply_trace_retention` for what
+each tier does and the row-level-security caveat.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m amfs_postgres.retention",
+        description="Strip old decision-trace payloads and drop old partitions.",
+    )
+    parser.add_argument("--dsn", default=os.environ.get("AMFS_POSTGRES_DSN"))
+    parser.add_argument("--namespace", default=os.environ.get("AMFS_NAMESPACE", "default"))
+    parser.add_argument(
+        "--hot-days", type=int, default=30,
+        help="Traces older than this lose task_input, response_text, tool_calls, "
+             "query_events and error_events (default 30).",
+    )
+    parser.add_argument(
+        "--no-strip", action="store_true",
+        help="Do not strip payloads; only drop partitions if --drop-after-days is set.",
+    )
+    parser.add_argument(
+        "--drop-after-days", type=int, default=None,
+        help="Drop whole monthly partitions older than this many days. Off by default; "
+             "a partition holds every namespace's traces for its month.",
+    )
+    parser.add_argument(
+        "--ensure-partitions", action="store_true",
+        help="Also create partitions for the current month and the next two.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print what would run and exit without touching the database.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    if not args.dsn:
+        parser.error("--dsn or AMFS_POSTGRES_DSN is required")
+
+    plan = {
+        "namespace": args.namespace,
+        "hot_days": args.hot_days,
+        "strip_payloads": not args.no_strip,
+        "drop_after_days": args.drop_after_days,
+        "ensure_partitions": args.ensure_partitions,
+    }
+    if args.dry_run:
+        print(json.dumps({"dry_run": True, **plan}, indent=2))
+        return 0
+
+    from amfs_postgres.adapter import PostgresAdapter
+
+    adapter = PostgresAdapter(args.dsn, namespace=args.namespace, auto_schema=False)
+    try:
+        result: dict = {}
+        if args.ensure_partitions:
+            result["partitions_created"] = adapter.ensure_trace_partitions()
+        result.update(
+            adapter.apply_trace_retention(
+                hot_days=args.hot_days,
+                strip_payloads=not args.no_strip,
+                drop_after_days=args.drop_after_days,
+            )
+        )
+        print(json.dumps(result, indent=2, default=str))
+    finally:
+        adapter.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/adapters/postgres/src/amfs_postgres/schema.sql
+++ b/packages/adapters/postgres/src/amfs_postgres/schema.sql
@@ -50,8 +50,19 @@ CREATE TABLE IF NOT EXISTS amfs_outcomes (
     account_id UUID
 );
 
+-- Range-partitioned by month on created_at. Traces are append-only and read by
+-- recency, so a page of recent traces touches one or two partitions, retention
+-- drops a month instead of deleting rows, and payload stripping runs per
+-- partition. The primary key carries created_at because a partitioned table's
+-- key must include the partition column; id is still unique per row and
+-- get_trace(id) still resolves by id alone.
+--
+-- Databases created before this was partitioned are rebuilt in place by
+-- _apply_migrations (see trace_partitions.migrate_to_partitioned). Monthly
+-- partitions are created by ensure_partitions at adapter start; the DEFAULT
+-- partition below catches anything created_at outside them.
 CREATE TABLE IF NOT EXISTS amfs_decision_traces (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    id UUID NOT NULL DEFAULT gen_random_uuid(),
     namespace TEXT NOT NULL,
     agent_id TEXT NOT NULL,
     session_id TEXT NOT NULL,
@@ -69,14 +80,41 @@ CREATE TABLE IF NOT EXISTS amfs_decision_traces (
     session_started_at TIMESTAMPTZ,
     session_ended_at TIMESTAMPTZ,
     session_duration_ms NUMERIC,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (id, created_at)
+) PARTITION BY RANGE (created_at);
+
+-- Guarded so this file stays runnable against a database whose traces table
+-- is still flat and about to be rebuilt by _apply_migrations: PARTITION OF a
+-- non-partitioned table is an error, not a no-op.
+DO $$ BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relname = 'amfs_decision_traces' AND c.relkind = 'p'
+          AND n.nspname = ANY (current_schemas(false))
+    ) THEN
+        CREATE TABLE IF NOT EXISTS amfs_decision_traces_default
+            PARTITION OF amfs_decision_traces DEFAULT;
+    END IF;
+END $$;
 
 CREATE INDEX IF NOT EXISTS idx_traces_namespace
     ON amfs_decision_traces (namespace, created_at DESC);
 
 CREATE INDEX IF NOT EXISTS idx_traces_agent
     ON amfs_decision_traces (namespace, agent_id);
+
+-- Keyset pages per agent: ORDER BY created_at DESC, id DESC under an agent
+-- filter is answered by this index alone.
+CREATE INDEX IF NOT EXISTS idx_traces_agent_created
+    ON amfs_decision_traces (namespace, agent_id, created_at DESC, id DESC);
+
+-- Serves the entity_path filter, causal_entries @> '[{"entity_path": ...}]'.
+-- jsonb_path_ops supports only containment, which is the only operator used,
+-- and is smaller and faster for it than the default opclass.
+CREATE INDEX IF NOT EXISTS idx_traces_causal_entries_gin
+    ON amfs_decision_traces USING gin (causal_entries jsonb_path_ops);
 
 CREATE INDEX IF NOT EXISTS idx_traces_outcome
     ON amfs_decision_traces (namespace, outcome_type)

--- a/packages/adapters/postgres/src/amfs_postgres/trace_partitions.py
+++ b/packages/adapters/postgres/src/amfs_postgres/trace_partitions.py
@@ -1,0 +1,669 @@
+"""Monthly range partitioning and retention for ``amfs_decision_traces``.
+
+Traces are append-only and queried almost entirely by recency, which is the
+shape range partitioning on ``created_at`` was made for: a page of recent
+traces touches one or two partitions instead of an index over the whole
+history, retention becomes ``DROP TABLE`` on a month instead of a
+``DELETE`` that bloats the table it is meant to shrink, and payload stripping
+runs one partition at a time rather than as a single table-wide ``UPDATE``.
+
+Three entry points, all taking a cursor on an *autocommit* connection (the
+adapter's maintenance checkout) because each manages its own transactions:
+
+- :func:`migrate_to_partitioned` turns a flat table into a partitioned one,
+  once, in a single transaction. Idempotent: a partitioned table is left alone.
+- :func:`ensure_partitions` creates the partitions for the current month and
+  the next few, so inserts never have to fall back to the DEFAULT partition.
+  Cheap enough to run on every adapter start.
+- :func:`apply_retention` strips captured payloads from traces past the hot
+  window and optionally drops partitions past a longer one. Nothing schedules
+  it; the adapter exposes it and an operator or a job calls it.
+
+Why copy rather than attach
+---------------------------
+The migration builds the partitioned parent beside the old table, copies the
+rows into it, and drops the old table — instead of attaching the old table as
+the DEFAULT partition, which would avoid the copy. Attaching was rejected
+because it leaves every existing row in the default partition forever:
+Postgres refuses to create a monthly partition for any range the default
+partition already holds rows in, so the current month could never get its own
+partition without moving rows anyway, and every query would keep scanning one
+large unpruned child. Copying yields real monthly partitions from the first
+day, and it costs one ``INSERT ... SELECT`` over a table the plan sizes at
+thousands of rows per tenant. The whole thing is one transaction, so a failure
+at any step leaves the flat table exactly as it was.
+
+Rolling back after the fact is a plain table rebuild, because the parent has
+the same columns in the same order::
+
+    BEGIN;
+    CREATE TABLE amfs_decision_traces_flat (LIKE amfs_decision_traces
+        INCLUDING DEFAULTS INCLUDING CONSTRAINTS);
+    INSERT INTO amfs_decision_traces_flat SELECT * FROM amfs_decision_traces;
+    ALTER TABLE amfs_decision_traces_flat ADD PRIMARY KEY (id);
+    DROP TABLE amfs_decision_traces;
+    ALTER TABLE amfs_decision_traces_flat RENAME TO amfs_decision_traces;
+    COMMIT;
+
+followed by recreating the indexes in ``schema.sql`` and any policies.
+
+Primary key
+-----------
+A partitioned table's primary key must include the partition column, so the
+key becomes ``(id, created_at)``. ``id`` is still a uuid generated per row and
+``get_trace(id)`` still resolves by id alone; the lookup probes the id index of
+each partition rather than one index, which at a few dozen partitions is a
+handful of index probes.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+TABLE = "amfs_decision_traces"
+LEGACY_TABLE = "amfs_decision_traces_legacy"
+DEFAULT_PARTITION = "amfs_decision_traces_default"
+
+_PARTITION_NAME_RE = re.compile(rf"^{TABLE}_y(\d{{4}})m(\d{{2}})$")
+
+_PAYLOAD_COLUMNS_NONNULL = ("task_input", "response_text")
+_PAYLOAD_COLUMNS_JSON_ARRAY = ("tool_calls", "query_events", "error_events")
+
+
+def partition_name(year: int, month: int) -> str:
+    return f"{TABLE}_y{year:04d}m{month:02d}"
+
+
+def month_start(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    dt = dt.astimezone(UTC)
+    return dt.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+def next_month(dt: datetime) -> datetime:
+    start = month_start(dt)
+    if start.month == 12:
+        return start.replace(year=start.year + 1, month=1)
+    return start.replace(month=start.month + 1)
+
+
+def partition_bounds(name: str) -> tuple[datetime, datetime] | None:
+    """``(start, end)`` for a partition we named, or None for anything else."""
+    m = _PARTITION_NAME_RE.match(name)
+    if not m:
+        return None
+    start = datetime(int(m.group(1)), int(m.group(2)), 1, tzinfo=UTC)
+    return start, next_month(start)
+
+
+def _relkind(cur: Any, table: str) -> str | None:
+    cur.execute(
+        """
+        SELECT c.relkind
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relname = %s AND n.nspname = ANY (current_schemas(false))
+        """,
+        (table,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    kind = row["relkind"] if isinstance(row, dict) else row[0]
+    return kind if isinstance(kind, str) else kind.decode()
+
+
+def is_partitioned(cur: Any) -> bool:
+    return _relkind(cur, TABLE) == "p"
+
+
+def list_partitions(cur: Any) -> list[str]:
+    cur.execute(
+        """
+        SELECT c.relname
+        FROM pg_catalog.pg_inherits i
+        JOIN pg_catalog.pg_class c ON c.oid = i.inhrelid
+        WHERE i.inhparent = %s::regclass
+        ORDER BY c.relname
+        """,
+        (TABLE,),
+    )
+    return [r["relname"] if isinstance(r, dict) else r[0] for r in cur.fetchall()]
+
+
+def _one(row: Any, key: str, idx: int = 0) -> Any:
+    return row[key] if isinstance(row, dict) else row[idx]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Migration
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _external_dependents(cur: Any) -> list[str]:
+    """Objects that would stop the flat table from being dropped.
+
+    Foreign keys from other tables and views over this one both follow the
+    table through a rename and then block the drop; worse, a foreign key to a
+    partitioned table must reference the whole partition key, which an
+    existing ``REFERENCES amfs_decision_traces(id)`` cannot. When any exist the
+    migration is skipped and reported rather than attempted and rolled back
+    on every start.
+    """
+    cur.execute(
+        """
+        SELECT conrelid::regclass::text AS dep
+        FROM pg_catalog.pg_constraint
+        WHERE contype = 'f' AND confrelid = %s::regclass
+        UNION ALL
+        SELECT DISTINCT dependent.relname::text
+        FROM pg_catalog.pg_depend d
+        JOIN pg_catalog.pg_rewrite r ON r.oid = d.objid
+        JOIN pg_catalog.pg_class dependent ON dependent.oid = r.ev_class
+        WHERE d.refobjid = %s::regclass
+          AND d.refclassid = 'pg_class'::regclass
+          AND dependent.oid <> %s::regclass
+        """,
+        (TABLE, TABLE, TABLE),
+    )
+    return [_one(r, "dep") for r in cur.fetchall()]
+
+
+def _capture_extras(cur: Any, table: str) -> dict[str, Any]:
+    """Everything attached to the table that ``CREATE TABLE ... LIKE`` does not copy.
+
+    Policies, the row-security flags, triggers, grants, owner and indexes all
+    live on the *relation*, so they would follow the old table into the drop.
+    They are read here and replayed onto the parent inside the same
+    transaction. Policies matter most: the hosted deployment scopes tenants
+    with row-level security, and a parent without them would answer every
+    tenant's query with every tenant's rows.
+    """
+    cur.execute(
+        """
+        SELECT policyname, permissive, roles, cmd, qual, with_check
+        FROM pg_catalog.pg_policies
+        WHERE tablename = %s
+        """,
+        (table,),
+    )
+    policies = [dict(r) if isinstance(r, dict) else r for r in cur.fetchall()]
+
+    cur.execute(
+        "SELECT relrowsecurity, relforcerowsecurity "
+        "FROM pg_catalog.pg_class WHERE oid = %s::regclass",
+        (table,),
+    )
+    flags = cur.fetchone()
+
+    cur.execute(
+        """
+        SELECT tgname, pg_get_triggerdef(oid) AS def
+        FROM pg_catalog.pg_trigger
+        WHERE tgrelid = %s::regclass AND NOT tgisinternal
+        """,
+        (table,),
+    )
+    triggers = [_one(r, "def", 1) for r in cur.fetchall()]
+
+    cur.execute(
+        """
+        SELECT grantee, privilege_type, is_grantable
+        FROM information_schema.role_table_grants
+        WHERE table_name = %s AND grantee <> current_user
+        """,
+        (table,),
+    )
+    grants = [dict(r) if isinstance(r, dict) else r for r in cur.fetchall()]
+
+    cur.execute("SELECT tableowner FROM pg_catalog.pg_tables WHERE tablename = %s", (table,))
+    owner_row = cur.fetchone()
+
+    cur.execute(
+        """
+        SELECT i.indexname, i.indexdef, x.indisunique, x.indisprimary
+        FROM pg_catalog.pg_indexes i
+        JOIN pg_catalog.pg_class c ON c.relname = i.indexname
+        JOIN pg_catalog.pg_index x ON x.indexrelid = c.oid
+        WHERE i.tablename = %s
+        """,
+        (table,),
+    )
+    indexes = [dict(r) if isinstance(r, dict) else r for r in cur.fetchall()]
+
+    return {
+        "policies": policies,
+        "rls": bool(_one(flags, "relrowsecurity")) if flags else False,
+        "force_rls": bool(_one(flags, "relforcerowsecurity", 1)) if flags else False,
+        "triggers": triggers,
+        "grants": grants,
+        "owner": _one(owner_row, "tableowner") if owner_row else None,
+        "indexes": indexes,
+    }
+
+
+def _quote_ident(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+def _role_list(roles: Any) -> str:
+    names = list(roles) if roles is not None else []
+    if not names:
+        return "PUBLIC"
+    out = []
+    for r in names:
+        r = str(r)
+        if r.lower() in ("public", "current_user", "session_user"):
+            out.append(r.upper())
+        else:
+            out.append(_quote_ident(r))
+    return ", ".join(out)
+
+
+def _replay_extras(cur: Any, extras: dict[str, Any], new: str) -> None:
+    """Recreate what :func:`_capture_extras` read, on the new parent.
+
+    The definitions were captured before the rename, so they already name
+    ``amfs_decision_traces`` — the name the parent now holds.
+    """
+    for idx in extras["indexes"]:
+        if idx["indisprimary"]:
+            continue  # replaced by PRIMARY KEY (id, created_at)
+        definition: str = idx["indexdef"]
+        if idx["indisunique"] and "created_at" not in definition:
+            logger.warning(
+                "trace partitioning: unique index %s cannot exist on a partitioned "
+                "table without created_at — not recreated",
+                idx["indexname"],
+            )
+            continue
+        definition = re.sub(
+            r"^CREATE (UNIQUE )?INDEX (?!IF NOT EXISTS)",
+            lambda m: f"CREATE {m.group(1) or ''}INDEX IF NOT EXISTS ",
+            definition,
+        )
+        cur.execute(definition)
+
+    for trig in extras["triggers"]:
+        cur.execute(trig)
+
+    for pol in extras["policies"]:
+        is_permissive = str(pol["permissive"]).upper().startswith("PERM")
+        permissive = "PERMISSIVE" if is_permissive else "RESTRICTIVE"
+        parts = [
+            f"CREATE POLICY {_quote_ident(pol['policyname'])} ON {new}",
+            f"AS {permissive}",
+            f"FOR {pol['cmd'] or 'ALL'}",
+            f"TO {_role_list(pol['roles'])}",
+        ]
+        if pol.get("qual"):
+            parts.append(f"USING ({pol['qual']})")
+        if pol.get("with_check"):
+            parts.append(f"WITH CHECK ({pol['with_check']})")
+        cur.execute(" ".join(parts))
+
+    if extras["rls"]:
+        cur.execute(f"ALTER TABLE {new} ENABLE ROW LEVEL SECURITY")
+    if extras["force_rls"]:
+        cur.execute(f"ALTER TABLE {new} FORCE ROW LEVEL SECURITY")
+
+    # Grants and ownership are best-effort: a role that can rebuild the table
+    # is not necessarily one that can grant to, or hand it to, another role.
+    # A savepoint keeps a refusal here from undoing the migration.
+    for g in extras["grants"]:
+        grantee = g["grantee"]
+        target = "PUBLIC" if str(grantee).upper() == "PUBLIC" else _quote_ident(str(grantee))
+        suffix = " WITH GRANT OPTION" if str(g.get("is_grantable", "NO")).upper() == "YES" else ""
+        cur.execute("SAVEPOINT amfs_grant")
+        try:
+            cur.execute(f"GRANT {g['privilege_type']} ON {new} TO {target}{suffix}")
+            cur.execute("RELEASE SAVEPOINT amfs_grant")
+        except Exception as exc:  # noqa: BLE001
+            cur.execute("ROLLBACK TO SAVEPOINT amfs_grant")
+            logger.warning("trace partitioning: could not replay grant to %s: %s", grantee, exc)
+
+    owner = extras.get("owner")
+    if owner:
+        cur.execute("SAVEPOINT amfs_owner")
+        try:
+            cur.execute(f"ALTER TABLE {new} OWNER TO {_quote_ident(owner)}")
+            cur.execute("RELEASE SAVEPOINT amfs_owner")
+        except Exception as exc:  # noqa: BLE001
+            cur.execute("ROLLBACK TO SAVEPOINT amfs_owner")
+            logger.warning("trace partitioning: could not set owner %s: %s", owner, exc)
+
+
+def _months_between(first: datetime, last: datetime) -> list[datetime]:
+    months: list[datetime] = []
+    m = month_start(first)
+    stop = month_start(last)
+    while m <= stop:
+        months.append(m)
+        m = next_month(m)
+    return months
+
+
+def _create_partition_sql(name: str, start: datetime, end: datetime) -> str:
+    return (
+        f"CREATE TABLE IF NOT EXISTS {name} PARTITION OF {TABLE} "
+        f"FOR VALUES FROM ('{start.isoformat()}') TO ('{end.isoformat()}')"
+    )
+
+
+def migrate_to_partitioned(cur: Any, *, months_ahead: int = 2, now: datetime | None = None) -> bool:
+    """Convert a flat ``amfs_decision_traces`` into a partitioned one, once.
+
+    Returns True when the table is partitioned on return — whether it already
+    was or this call did it — or when partitioning is deliberately skipped for
+    a permanent reason (foreign keys or views over the table), so the caller
+    records the schema as applied and does not retry on every start. Raises on
+    a transient failure after rolling back, so the caller can leave the schema
+    marker unset and try again next start.
+    """
+    kind = _relkind(cur, TABLE)
+    if kind is None:
+        return False
+    if kind == "p":
+        return True
+    if kind != "r":
+        logger.warning("trace partitioning: %s has relkind %r — leaving it alone", TABLE, kind)
+        return True
+
+    dependents = _external_dependents(cur)
+    if dependents:
+        logger.error(
+            "trace partitioning: %s has dependents %s (foreign keys or views) — "
+            "cannot be partitioned in place; leaving the flat table. Remove or "
+            "recreate the dependents against (id, created_at) and restart.",
+            TABLE, dependents,
+        )
+        return True
+
+    now = now or datetime.now(UTC)
+    try:
+        cur.execute("BEGIN")
+        extras = _capture_extras(cur, TABLE)
+
+        cur.execute(f"ALTER TABLE {TABLE} RENAME TO {LEGACY_TABLE}")
+        # Index names are schema-wide: the new primary key wants the name the
+        # old one holds, and the schema.sql indexes are recreated under their
+        # own names after the drop below.
+        cur.execute(f"ALTER INDEX IF EXISTS {TABLE}_pkey RENAME TO {LEGACY_TABLE}_pkey")
+        # The copy has to see every row. Under FORCE ROW LEVEL SECURITY a
+        # maintenance connection with no tenant sees none, and would copy an
+        # empty table and drop the full one; disabling RLS on the doomed table
+        # is what makes the count check below meaningful. Only the owner may
+        # do this, and a role that is not the owner fails here, rolls back, and
+        # leaves the flat table in place.
+        cur.execute(f"ALTER TABLE {LEGACY_TABLE} DISABLE ROW LEVEL SECURITY")
+
+        cur.execute(
+            f"""
+            CREATE TABLE {TABLE} (
+                LIKE {LEGACY_TABLE} INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING GENERATED,
+                PRIMARY KEY (id, created_at)
+            ) PARTITION BY RANGE (created_at)
+            """
+        )
+        cur.execute(f"CREATE TABLE {DEFAULT_PARTITION} PARTITION OF {TABLE} DEFAULT")
+
+        cur.execute(
+            f"SELECT min(created_at) AS lo, max(created_at) AS hi, count(*) AS n "
+            f"FROM {LEGACY_TABLE}"
+        )
+        span = cur.fetchone()
+        lo, hi, legacy_count = _one(span, "lo", 0), _one(span, "hi", 1), int(_one(span, "n", 2))
+
+        wanted: dict[str, tuple[datetime, datetime]] = {}
+        horizon = month_start(now)
+        for _ in range(months_ahead):
+            horizon = next_month(horizon)
+        for m in _months_between(lo or now, max(hi or now, horizon)):
+            wanted[partition_name(m.year, m.month)] = (m, next_month(m))
+        for name, (start, end) in wanted.items():
+            cur.execute(_create_partition_sql(name, start, end))
+
+        cur.execute(f"INSERT INTO {TABLE} SELECT * FROM {LEGACY_TABLE}")
+        cur.execute(f"SELECT count(*) AS n FROM {TABLE}")
+        copied = int(_one(cur.fetchone(), "n"))
+        if copied != legacy_count:
+            raise RuntimeError(
+                f"trace partitioning: copied {copied} rows but the flat table held "
+                f"{legacy_count}; refusing to drop it"
+            )
+
+        cur.execute(f"DROP TABLE {LEGACY_TABLE}")
+        _replay_extras(cur, extras, TABLE)
+        cur.execute("COMMIT")
+    except Exception:
+        try:
+            cur.execute("ROLLBACK")
+        except Exception:  # noqa: BLE001
+            pass
+        logger.exception("trace partitioning: migration rolled back; flat table left in place")
+        raise
+
+    logger.info(
+        "trace partitioning: %s is now range-partitioned by month (%d rows moved, %d partitions)",
+        TABLE, legacy_count, len(wanted),
+    )
+    return True
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Partition upkeep
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _default_partition_months(cur: Any) -> list[datetime]:
+    """Months for which the DEFAULT partition is holding rows.
+
+    Rows land there only when no partition covered their ``created_at`` — a
+    backdated trace, or a deployment that was not restarted for longer than
+    the partitions created ahead. Each such month is given a partition of its
+    own by :func:`ensure_partitions`.
+    """
+    cur.execute(
+        f"""
+        SELECT DISTINCT date_trunc('month', created_at AT TIME ZONE 'UTC') AS m
+        FROM {DEFAULT_PARTITION}
+        """
+    )
+    months = []
+    for r in cur.fetchall():
+        m = _one(r, "m")
+        if m is None:
+            continue
+        if m.tzinfo is None:
+            m = m.replace(tzinfo=UTC)
+        months.append(month_start(m))
+    return months
+
+
+def _create_partition(cur: Any, name: str, start: datetime, end: datetime) -> None:
+    """Create one monthly partition, moving any rows the default partition holds for it.
+
+    Postgres refuses ``CREATE TABLE ... PARTITION OF`` for a range the default
+    partition has rows in, so those rows are moved into a standalone table
+    first and the table attached afterwards, all in one transaction.
+    """
+    cur.execute("BEGIN")
+    try:
+        cur.execute(
+            f"SELECT 1 FROM {DEFAULT_PARTITION} WHERE created_at >= %s AND created_at < %s LIMIT 1",
+            (start, end),
+        )
+        if cur.fetchone() is None:
+            cur.execute(_create_partition_sql(name, start, end))
+        else:
+            cur.execute(
+                f"CREATE TABLE {name} (LIKE {TABLE} INCLUDING DEFAULTS INCLUDING CONSTRAINTS)"
+            )
+            cur.execute(
+                f"INSERT INTO {name} SELECT * FROM {DEFAULT_PARTITION} "
+                f"WHERE created_at >= %s AND created_at < %s",
+                (start, end),
+            )
+            cur.execute(
+                f"DELETE FROM {DEFAULT_PARTITION} WHERE created_at >= %s AND created_at < %s",
+                (start, end),
+            )
+            cur.execute(
+                f"ALTER TABLE {TABLE} ATTACH PARTITION {name} "
+                f"FOR VALUES FROM ('{start.isoformat()}') TO ('{end.isoformat()}')"
+            )
+        cur.execute("COMMIT")
+    except Exception:
+        try:
+            cur.execute("ROLLBACK")
+        except Exception:  # noqa: BLE001
+            pass
+        raise
+
+
+def ensure_partitions(cur: Any, *, months_ahead: int = 2, now: datetime | None = None) -> list[str]:
+    """Create partitions for this month and *months_ahead* more. Returns the names created.
+
+    A no-op on a table that is not partitioned. Also gives a partition to any
+    month the DEFAULT partition is holding rows for, so the default partition
+    stays empty and every query can prune.
+    """
+    if not is_partitioned(cur):
+        return []
+    existing = set(list_partitions(cur))
+    now = now or datetime.now(UTC)
+
+    wanted: dict[str, tuple[datetime, datetime]] = {}
+    m = month_start(now)
+    for _ in range(months_ahead + 1):
+        wanted[partition_name(m.year, m.month)] = (m, next_month(m))
+        m = next_month(m)
+    if DEFAULT_PARTITION in existing:
+        for m in _default_partition_months(cur):
+            wanted.setdefault(partition_name(m.year, m.month), (m, next_month(m)))
+    else:
+        cur.execute(f"CREATE TABLE IF NOT EXISTS {DEFAULT_PARTITION} PARTITION OF {TABLE} DEFAULT")
+
+    created: list[str] = []
+    for name, (start, end) in sorted(wanted.items()):
+        if name in existing:
+            continue
+        _create_partition(cur, name, start, end)
+        created.append(name)
+    if created:
+        logger.info("trace partitioning: created %s", ", ".join(created))
+    return created
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Retention
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _strip_sql(target: str, *, bounded: bool) -> str:
+    sets = ", ".join(
+        [f"{c} = NULL" for c in _PAYLOAD_COLUMNS_NONNULL]
+        + [f"{c} = '[]'::jsonb" for c in _PAYLOAD_COLUMNS_JSON_ARRAY]
+    )
+    has_payload = " OR ".join(
+        [f"{c} IS NOT NULL" for c in _PAYLOAD_COLUMNS_NONNULL]
+        + [f"{c} <> '[]'::jsonb" for c in _PAYLOAD_COLUMNS_JSON_ARRAY]
+    )
+    where = f"namespace = %s AND ({has_payload})"
+    if bounded:
+        where += " AND created_at < %s"
+    return f"UPDATE {target} SET {sets} WHERE {where}"
+
+
+def apply_retention(
+    cur: Any,
+    *,
+    namespace: str,
+    hot_days: int = 30,
+    strip_payloads: bool = True,
+    drop_after_days: int | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Age traces out in two tiers.
+
+    Past *hot_days*, the captured payload — ``task_input``, ``response_text``,
+    ``tool_calls``, ``query_events``, ``error_events`` — is cleared while the
+    trace itself, its ``causal_entries``, contexts, state diff and metadata
+    stay, so explainability survives and only the bulk goes. Past
+    *drop_after_days*, whole monthly partitions are dropped.
+
+    Stripping is scoped to *namespace* and runs one partition at a time so no
+    single statement touches the whole table. Dropping a partition is not
+    scoped — a partition holds every namespace's traces for that month — which
+    is why it is off unless asked for. On an unpartitioned table stripping
+    still works as one bounded ``UPDATE`` and nothing is dropped.
+    """
+    now = now or datetime.now(UTC)
+    hot_cutoff = now - timedelta(days=hot_days)
+    drop_cutoff = now - timedelta(days=drop_after_days) if drop_after_days is not None else None
+    result: dict[str, Any] = {
+        "stripped_rows": 0,
+        "dropped_partitions": [],
+        "hot_cutoff": hot_cutoff.isoformat(),
+        "drop_cutoff": drop_cutoff.isoformat() if drop_cutoff else None,
+    }
+
+    if not is_partitioned(cur):
+        if strip_payloads:
+            cur.execute(_strip_sql(TABLE, bounded=True), (namespace, hot_cutoff))
+            result["stripped_rows"] = max(cur.rowcount, 0)
+        return result
+
+    partitions = list_partitions(cur)
+
+    if drop_cutoff is not None:
+        for name in partitions:
+            bounds = partition_bounds(name)
+            if bounds is None:
+                continue
+            _, end = bounds
+            if end <= drop_cutoff:
+                cur.execute(f"DROP TABLE IF EXISTS {name}")
+                result["dropped_partitions"].append(name)
+        partitions = [p for p in partitions if p not in result["dropped_partitions"]]
+
+    if strip_payloads:
+        for name in partitions:
+            bounds = partition_bounds(name)
+            if bounds is not None:
+                start, end = bounds
+                if start >= hot_cutoff:
+                    continue
+                if end <= hot_cutoff:
+                    cur.execute(_strip_sql(name, bounded=False), (namespace,))
+                else:
+                    cur.execute(_strip_sql(name, bounded=True), (namespace, hot_cutoff))
+            elif name == DEFAULT_PARTITION:
+                cur.execute(_strip_sql(name, bounded=True), (namespace, hot_cutoff))
+            else:
+                continue
+            result["stripped_rows"] += max(cur.rowcount, 0)
+
+    return result
+
+
+def create_causal_entries_index(cur: Any) -> None:
+    """GIN index that serves ``causal_entries @> '[{"entity_path": ...}]'``.
+
+    ``jsonb_path_ops`` rather than the default opclass: it only supports
+    containment, which is the only operator the filter uses, and its index is
+    smaller and faster for exactly that. Works the same on a flat table and a
+    partitioned one, where it cascades to every partition.
+    """
+    cur.execute(
+        f"""
+        CREATE INDEX IF NOT EXISTS idx_traces_causal_entries_gin
+            ON {TABLE} USING gin (causal_entries jsonb_path_ops)
+        """
+    )

--- a/packages/core/src/amfs_core/abc.py
+++ b/packages/core/src/amfs_core/abc.py
@@ -116,14 +116,37 @@ class AdapterABC(ABC):
         entity_path: str | None = None,
         since: datetime | None = None,
         limit: int = 1000,
+        outcome_ref: str | None = None,
     ) -> list[OutcomeRecord]:
         """Return historical outcome records.
 
         Used by the Pro ML layer for training ranking models and calibrating
         confidence multipliers.  Default implementation returns an empty list;
         adapters that persist outcomes (e.g. Postgres) should override.
+
+        *outcome_ref* narrows to records with that reference. It exists so a
+        caller resolving one outcome does not have to page through all of
+        them to find it.
         """
         return []
+
+    def count_outcomes(
+        self,
+        *,
+        entity_path: str | None = None,
+        since: datetime | None = None,
+    ) -> int:
+        """How many outcome records match, counted where they are stored.
+
+        The default counts a bounded ``list_outcomes`` and so cannot see past
+        :func:`amfs_core.pagination.max_scan_rows`; adapters with SQL storage
+        override with ``COUNT(*)`` so the number is right at any volume.
+        """
+        from amfs_core.pagination import max_scan_rows
+
+        return len(
+            self.list_outcomes(entity_path=entity_path, since=since, limit=max_scan_rows())
+        )
 
     def read_at_version(
         self,
@@ -150,7 +173,9 @@ class AdapterABC(ABC):
         Default implementation scans ``list_traces()``; adapters with
         indexed storage (e.g. Postgres) should override for O(1) lookup.
         """
-        for t in self.list_traces(limit=10_000):
+        from amfs_core.pagination import max_scan_rows
+
+        for t in self.list_traces(limit=max_scan_rows()):
             if t.id == trace_id:
                 return t
         return None
@@ -167,9 +192,117 @@ class AdapterABC(ABC):
         agent_id: str | None = None,
         outcome_type: str | None = None,
         limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
     ) -> list[DecisionTrace]:
-        """Return persisted decision traces. Default returns an empty list."""
+        """Return persisted decision traces, newest first.
+
+        Ordering is total: ``created_at DESC, id DESC``. *cursor* is an opaque
+        keyset position from :func:`amfs_core.pagination.encode_cursor` naming
+        the last trace already seen; when given, only strictly older traces
+        are returned and *offset* is ignored. *offset* remains for callers on
+        the older contract. *since*/*until* bound ``created_at`` (inclusive
+        lower, exclusive upper) so a time-partitioned store can prune.
+
+        Callers wanting ``has_more`` ask for ``limit + 1`` rows and build the
+        page with :func:`amfs_core.pagination.page_from_overfetch`.
+
+        Every new parameter defaults to "no constraint", so adapters written
+        against the old signature keep working when called with the old
+        arguments. Default returns an empty list.
+        """
         return []
+
+    def count_traces(
+        self,
+        *,
+        entity_path: str | None = None,
+        agent_id: str | None = None,
+        outcome_type: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> int:
+        """How many traces match, counted where they are stored.
+
+        The default counts a bounded ``list_traces`` and cannot see past
+        :func:`amfs_core.pagination.max_scan_rows`; SQL adapters override
+        with ``COUNT(*)``.
+        """
+        from amfs_core.pagination import max_scan_rows
+
+        return len(
+            self.list_traces(
+                entity_path=entity_path,
+                agent_id=agent_id,
+                outcome_type=outcome_type,
+                since=since,
+                until=until,
+                limit=max_scan_rows(),
+            )
+        )
+
+    def trace_read_counts(self, agent_id: str) -> dict[str, dict[str, int]]:
+        """How often an agent's traces read each entry: ``{entity_path: {key: n}}``.
+
+        Summing every count gives the agent's total recorded reads. This is
+        the aggregate behind the memory-graph and cross-agent-read views,
+        which used to pull every trace over the wire to compute it.
+
+        The default scans a bounded ``list_traces``; SQL adapters override
+        with a JSONB unnest and ``GROUP BY`` so full traces never leave the
+        database.
+        """
+        from amfs_core.pagination import max_scan_rows
+
+        counts: dict[str, dict[str, int]] = {}
+        for t in self.list_traces(agent_id=agent_id, limit=max_scan_rows()):
+            for ce in t.causal_entries:
+                per_entity = counts.setdefault(ce.entity_path, {})
+                per_entity[ce.key] = per_entity.get(ce.key, 0) + 1
+        return counts
+
+    def list_entries_for_agent(
+        self,
+        agent_id: str,
+        *,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        cursor: str | None = None,
+        limit: int = 100,
+        exclude_prefixes: tuple[str, ...] = ("_system/",),
+    ) -> list[MemoryEntry]:
+        """Current entries written by *agent_id*, newest first, keyset-paged.
+
+        Ordering is total: ``written_at DESC, entity_path DESC, key DESC,
+        version DESC``; the cursor tiebreak is
+        :func:`amfs_core.pagination.entry_tiebreak`. *exclude_prefixes* drops
+        entity paths the activity views never show (``_system/`` by default).
+
+        The default filters ``list()`` in memory. Adapters with indexed
+        storage override so the filter, order and page happen in the query.
+        """
+        from amfs_core.pagination import entry_tiebreak, paginate_desc
+
+        def keep(e: MemoryEntry) -> bool:
+            if e.provenance.agent_id != agent_id:
+                return False
+            if any(e.entity_path.startswith(p) for p in exclude_prefixes):
+                return False
+            written = e.provenance.written_at
+            if since is not None and written < since:
+                return False
+            return not (until is not None and written >= until)
+
+        page = paginate_desc(
+            (e for e in self.list() if keep(e)),
+            timestamp=lambda e: e.provenance.written_at,
+            tiebreak=entry_tiebreak,
+            limit=limit,
+            cursor=cursor,
+        )
+        return page.items
 
     def list_traces_for_entry(
         self,
@@ -387,9 +520,10 @@ class AdapterABC(ABC):
         override with a JSONB aggregate so full traces never leave the DB.
         """
         from amfs_core.aggregates import share_stats_from_traces
+        from amfs_core.pagination import max_scan_rows
 
         return share_stats_from_traces(
-            self.list_traces(limit=10_000),
+            self.list_traces(limit=max_scan_rows()),
             since=since,
             pair_limit=pair_limit,
             agent_ids=agent_ids,
@@ -654,8 +788,18 @@ class AdapterABC(ABC):
         event_type: str | None = None,
         since: datetime | None = None,
         limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        until: datetime | None = None,
     ) -> list[Event]:
-        """Return events on an agent's timeline. Default returns empty list."""
+        """Return events on an agent's timeline, newest first.
+
+        Ordering is total: ``created_at DESC, id DESC``. *cursor* is a keyset
+        position (see :func:`amfs_core.pagination.encode_cursor`) naming the
+        last event already seen; when given, only strictly older events are
+        returned and *offset* is ignored. *until* is an exclusive upper bound
+        on ``created_at``. Default returns an empty list.
+        """
         return []
 
     def get_event(self, event_id: str, namespace: str = "default") -> Event | None:

--- a/packages/core/src/amfs_core/models.py
+++ b/packages/core/src/amfs_core/models.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class MemoryType(str, Enum):
@@ -649,7 +649,17 @@ class SessionMetadata(BaseModel):
     Captured once per session (typically via amfs_set_identity) and attached
     to the AgentProfile and DecisionTrace so every trace records which model,
     platform, and toolset produced the decisions.
+
+    Extra keys are kept and serialised. Session-scoped data the SDKs collect for
+    a trace — the ``attributes`` bag set by ``AgentMemory.set_session_attributes``
+    and the ``llm_calls`` list built by ``AgentMemory.record_llm_call`` — rides
+    here rather than as new fields on ``DecisionTrace``, and a subclass or
+    extension may add keys of its own. Without ``extra="allow"`` such keys were
+    dropped twice: once when a dict was validated into this model and again when
+    a trace was dumped for the HTTP adapter, which serialises by declared type.
     """
+
+    model_config = ConfigDict(extra="allow")
 
     model: str | None = None
     client_name: str | None = None

--- a/packages/core/src/amfs_core/models.py
+++ b/packages/core/src/amfs_core/models.py
@@ -261,6 +261,11 @@ class OutcomeRecord(BaseModel):
     #: Typed as plain dicts because ``ToolCall`` is declared further down this
     #: module; they are the ``model_dump`` of one.
     tool_calls: list[dict[str, Any]] = Field(default_factory=list)
+    #: The session's metadata as the trace will carry it — the ``attributes``
+    #: bag and ``llm_calls`` list merged in — carried here for the same reason:
+    #: the server seals from this call, and a bag that arrived only on the later
+    #: trace left the sealed copy with no attributes and no token or cost figures.
+    session_metadata: dict[str, Any] | None = None
 
 
 class TraceEntry(BaseModel):

--- a/packages/core/src/amfs_core/outcome.py
+++ b/packages/core/src/amfs_core/outcome.py
@@ -91,6 +91,7 @@ class OutcomeBackPropagator:
         task_input: str | None = None,
         response_text: str | None = None,
         tool_calls: list[dict[str, Any]] | None = None,
+        session_metadata: dict[str, Any] | None = None,
     ) -> OutcomeRecord:
         """Convenience factory for creating OutcomeRecord instances."""
         return OutcomeRecord(
@@ -103,4 +104,5 @@ class OutcomeBackPropagator:
             task_input=task_input,
             response_text=response_text,
             tool_calls=tool_calls or [],
+            session_metadata=session_metadata or None,
         )

--- a/packages/core/src/amfs_core/pagination.py
+++ b/packages/core/src/amfs_core/pagination.py
@@ -1,0 +1,195 @@
+"""Keyset pagination primitives shared by adapters and the HTTP server.
+
+A cursor names the last row a caller has already seen — its timestamp plus a
+tiebreaker that makes the ordering total — so the next page is "everything
+strictly older than this", which an index can answer directly. ``OFFSET`` has
+to walk and discard every skipped row first, which is why it degrades linearly
+with page depth; a keyset page costs the same at row 100 as at row 100,000.
+
+Cursors are opaque to callers: base64url over a small JSON document. Nothing
+in the encoding is a secret and nothing about it is stable API — a client that
+decodes one and depends on its shape has been warned here.
+
+Also home to the scan ceiling that replaced the hard-coded ``limit=10000``
+reads. Aggregates that cannot yet run in SQL still read a bounded number of
+rows; the bound is configurable and every caller reports when it was hit.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import os
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Generic, TypeVar
+
+T = TypeVar("T")
+
+#: Default ceiling for bounded scans. The historical hard-coded value, kept as
+#: the default so nothing changes for deployments that do not set the variable.
+DEFAULT_MAX_SCAN_ROWS = 10_000
+
+#: Hard upper bound on any single page, whatever the caller asks for.
+MAX_PAGE_SIZE = 1_000
+
+
+def max_scan_rows() -> int:
+    """Rows a bounded scan may read before it stops and reports truncation.
+
+    Read from ``AMFS_MAX_SCAN_ROWS`` on each call, not cached, so tests and
+    operators can change it without restarting. Anything unparseable or
+    non-positive falls back to the default rather than raising: a typo in an
+    environment variable should not take the server down.
+    """
+    raw = os.environ.get("AMFS_MAX_SCAN_ROWS", "").strip()
+    if not raw:
+        return DEFAULT_MAX_SCAN_ROWS
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_MAX_SCAN_ROWS
+    return value if value > 0 else DEFAULT_MAX_SCAN_ROWS
+
+
+def clamp_limit(limit: int | None, *, default: int = 100) -> int:
+    """A page size that is at least 1 and at most :data:`MAX_PAGE_SIZE`."""
+    if limit is None:
+        return default
+    return max(1, min(int(limit), MAX_PAGE_SIZE))
+
+
+class InvalidCursorError(ValueError):
+    """The cursor was not produced by :func:`encode_cursor`, or was corrupted."""
+
+
+def encode_cursor(timestamp: datetime, tiebreak: Any) -> str:
+    """Encode a ``(timestamp, tiebreak)`` position as an opaque string.
+
+    *tiebreak* is whatever makes the ordering total for the row set in
+    question — a row id for traces and events, a ``[entity_path, key, version]``
+    triple for entries. It must be JSON-serialisable and must compare the same
+    way in Python as in SQL for the adapter that issued it.
+    """
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=UTC)
+    payload = json.dumps(
+        {"t": timestamp.isoformat(), "k": tiebreak},
+        separators=(",", ":"),
+        default=str,
+    )
+    return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def decode_cursor(cursor: str) -> tuple[datetime, Any]:
+    """Invert :func:`encode_cursor`.
+
+    Raises :class:`InvalidCursorError` for anything that is not one of ours.
+    The HTTP layer turns that into a 400; adapters let it propagate.
+    """
+    if not isinstance(cursor, str) or not cursor:
+        raise InvalidCursorError("empty cursor")
+    padded = cursor + "=" * (-len(cursor) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(padded.encode("ascii"))
+        doc = json.loads(raw.decode("utf-8"))
+    except (binascii.Error, UnicodeDecodeError, UnicodeEncodeError, json.JSONDecodeError) as exc:
+        raise InvalidCursorError("malformed cursor") from exc
+    if not isinstance(doc, dict) or "t" not in doc or "k" not in doc:
+        raise InvalidCursorError("malformed cursor")
+    try:
+        ts = datetime.fromisoformat(doc["t"])
+    except (TypeError, ValueError) as exc:
+        raise InvalidCursorError("malformed cursor timestamp") from exc
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return ts, doc["k"]
+
+
+@dataclass
+class Page(Generic[T]):
+    """One page of results plus what a caller needs to ask for the next."""
+
+    items: list[T]
+    next_cursor: str | None
+    has_more: bool
+    #: True when a bounded scan stopped before seeing every candidate row, so
+    #: the page (or aggregate built from it) may be incomplete.
+    truncated: bool = False
+
+
+def _as_key(ts: datetime, tiebreak: Any) -> tuple[datetime, str]:
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return ts, json.dumps(tiebreak, default=str, sort_keys=True)
+
+
+def paginate_desc(
+    items: Iterable[T],
+    *,
+    timestamp: Callable[[T], datetime],
+    tiebreak: Callable[[T], Any],
+    limit: int,
+    cursor: str | None = None,
+    offset: int = 0,
+) -> Page[T]:
+    """Keyset-paginate an in-memory iterable, newest first.
+
+    The reference implementation for adapters that cannot push the predicate
+    into a query — the filesystem adapter, the ABC defaults, tests. SQL
+    adapters do the same thing with ``(created_at, id) < (%s, %s)`` and an
+    ``ORDER BY created_at DESC, id DESC``; this is what they must agree with.
+
+    *offset* is honoured only when no cursor is given, for callers still on
+    the old ``limit``/``offset`` contract.
+    """
+    # Not clamped: callers overfetch by one to learn ``has_more``, and the
+    # clamp belongs at the HTTP boundary, before that extra row is added.
+    limit = max(1, int(limit))
+    keyed = [(_as_key(timestamp(x), tiebreak(x)), x) for x in items]
+    keyed.sort(key=lambda kv: kv[0], reverse=True)
+
+    if cursor:
+        cursor_key = _as_key(*decode_cursor(cursor))
+        keyed = [kv for kv in keyed if kv[0] < cursor_key]
+    elif offset > 0:
+        keyed = keyed[offset:]
+
+    window = keyed[: limit + 1]
+    has_more = len(window) > limit
+    window = window[:limit]
+    next_cursor = None
+    if window and has_more:
+        last = window[-1][1]
+        next_cursor = encode_cursor(timestamp(last), tiebreak(last))
+    return Page(items=[x for _, x in window], next_cursor=next_cursor, has_more=has_more)
+
+
+def page_from_overfetch(
+    rows: list[T],
+    *,
+    limit: int,
+    timestamp: Callable[[T], datetime],
+    tiebreak: Callable[[T], Any],
+) -> Page[T]:
+    """Build a page from a query that fetched ``limit + 1`` rows.
+
+    The extra row is how ``has_more`` is known without a second COUNT query;
+    it is dropped from the page. The cursor points at the last row *returned*,
+    so a caller that filters the page afterwards (visibility, for instance)
+    still resumes from the right place.
+    """
+    has_more = len(rows) > limit
+    window = rows[:limit]
+    next_cursor = None
+    if window and has_more:
+        last = window[-1]
+        next_cursor = encode_cursor(timestamp(last), tiebreak(last))
+    return Page(items=window, next_cursor=next_cursor, has_more=has_more)
+
+
+def entry_tiebreak(entry: Any) -> list[Any]:
+    """Tiebreaker for ``MemoryEntry`` rows, which carry no row id."""
+    return [entry.entity_path, entry.key, entry.version]

--- a/packages/http-server/src/amfs_http/models.py
+++ b/packages/http-server/src/amfs_http/models.py
@@ -41,6 +41,11 @@ class OutcomeRequest(BaseModel):
     #: Already scanned by the client before they reach here, and scanned again on
     #: the way in, because this endpoint is reachable by anything with a key.
     tool_calls: list[dict[str, Any]] = Field(default_factory=list)
+    #: The client's session metadata. Only ``attributes`` (the trace's dimension
+    #: bag) and ``llm_calls`` (token/cost records) are read from it; a remote
+    #: client has no other way to get either onto the trace this commit builds,
+    #: since the trace is assembled here from the server's own handle.
+    session_metadata: dict[str, Any] | None = None
 
 
 class SearchRequest(BaseModel):

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -2614,6 +2614,8 @@ async def list_traces(
     limit: int = Query(100, ge=1),
     offset: int = Query(0, ge=0),
     cursor: str | None = Query(None),
+    since: datetime | None = Query(None),
+    until: datetime | None = Query(None),
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
     """Decision traces, newest first, keyset-paginated.
@@ -2622,6 +2624,10 @@ async def list_traces(
     only when no cursor is given. The page's cursor points at the last row
     read, so a caller whose visibility hides some agents still advances past
     them rather than seeing the same rows again.
+
+    ``since`` (inclusive) and ``until`` (exclusive) bound ``created_at`` in
+    the query itself, so a window that excludes the newest traces still
+    returns the older matches instead of an empty first page.
     """
     limit = clamp_limit(limit)
     page = await _list_traces_page(
@@ -2631,6 +2637,8 @@ async def list_traces(
         limit=limit,
         offset=offset,
         cursor=_check_cursor(cursor),
+        since=since,
+        until=until,
     )
     traces = page.items
     allowed = _visible_agent_ids(request)

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -23,7 +23,7 @@ import re
 import secrets
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from typing import Any
 
 import uvicorn
@@ -48,6 +48,16 @@ from amfs_core.models import (
     MemoryEntry,
     SearchQuery,
     SemanticQuery,
+)
+from amfs_core.pagination import (
+    InvalidCursorError,
+    Page,
+    clamp_limit,
+    decode_cursor,
+    encode_cursor,
+    entry_tiebreak,
+    max_scan_rows,
+    page_from_overfetch,
 )
 from amfs_core.quality import HeuristicQualityEvaluator
 
@@ -283,10 +293,13 @@ try:
 
     from amfs_traces.store import PostgresImmutableTraceStore
     from amfs_traces.crypto import seal, get_signing_key, get_signing_key_id
-    from amfs_traces.models import ImmutableDecisionTrace, TraceEntry, TraceExternalContext
-    # Aliased because the OSS ``ToolCall`` of the same name is what arrives on the
-    # trace being sealed, and the two are easy to confuse at the mapping site.
-    from amfs_traces.models import ToolCall as ProToolCall
+    # The OSS -> immutable mapping lives with the Pro package, shared with its
+    # other two seal paths, so what this server seals is what they seal. It used
+    # to be inlined here and silently dropped the fields it did not know about.
+    from amfs_traces.seal_on_demand import (
+        finalize_spans as _pro_finalize_spans,
+        immutable_from_oss_trace as _pro_immutable_from_oss_trace,
+    )
     _HAS_PRO_TRACES = True
 except ImportError:
     _HAS_PRO_TRACES = False
@@ -514,6 +527,130 @@ def _require_agent_visible(request: Request, agent_id: str) -> None:
     vis = _active_visibility_filter(request)
     if vis is not None and not vis.is_agent_visible(agent_id):
         raise HTTPException(status_code=404, detail="Agent not found")
+
+
+# ── Keyset pagination and bounded scans ─────────────────────────────────
+#
+# Paged list routes return the existing list key plus ``next_cursor`` and
+# ``has_more``, the shape the rooms endpoints already use. ``limit``/``offset``
+# keep working for callers on the old contract; a cursor, when given, wins.
+
+
+def _check_cursor(cursor: str | None) -> str | None:
+    """Reject a malformed cursor at the boundary with a 400, not a 500 later."""
+    if not cursor:
+        return None
+    try:
+        decode_cursor(cursor)
+    except InvalidCursorError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid cursor: {exc}") from exc
+    return cursor
+
+
+def _page_meta(page: Page[Any]) -> dict[str, Any]:
+    return {"next_cursor": page.next_cursor, "has_more": page.has_more}
+
+
+def _parse_ts(value: str | None) -> datetime | None:
+    """ISO-8601 query parameter to an aware datetime; naive input is taken as UTC.
+
+    Adapters compare these against stored timestamps that are always aware,
+    and a naive value would raise from inside that comparison rather than
+    here, where it can be a 400.
+    """
+    if not value:
+        return None
+    try:
+        ts = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid timestamp: {value!r}") from exc
+    return ts if ts.tzinfo is not None else ts.replace(tzinfo=UTC)
+
+
+async def _via_async_or_sync(method: str, *args: Any, **kwargs: Any) -> Any:
+    """Call *method* on the async adapter when there is one, else on the sync adapter.
+
+    The async adapter is the request path's; falling back to the sync adapter
+    is what keeps the filesystem adapter and the tests working. A failure on
+    the async side is logged and retried on the sync side so a transient
+    pool problem degrades to a blocking call rather than an error — the same
+    posture the read and search routes take.
+    """
+    if _async_adapter is not None and hasattr(_async_adapter, method):
+        try:
+            return await getattr(_async_adapter, method)(*args, **kwargs)
+        except InvalidCursorError:
+            raise
+        except Exception:
+            logger.warning("async %s failed — falling back to sync adapter", method, exc_info=True)
+    return getattr(_get_memory()._adapter, method)(*args, **kwargs)
+
+
+async def _list_traces_page(
+    *,
+    limit: int,
+    offset: int = 0,
+    cursor: str | None = None,
+    **filters: Any,
+) -> Page[DecisionTrace]:
+    """One page of traces, overfetching by one row to learn ``has_more``."""
+    rows = await _via_async_or_sync(
+        "list_traces", limit=limit + 1, offset=offset, cursor=cursor, **filters
+    )
+    return page_from_overfetch(
+        list(rows),
+        limit=limit,
+        timestamp=lambda t: t.created_at,
+        tiebreak=lambda t: t.id,
+    )
+
+
+async def _list_events_page(
+    agent_id: str,
+    namespace: str,
+    *,
+    limit: int,
+    offset: int = 0,
+    cursor: str | None = None,
+    **filters: Any,
+) -> Page[Event]:
+    rows = await _via_async_or_sync(
+        "list_events", agent_id, namespace, limit=limit + 1, offset=offset, cursor=cursor,
+        **filters,
+    )
+    return page_from_overfetch(
+        list(rows),
+        limit=limit,
+        timestamp=lambda e: e.created_at,
+        tiebreak=lambda e: e.id,
+    )
+
+
+async def _list_agent_entries_page(
+    agent_id: str,
+    *,
+    limit: int,
+    cursor: str | None = None,
+    **filters: Any,
+) -> Page[MemoryEntry]:
+    rows = await _via_async_or_sync(
+        "list_entries_for_agent", agent_id, limit=limit + 1, cursor=cursor, **filters
+    )
+    return page_from_overfetch(
+        list(rows),
+        limit=limit,
+        timestamp=lambda e: e.provenance.written_at,
+        tiebreak=entry_tiebreak,
+    )
+
+
+def _bounded_scan(items: list[Any], ceiling: int) -> tuple[list[Any], bool]:
+    """Trim a scan to *ceiling* rows and say whether anything was cut.
+
+    Callers fetch ``ceiling + 1`` so the flag is exact: a result exactly at
+    the ceiling is complete, one row past it is not.
+    """
+    return items[:ceiling], len(items) > ceiling
 
 
 def _require_account_admin(request: Request) -> None:
@@ -1856,15 +1993,20 @@ async def get_agent_profile(
         (e.provenance.written_at for e in entries),
         default=None,
     )
-    traces = mem._adapter.list_traces(agent_id=agent_id, limit=10000)
+    # Both numbers are aggregates the adapter computes where the traces live;
+    # this route used to pull up to 10,000 full traces to count them.
+    trace_count = mem._adapter.count_traces(agent_id=agent_id)
+    total_reads = sum(
+        sum(keys.values()) for keys in mem._adapter.trace_read_counts(agent_id).values()
+    )
 
     result: dict[str, Any] = {
         "agentId": agent_id,
         "entriesWritten": len(entries),
         "entitiesTouched": len(entities_touched),
         "entityPaths": sorted(entities_touched),
-        "totalReads": sum(len(t.causal_entries) for t in traces),
-        "decisionTraces": len(traces),
+        "totalReads": total_reads,
+        "decisionTraces": trace_count,
         "lastActive": last_active.isoformat() if last_active else None,
     }
 
@@ -1875,7 +2017,7 @@ async def get_agent_profile(
 
         if not profile and not capabilities and entries:
             profile, capabilities = _synthesize_agent_profile(
-                agent_id, entries, traces,
+                agent_id, entries, trace_count,
             )
 
         result["profile"] = profile.model_dump() if profile else {}
@@ -1889,7 +2031,7 @@ async def get_agent_profile(
 def _synthesize_agent_profile(
     agent_id: str,
     entries: list,
-    traces: list,
+    traces: list | int,
 ) -> tuple:
     """Build an AgentProfile and capabilities from observed activity."""
     from amfs_core.models import AgentProfile, AgentCapability, MemoryType
@@ -1916,8 +2058,10 @@ def _synthesize_agent_profile(
             f"Active across {len(entities_touched)} "
             f"entit{'y' if len(entities_touched) == 1 else 'ies'}."
         )
-    if traces:
-        desc_parts.append(f"{len(traces)} decision trace(s) recorded.")
+    # Callers pass the count; a list is still accepted for older call sites.
+    trace_count = traces if isinstance(traces, int) else len(traces)
+    if trace_count:
+        desc_parts.append(f"{trace_count} decision trace(s) recorded.")
 
     profile = AgentProfile(
         description=" ".join(desc_parts),
@@ -2252,11 +2396,29 @@ def _scan_captured_actions(
     return kept
 
 
-def _auto_seal_trace(mem: AgentMemory) -> str | None:
-    """If Pro traces are available, auto-seal the last OSS trace as immutable."""
+def _auto_seal_trace(
+    mem: AgentMemory,
+    oss_trace: Any | None = None,
+    *,
+    session_metadata: Any | None = None,
+) -> str | None:
+    """If Pro traces are available, seal an OSS trace as immutable.
+
+    ``oss_trace`` defaults to the trace ``mem`` just committed. ``POST
+    /api/v1/traces`` passes the trace it persisted instead, together with the
+    request body's raw ``session_metadata``: validating the body into the OSS
+    model discards keys the model does not declare, and the Pro recorder's spans
+    and LLM calls travel in exactly such keys.
+
+    The OSS -> immutable mapping is the Pro package's, not this file's. The copy
+    that lived here mapped only the fields it knew about, so every field added
+    to the sealed record afterwards — ``llm_calls`` first — was silently dropped
+    on this path while the other two seal paths carried it.
+    """
     if not _HAS_PRO_TRACES:
         return None
-    oss_trace = getattr(mem, "_last_trace", None)
+    if oss_trace is None:
+        oss_trace = getattr(mem, "_last_trace", None)
     if oss_trace is None:
         return None
     store = _get_immutable_store()
@@ -2266,50 +2428,11 @@ def _auto_seal_trace(mem: AgentMemory) -> str | None:
         from uuid import UUID as _UUID
 
         now = datetime.now(timezone.utc)
-        causal = [
-            TraceEntry(
-                entity_path=e.entity_path,
-                key=e.key,
-                version=e.version,
-                confidence=e.confidence,
-                value=e.value,
-                memory_type=getattr(e, "memory_type", None) or "fact",
-                written_by=getattr(e, "written_by", None),
-                read_at=getattr(e, "read_at", None) or now,
-            )
-            for e in (oss_trace.causal_entries or [])
-        ]
-        contexts = [
-            TraceExternalContext(
-                label=c.label,
-                summary=c.summary,
-                source=getattr(c, "source", None),
-                recorded_at=getattr(c, "recorded_at", None) or now,
-            )
-            for c in (oss_trace.external_contexts or [])
-        ]
-        # The action side of the training pair. Mapped field by field rather than
-        # by model_dump so that a shape change on either model surfaces here as a
-        # type error instead of a silently empty column.
-        actions = [
-            ProToolCall(
-                tool_name=t.tool_name,
-                arguments=t.arguments,
-                result_summary=t.result_summary,
-                result_hash=t.result_hash,
-                started_at=t.started_at or now,
-                duration_ms=t.duration_ms,
-                source=t.source,
-                success=t.success,
-            )
-            for t in (getattr(oss_trace, "tool_calls", None) or [])
-        ]
-
-        session_id = mem.session_id
+        # The trace's own session when it has one: a trace posted by a remote
+        # client belongs to that client's session, not to the server handle's.
+        session_id = getattr(oss_trace, "session_id", None) or mem.session_id
         seq = _seal_sequence.get(session_id, 0)
         parent_hash = store.get_latest_hash(session_id)
-
-        trace_id = _UUID(oss_trace.id) if oss_trace.id else None
 
         account_id = None
         try:
@@ -2320,9 +2443,11 @@ def _auto_seal_trace(mem: AgentMemory) -> str | None:
         except (ImportError, ValueError):
             pass
 
-        imm = ImmutableDecisionTrace(
-            **({"id": trace_id} if trace_id else {}),
-            **({"account_id": account_id} if account_id else {}),
+        imm = _pro_immutable_from_oss_trace(
+            oss_trace,
+            session_id=session_id,
+            sequence_number=seq,
+            account_id=account_id,
             # From the trace, not from ``mem``. ``mem`` is shared by every
             # request: the caller's agent is written onto its tagger for the
             # duration of the commit and restored in a ``finally``, and this runs
@@ -2332,18 +2457,10 @@ def _auto_seal_trace(mem: AgentMemory) -> str | None:
             # model trains on an empty set. The trace was built while the tagger
             # still pointed at the caller.
             agent_id=getattr(oss_trace, "agent_id", None) or mem.agent_id,
-            session_id=session_id,
-            sequence_number=seq,
-            outcome_ref=oss_trace.outcome_ref,
-            outcome_type=oss_trace.outcome_type,
-            decision_summary=getattr(oss_trace, "decision_summary", None),
-            task_input=getattr(oss_trace, "task_input", None),
-            response_text=getattr(oss_trace, "response_text", None),
-            causal_entries=causal,
-            external_contexts=contexts,
-            tool_calls=actions,
             created_at=now,
+            session_metadata=session_metadata,
         )
+        imm = _pro_finalize_spans(imm)
         sealed = seal(
             imm,
             get_signing_key(),
@@ -2354,7 +2471,7 @@ def _auto_seal_trace(mem: AgentMemory) -> str | None:
         saved = store.save(sealed)
         _seal_sequence[session_id] = seq + 1
         logger.info("Auto-sealed immutable trace %s for outcome %s",
-                     saved.id, oss_trace.outcome_ref)
+                     saved.id, getattr(oss_trace, "outcome_ref", None))
         return str(saved.id)
     except Exception:
         logger.warning("Failed to auto-seal immutable trace", exc_info=True)
@@ -2429,6 +2546,7 @@ async def list_outcomes(
     entity_path: str | None = Query(None),
     since: str | None = Query(None),
     limit: int = Query(100),
+    outcome_ref: str | None = Query(None),
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
     mem = _get_memory()
@@ -2437,6 +2555,7 @@ async def list_outcomes(
         entity_path=entity_path,
         since=since_dt,
         limit=limit,
+        outcome_ref=outcome_ref,
     )
     allowed = _visible_agent_ids(request)
     if allowed is not None:
@@ -2472,8 +2591,10 @@ async def explain(
         # they can see; the ref-less session explain spans the whole account.
         if outcome_ref is None:
             raise HTTPException(status_code=403, detail="outcome_ref is required")
-        records = mem._adapter.list_outcomes(limit=10000)
-        record = next((r for r in records if r.outcome_ref == outcome_ref), None)
+        # Filtered where the outcomes live rather than paged through all of
+        # them here; an outcome_ref is not unique, so the newest record wins.
+        records = mem._adapter.list_outcomes(outcome_ref=outcome_ref, limit=1)
+        record = records[0] if records else None
         if record is None or record.agent_id not in allowed:
             raise HTTPException(status_code=404, detail="Outcome not found")
     return mem.explain(outcome_ref)
@@ -2490,20 +2611,35 @@ async def list_traces(
     entity_path: str | None = Query(None),
     agent_id: str | None = Query(None),
     outcome_type: str | None = Query(None),
-    limit: int = Query(100),
+    limit: int = Query(100, ge=1),
+    offset: int = Query(0, ge=0),
+    cursor: str | None = Query(None),
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
-    mem = _get_memory()
-    traces = mem._adapter.list_traces(
+    """Decision traces, newest first, keyset-paginated.
+
+    Follow ``next_cursor`` while ``has_more`` is true. ``offset`` is honoured
+    only when no cursor is given. The page's cursor points at the last row
+    read, so a caller whose visibility hides some agents still advances past
+    them rather than seeing the same rows again.
+    """
+    limit = clamp_limit(limit)
+    page = await _list_traces_page(
         entity_path=entity_path,
         agent_id=agent_id,
         outcome_type=outcome_type,
         limit=limit,
+        offset=offset,
+        cursor=_check_cursor(cursor),
     )
+    traces = page.items
     allowed = _visible_agent_ids(request)
     if allowed is not None:
         traces = [t for t in traces if t.agent_id in allowed]
-    return {"traces": [t.model_dump(mode="json") for t in traces]}
+    return {
+        "traces": [t.model_dump(mode="json") for t in traces],
+        **_page_meta(page),
+    }
 
 
 @app.post("/api/v1/traces")
@@ -2557,7 +2693,18 @@ async def save_trace(
             ),
         })
     saved = mem._adapter.save_trace(trace)
-    return saved.model_dump(mode="json")
+    # Sealed like a trace committed through /outcomes. Until this call, a trace
+    # arriving here — which is every trace an HttpAdapter client commits — was
+    # never sealed, so it had no immutable copy at all. The saved trace is what
+    # is sealed, so the immutable copy carries the persisted id; the raw body is
+    # passed alongside because ``model_validate`` above dropped the
+    # ``session_metadata`` keys the Pro recorder's spans travel in.
+    raw_meta = body.get("session_metadata") if isinstance(body, dict) else None
+    immutable_trace_id = _auto_seal_trace(mem, saved, session_metadata=raw_meta)
+    result = saved.model_dump(mode="json")
+    if immutable_trace_id:
+        result["immutable_trace_id"] = immutable_trace_id
+    return result
 
 
 # NOTE: must be registered before /api/v1/traces/{trace_id} so "share-stats"
@@ -2590,8 +2737,7 @@ async def get_trace(
     trace_id: str,
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
-    mem = _get_memory()
-    trace = mem._adapter.get_trace(trace_id)
+    trace = await _via_async_or_sync("get_trace", trace_id)
     allowed = _visible_agent_ids(request)
     if trace is not None and allowed is not None and trace.agent_id not in allowed:
         trace = None
@@ -2775,7 +2921,9 @@ async def get_usage(
         }
     mem = _get_memory()
     st = mem.stats()
-    outcomes = mem._adapter.list_outcomes(limit=10000)
+    # Counted in SQL. This used to be len() over a list capped at 10,000, so
+    # every account past that reported exactly 10,000 decision traces.
+    outcome_count = mem._adapter.count_outcomes()
 
     top_agents = sorted(st.agents.items(), key=lambda x: x[1], reverse=True)[:10]
     top_entities = sorted(st.entities.items(), key=lambda x: x[1], reverse=True)[:10]
@@ -2824,7 +2972,7 @@ async def get_usage(
         "avgLatencyMs": 0,
         "quotas": [
             {"label": "Memory entries", "current": st.total_entries, "limit": 0},
-            {"label": "Decision traces", "current": len(outcomes), "limit": 0},
+            {"label": "Decision traces", "current": outcome_count, "limit": 0},
             {"label": "API keys", "current": api_key_count, "limit": 0},
             {"label": "Users", "current": st.total_agents, "limit": 0},
         ],
@@ -3002,7 +3150,12 @@ async def agent_memory_graph(
 
     mem = _get_memory()
     entries = mem.list()
-    traces = mem._adapter.list_traces(agent_id=agent_id, limit=10000)
+    # Read counts and the trace count are aggregated by the adapter; this
+    # used to pull up to 10,000 full traces to tally causal_entries here.
+    trace_count = mem._adapter.count_traces(agent_id=agent_id)
+    read_entities: dict[str, dict[str, int]] = {
+        ep: dict(keys) for ep, keys in mem._adapter.trace_read_counts(agent_id).items()
+    }
 
     written_by_agent = [
         e for e in entries
@@ -3030,25 +3183,26 @@ async def agent_memory_graph(
     total_recalls = sum(getattr(e, "recall_count", 0) for e in written_by_agent)
     recalled_tokens_saved = sum(recall_tokens_saved(e) for e in written_by_agent)
 
-    # Build read counts from both traces (causal_entries) and timeline events.
-    read_entities: dict[str, dict[str, int]] = {}
-    for t in traces:
-        for ce in t.causal_entries:
-            ep = ce.entity_path
-            key = ce.key
-            if ep not in read_entities:
-                read_entities[ep] = {}
-            read_entities[ep][key] = read_entities[ep].get(key, 0) + 1
-
-    # Supplement with READ events from the timeline (persisted independently).
+    # Supplement the trace read counts with READ events from the timeline
+    # (persisted independently). Bounded by AMFS_MAX_SCAN_ROWS per event
+    # type, and the response says when the bound was hit.
     total_read_events = 0
+    read_events_truncated = False
+    ceiling = max_scan_rows()
     try:
-        read_events = mem._adapter.list_events(
-            agent_id, mem.namespace, event_type="read", limit=10000,
+        read_events, cut_a = _bounded_scan(
+            mem._adapter.list_events(
+                agent_id, mem.namespace, event_type="read", limit=ceiling + 1,
+            ),
+            ceiling,
         )
-        cross_read_events = mem._adapter.list_events(
-            agent_id, mem.namespace, event_type="cross_agent_read", limit=10000,
+        cross_read_events, cut_b = _bounded_scan(
+            mem._adapter.list_events(
+                agent_id, mem.namespace, event_type="cross_agent_read", limit=ceiling + 1,
+            ),
+            ceiling,
         )
+        read_events_truncated = cut_a or cut_b
         for ev in read_events + cross_read_events:
             ep = ev.details.get("entity_path", "")
             key = ev.details.get("key", "")
@@ -3088,12 +3242,13 @@ async def agent_memory_graph(
     return {
         "agentId": agent_id,
         "nodes": nodes,
-        "traceCount": len(traces),
+        "traceCount": trace_count,
         "totalWritten": len(written_by_agent),
         "totalReads": total_read_events,
         "totalRecalls": total_recalls,
         "recalledTokensSaved": recalled_tokens_saved,
         "crossAgentReads": cross_agent_reads,
+        "truncated": read_events_truncated,
     }
 
 
@@ -3110,20 +3265,14 @@ async def agent_cross_reads(
 
     mem = _get_memory()
     entries = mem.list()
-    traces = mem._adapter.list_traces(agent_id=agent_id, limit=10000)
 
     entry_authors: dict[str, str] = {}
     for e in entries:
         entry_authors[f"{e.entity_path}/{e.key}"] = e.provenance.agent_id
 
-    read_entities: dict[str, dict[str, int]] = {}
-    for t in traces:
-        for ce in t.causal_entries:
-            ep = ce.entity_path
-            key = ce.key
-            if ep not in read_entities:
-                read_entities[ep] = {}
-            read_entities[ep][key] = read_entities[ep].get(key, 0) + 1
+    # Aggregated by the adapter; previously up to 10,000 full traces were
+    # fetched to tally their causal_entries here.
+    read_entities = mem._adapter.trace_read_counts(agent_id)
 
     cross_reads: dict[str, list[dict[str, Any]]] = {}
     for ep, keys in read_entities.items():
@@ -3239,67 +3388,147 @@ async def agent_read_from(
     return _entry_to_response(entry)
 
 
+_ACTIVITY_SOURCES = ("w", "o", "e")  # writes, outcomes, events
+
+
+def _encode_activity_cursor(positions: dict[str, str | None]) -> str | None:
+    """A composite cursor over the three activity sources.
+
+    The activity feed merges three independently-ordered streams, so a
+    single ``(timestamp, id)`` position cannot resume it exactly: two
+    sources can share a timestamp, and dropping to a strict ``<`` on the
+    timestamp alone would skip rows. Each source keeps its own keyset
+    position instead, and the composite is just the three of them.
+    """
+    if all(v is None for v in positions.values()):
+        return None
+    return encode_cursor(datetime.now(UTC), {k: positions.get(k) for k in _ACTIVITY_SOURCES})
+
+
+def _decode_activity_cursor(cursor: str | None) -> dict[str, str | None]:
+    if not cursor:
+        return {k: None for k in _ACTIVITY_SOURCES}
+    _, positions = decode_cursor(cursor)
+    if not isinstance(positions, dict):
+        raise InvalidCursorError("cursor does not belong to the activity feed")
+    return {k: positions.get(k) for k in _ACTIVITY_SOURCES}
+
+
 @app.get("/api/v1/agents/{agent_id:path}/activity")
 async def agent_activity(
     request: Request,
     agent_id: str,
-    limit: int = Query(100),
+    limit: int = Query(100, ge=1),
+    cursor: str | None = Query(None),
+    since: str | None = Query(None),
+    until: str | None = Query(None),
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
-    """Timeline of writes, outcomes, reads, and other events for this agent."""
+    """Timeline of writes, outcomes, reads, and other events for this agent.
+
+    Each of the three sources — the agent's current entries, its traces, and
+    its timeline events — is filtered, ordered and paged by the adapter, so
+    this route reads at most ``3 * (limit + 1)`` rows however much history the
+    agent has. It used to list every entry in the namespace and filter here.
+
+    Keyset-paginated with a composite cursor: follow ``next_cursor`` while
+    ``has_more`` is true. ``since``/``until`` bound every source by time.
+    """
     vis = _get_visibility_filter(request)
     if vis is not None and vis.should_filter() and not vis.is_agent_visible(agent_id):
         raise HTTPException(status_code=404, detail="Agent not found")
 
+    limit = clamp_limit(limit)
+    try:
+        positions = _decode_activity_cursor(cursor)
+        for pos in positions.values():
+            _check_cursor(pos)
+    except InvalidCursorError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid cursor: {exc}") from exc
+    since_dt = _parse_ts(since)
+    until_dt = _parse_ts(until)
+
     mem = _get_memory()
-    entries = [
-        e for e in mem.list()
-        if e.provenance.agent_id == agent_id and not e.entity_path.startswith("_system/")
-    ]
-    entries.sort(key=lambda e: e.provenance.written_at, reverse=True)
+    entries_page = await _list_agent_entries_page(
+        agent_id, limit=limit, cursor=positions["w"], since=since_dt, until=until_dt,
+    )
+    traces_page = await _list_traces_page(
+        agent_id=agent_id, limit=limit, cursor=positions["o"], since=since_dt, until=until_dt,
+    )
+    events_page = await _list_events_page(
+        agent_id, mem.namespace, limit=limit, cursor=positions["e"],
+        since=since_dt, until=until_dt,
+    )
 
-    writes = [
-        {
-            "type": "write",
-            "entityPath": e.entity_path,
-            "key": e.key,
-            "version": e.version,
-            "confidence": e.confidence,
-            "timestamp": e.provenance.written_at.isoformat(),
-        }
-        for e in entries[:limit]
-    ]
-
-    traces = mem._adapter.list_traces(agent_id=agent_id, limit=limit)
-    outcomes = [
-        {
+    # Every candidate row carries the cursor its source would resume from if
+    # this row were the last one taken, so the merge can advance each source
+    # independently and exactly.
+    candidates: list[tuple[datetime, str, dict[str, Any], str]] = []
+    for e in entries_page.items:
+        candidates.append((
+            e.provenance.written_at, "w",
+            {
+                "type": "write",
+                "entityPath": e.entity_path,
+                "key": e.key,
+                "version": e.version,
+                "confidence": e.confidence,
+                "timestamp": e.provenance.written_at.isoformat(),
+            },
+            encode_cursor(e.provenance.written_at, entry_tiebreak(e)),
+        ))
+    for t in traces_page.items:
+        # Traces without an outcome_ref are not shown, but they still
+        # advance the trace cursor so paging never stalls on a run of them.
+        item = {
             "type": "outcome",
             "outcomeRef": t.outcome_ref,
             "outcomeType": t.outcome_type,
             "causalEntryCount": len(t.causal_entries),
             "timestamp": t.created_at.isoformat(),
-        }
-        for t in traces if t.outcome_ref
-    ]
+        } if t.outcome_ref else None
+        candidates.append((t.created_at, "o", item, encode_cursor(t.created_at, t.id)))
+    for evt in events_page.items:
+        candidates.append((
+            evt.created_at, "e",
+            {
+                "type": (
+                    evt.event_type.value
+                    if hasattr(evt.event_type, "value")
+                    else str(evt.event_type)
+                ),
+                "summary": evt.summary,
+                "details": evt.details,
+                "actorAgentId": evt.actor_agent_id,
+                "timestamp": evt.created_at.isoformat(),
+            },
+            encode_cursor(evt.created_at, evt.id),
+        ))
 
-    events = mem._adapter.list_events(agent_id, mem.namespace, limit=limit)
-    event_items = [
-        {
-            "type": evt.event_type.value if hasattr(evt.event_type, "value") else str(evt.event_type),
-            "summary": evt.summary,
-            "details": evt.details,
-            "actorAgentId": evt.actor_agent_id,
-            "timestamp": evt.created_at.isoformat(),
-        }
-        for evt in events
-    ]
+    def _sort_ts(ts: datetime) -> datetime:
+        return ts if ts.tzinfo is not None else ts.replace(tzinfo=UTC)
 
-    timeline = sorted(
-        writes + outcomes + event_items,
-        key=lambda x: x["timestamp"],
-        reverse=True,
-    )[:limit]
-    return {"agentId": agent_id, "timeline": timeline}
+    candidates.sort(key=lambda c: (_sort_ts(c[0]), c[1]), reverse=True)
+
+    timeline: list[dict[str, Any]] = []
+    next_positions: dict[str, str | None] = dict(positions)
+    consumed = 0
+    for _, source, item, pos in candidates:
+        if len(timeline) >= limit:
+            break
+        next_positions[source] = pos
+        consumed += 1
+        if item is not None:
+            timeline.append(item)
+
+    leftover = len(candidates) - consumed
+    has_more = leftover > 0 or entries_page.has_more or traces_page.has_more or events_page.has_more
+    return {
+        "agentId": agent_id,
+        "timeline": timeline,
+        "next_cursor": _encode_activity_cursor(next_positions) if has_more else None,
+        "has_more": has_more,
+    }
 
 
 @app.get("/api/v1/agents/{agent_id:path}/timeline")
@@ -3308,26 +3537,37 @@ async def agent_timeline(
     agent_id: str,
     event_type: str | None = Query(None),
     since: str | None = Query(None),
-    limit: int = Query(100),
+    until: str | None = Query(None),
+    limit: int = Query(100, ge=1),
+    offset: int = Query(0, ge=0),
+    cursor: str | None = Query(None),
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
     """Git-like event log for an agent — every write, outcome, and
-    cross-agent read is recorded as an event on the agent's timeline."""
+    cross-agent read is recorded as an event on the agent's timeline.
+
+    Keyset-paginated: follow ``next_cursor`` while ``has_more`` is true.
+    ``offset`` is honoured only when no cursor is given.
+    """
     vis = _get_visibility_filter(request)
     if vis is not None and vis.should_filter() and not vis.is_agent_visible(agent_id):
         raise HTTPException(status_code=404, detail="Agent not found")
 
     mem = _get_memory()
-    since_dt = datetime.fromisoformat(since) if since else None
-    events = mem._adapter.list_events(
+    since_dt = _parse_ts(since)
+    until_dt = _parse_ts(until)
+    limit = clamp_limit(limit)
+    page = await _list_events_page(
         agent_id, mem.namespace,
         event_type=event_type,
-        since=since_dt, limit=limit,
+        since=since_dt, until=until_dt,
+        limit=limit, offset=offset, cursor=_check_cursor(cursor),
     )
     return {
         "agentId": agent_id,
-        "events": [e.model_dump(mode="json") for e in events],
-        "count": len(events),
+        "events": [e.model_dump(mode="json") for e in page.items],
+        "count": len(page.items),
+        **_page_meta(page),
     }
 
 
@@ -3915,7 +4155,9 @@ async def rollback(
     if target_event_id:
         event = mem._adapter.get_event(target_event_id, mem.namespace)
         if event is None and agent_id:
-            for e in mem._adapter.list_events(agent_id, mem.namespace, limit=10000):
+            # Fallback for adapters without get_event: a bounded scan of the
+            # agent's timeline, newest first, capped by AMFS_MAX_SCAN_ROWS.
+            for e in mem._adapter.list_events(agent_id, mem.namespace, limit=max_scan_rows()):
                 if e.id == target_event_id:
                     event = e
                     break
@@ -4930,7 +5172,14 @@ async def run_pattern_scan(
 
     mem = _get_memory()
     entries = mem.list(req.entity_path)
-    outcomes = mem._adapter.list_outcomes(entity_path=req.entity_path, limit=10000)
+    # Pattern detection is a whole-history analysis, so it reads a bounded
+    # window of outcomes (AMFS_MAX_SCAN_ROWS, newest first) and reports when
+    # the window was not the whole history.
+    scan_ceiling = max_scan_rows()
+    outcomes, outcomes_truncated = _bounded_scan(
+        mem._adapter.list_outcomes(entity_path=req.entity_path, limit=scan_ceiling + 1),
+        scan_ceiling,
+    )
 
     if req.agent_id:
         entries = [e for e in entries if e.provenance.agent_id == req.agent_id]
@@ -4993,6 +5242,7 @@ async def run_pattern_scan(
     return {
         "scannedEntries": report.scanned_entries,
         "scannedOutcomes": report.scanned_outcomes,
+        "outcomesTruncated": outcomes_truncated,
         "scanDurationMs": round(report.scan_duration_ms, 2),
         "patternsFound": len(report.patterns),
         "patternsPersisted": persisted,

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -2614,8 +2614,8 @@ async def list_traces(
     limit: int = Query(100, ge=1),
     offset: int = Query(0, ge=0),
     cursor: str | None = Query(None),
-    since: datetime | None = Query(None),
-    until: datetime | None = Query(None),
+    since: str | None = Query(None),
+    until: str | None = Query(None),
     _auth: str | None = Depends(verify_api_key),
 ) -> dict[str, Any]:
     """Decision traces, newest first, keyset-paginated.
@@ -2627,7 +2627,9 @@ async def list_traces(
 
     ``since`` (inclusive) and ``until`` (exclusive) bound ``created_at`` in
     the query itself, so a window that excludes the newest traces still
-    returns the older matches instead of an empty first page.
+    returns the older matches instead of an empty first page. Both go through
+    :func:`_parse_ts` like the sibling list routes: naive input is taken as
+    UTC rather than compared naive against aware timestamps.
     """
     limit = clamp_limit(limit)
     page = await _list_traces_page(
@@ -2637,8 +2639,8 @@ async def list_traces(
         limit=limit,
         offset=offset,
         cursor=_check_cursor(cursor),
-        since=since,
-        until=until,
+        since=_parse_ts(since),
+        until=_parse_ts(until),
     )
     traces = page.items
     allowed = _visible_agent_ids(request)

--- a/packages/http-server/src/amfs_http/server.py
+++ b/packages/http-server/src/amfs_http/server.py
@@ -34,6 +34,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from amfs import AgentMemory, MemoryType, OutcomeType
 from amfs.config import load_config_or_default
+from amfs.memory import validate_session_attributes
 from pydantic import BaseModel, Field
 from amfs_core.aggregates import REUSE_CREDIT_K
 from amfs_core.capture import scan_captured_arguments, scan_captured_text
@@ -2501,6 +2502,20 @@ async def commit_outcome(
             mem._adapter.ensure_agent(req.agent_id, mem.namespace)
         except Exception:
             pass
+    # The remote session's attribute bag and LLM calls, passed explicitly for
+    # the same reason ``tool_calls`` is: ``mem`` is shared, so nothing may be
+    # buffered on it between requests. Attributes are validated by
+    # ``commit_outcome``; a bad bag is a 422 here rather than a lost commit.
+    client_meta = req.session_metadata or {}
+    try:
+        client_attributes = validate_session_attributes(client_meta.get("attributes"))
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=422, detail=f"session_metadata.attributes: {exc}"
+        ) from exc
+    client_llm_calls = client_meta.get("llm_calls")
+    if not isinstance(client_llm_calls, list):
+        client_llm_calls = []
     try:
         entries = mem.commit_outcome(
             req.outcome_ref,
@@ -2517,6 +2532,8 @@ async def commit_outcome(
             # requests, so letting this fall through to its tracker would attribute
             # whatever actions happen to be buffered there to this caller.
             tool_calls=req.tool_calls,
+            attributes=client_attributes or None,
+            llm_calls=client_llm_calls or None,
         )
     finally:
         if original_agent is not None:

--- a/packages/mcp-server/src/amfs_mcp/server.py
+++ b/packages/mcp-server/src/amfs_mcp/server.py
@@ -2285,7 +2285,10 @@ def _http_api_call(method: str, path: str, *, params: dict | None = None, body: 
             resp = httpx.get(f"{base_url}{path}", params=params, headers=headers, timeout=30.0)
         else:
             resp = httpx.post(f"{base_url}{path}", params=params, json=body or {}, headers=headers, timeout=30.0)
-        if resp.status_code == 200:
+        if 200 <= resp.status_code < 300:
+            # 201 Created / 202 Accepted are success too; 204 has no body.
+            if resp.status_code == 204 or not resp.content:
+                return json.dumps({})
             return json.dumps(resp.json(), default=str)
         return json.dumps({"error": f"API returned {resp.status_code}", "detail": resp.text})
     except ImportError:

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -1407,8 +1407,12 @@ class AgentMemory:
         agent_id: str | None = None,
         outcome_type: str | None = None,
         limit: int = 100,
+        offset: int = 0,
+        cursor: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
     ) -> list[DecisionTrace]:
-        """Browse persisted decision traces from past sessions.
+        """Browse persisted decision traces from past sessions, newest first.
 
         Each trace is the full causal chain a committed outcome snapshotted:
         the reads, external contexts, recorded actions, and the outcome itself.
@@ -1419,6 +1423,13 @@ class AgentMemory:
             agent_id: Only traces committed by this agent.
             outcome_type: Filter by outcome (e.g. "success", "failure").
             limit: Maximum traces to return (default 100).
+            offset: Rows to skip; honoured only when no cursor is given.
+            cursor: Opaque keyset position from a previous page — pass
+                ``amfs_core.pagination.encode_cursor(last.created_at, last.id)``
+                (or the ``next_cursor`` an HTTP page returned) to get the
+                traces strictly older than the last one seen.
+            since: Only traces created at or after this time.
+            until: Only traces created before this time.
 
         Returns an empty list on adapters without trace persistence (e.g. the
         default filesystem adapter) — traces live in Postgres or the hosted API.
@@ -1428,6 +1439,10 @@ class AgentMemory:
             agent_id=agent_id,
             outcome_type=outcome_type,
             limit=limit,
+            offset=offset,
+            cursor=cursor,
+            since=since,
+            until=until,
         )
 
     def get_trace(self, trace_id: str) -> DecisionTrace | None:
@@ -1598,20 +1613,14 @@ class AgentMemory:
             # {'deploy-agent': [{'entity_path': 'checkout-service', 'key': 'retry-pattern', 'read_count': 3}]}
         """
         entries = self.list()
-        traces = self._adapter.list_traces(agent_id=self.agent_id, limit=10000)
 
         entry_authors: dict[str, str] = {}
         for e in entries:
             entry_authors[f"{e.entity_path}/{e.key}"] = e.provenance.agent_id
 
-        read_entities: dict[str, dict[str, int]] = {}
-        for t in traces:
-            for ce in t.causal_entries:
-                ep = ce.entity_path
-                key = ce.key
-                if ep not in read_entities:
-                    read_entities[ep] = {}
-                read_entities[ep][key] = read_entities[ep].get(key, 0) + 1
+        # Aggregated by the adapter (in SQL on Postgres) instead of pulling up
+        # to 10,000 full traces here to tally their causal_entries.
+        read_entities = self._adapter.trace_read_counts(self.agent_id)
 
         cross_reads: dict[str, list[dict[str, Any]]] = {}
         for ep, keys in read_entities.items():

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -86,6 +86,20 @@ SESSION_ATTRIBUTE_VALUE_MAX_LEN = 256
 _ATTRIBUTE_SCALARS = (str, int, float, bool)
 
 
+def _check_attribute_count(attributes: dict[str, Any], what: str = "session attributes") -> None:
+    """``ValueError`` when *attributes* holds more than ``SESSION_ATTRIBUTES_MAX_KEYS``.
+
+    Applied to each incoming bag and again to every merge (the session bag as
+    it grows, and the trace's bag of identity metadata + session bag + commit
+    attributes): a per-call check alone lets three bags of 20 become one of 60.
+    """
+    if len(attributes) > SESSION_ATTRIBUTES_MAX_KEYS:
+        raise ValueError(
+            f"at most {SESSION_ATTRIBUTES_MAX_KEYS} {what} are allowed "
+            f"(got {len(attributes)})"
+        )
+
+
 def validate_session_attributes(attributes: Any) -> dict[str, str | int | float | bool]:
     """The validated form of a session attribute bag, or ``ValueError``.
 
@@ -102,11 +116,7 @@ def validate_session_attributes(attributes: Any) -> dict[str, str | int | float 
         return {}
     if not isinstance(attributes, dict):
         raise TypeError("attributes must be a dict of scalar values")
-    if len(attributes) > SESSION_ATTRIBUTES_MAX_KEYS:
-        raise ValueError(
-            f"at most {SESSION_ATTRIBUTES_MAX_KEYS} session attributes are allowed "
-            f"(got {len(attributes)})"
-        )
+    _check_attribute_count(attributes)
     out: dict[str, str | int | float | bool] = {}
     for raw_key, value in attributes.items():
         key = str(raw_key).strip().lower()
@@ -1179,6 +1189,12 @@ class AgentMemory:
         explicit_calls = [
             c for c in (_normalize_llm_call(lc) for lc in (llm_calls or [])) if c is not None
         ]
+        # Built here, before the record leaves for the adapter: the server seals
+        # its trace from the outcome call, so the bag has to travel on it. This
+        # is also where the merged bag (session metadata + set_session_attributes
+        # + *attributes*) is checked against the key cap, so an oversized merge
+        # raises before anything is sent.
+        session_metadata = self._session_metadata_for_trace(commit_attributes, explicit_calls)
 
         if causal_entry_keys is None:
             causal_entry_keys = self._read_tracker.causal_keys
@@ -1218,6 +1234,7 @@ class AgentMemory:
             task_input=task_input,
             response_text=response_text,
             tool_calls=tool_calls,
+            session_metadata=_metadata_to_dict(session_metadata) or None,
         )
         updated = self._propagator.propagate(record)
 
@@ -1292,8 +1309,6 @@ class AgentMemory:
             entries_created=sum(1 for w in writes if w.get("is_new")),
             entries_updated=sum(1 for w in writes if not w.get("is_new")),
         )
-
-        session_metadata = self._session_metadata_for_trace(commit_attributes, explicit_calls)
 
         trace = DecisionTrace(
             agent_id=self.agent_id,
@@ -1375,6 +1390,10 @@ class AgentMemory:
         span tree a Pro recorder placed there, say — are kept, and so the trace
         holds its own instance rather than the one the session keeps mutating.
         ``None`` stays ``None`` when there is nothing to add.
+
+        Raises ``ValueError`` when the merged bag exceeds
+        ``SESSION_ATTRIBUTES_MAX_KEYS``: each source is capped on its own, so
+        only the merge can tell whether the trace's bag is within the limit.
         """
         data = _metadata_to_dict(self._session_metadata)
         existing_attrs = data.get(SESSION_ATTRIBUTES_KEY)
@@ -1383,6 +1402,7 @@ class AgentMemory:
             **self._session_attributes,
             **commit_attributes,
         }
+        _check_attribute_count(attributes, "the merged session attributes")
         existing_calls = data.get(SESSION_LLM_CALLS_KEY)
         llm_calls = [
             *(existing_calls if isinstance(existing_calls, list) else []),
@@ -1418,12 +1438,18 @@ class AgentMemory:
         string values up to 256 characters; anything else raises. Keys are
         lowercased. The bag is cleared when the trace is committed.
 
+        The key cap applies to the bag as merged, not to each call: a merge that
+        would take it past 20 keys raises ``ValueError`` and leaves the bag as
+        it was.
+
         Example::
 
             mem.set_session_attributes({"customer": "acme", "task_type": "deploy"})
         """
         validated = validate_session_attributes(attributes)
-        self._session_attributes.update(validated)
+        merged = {**self._session_attributes, **validated}
+        _check_attribute_count(merged, "the session attribute bag")
+        self._session_attributes = merged
         return dict(self._session_attributes)
 
     def record_llm_call(

--- a/packages/sdk-python/src/amfs/memory.py
+++ b/packages/sdk-python/src/amfs/memory.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import logging
 import math
 import threading
+import uuid
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
@@ -65,6 +66,125 @@ def _get_sdk_executor() -> ThreadPoolExecutor:
                     max_workers=1, thread_name_prefix="amfs-sdk-bg"
                 )
     return _sdk_bg_executor
+
+
+# ---------------------------------------------------------------------------
+# Session metadata extras: the attribute bag and the LLM-call list a session
+# collects for its trace. Both travel in ``DecisionTrace.session_metadata``
+# under the keys below, which is what the server lifts into the sealed trace.
+# ---------------------------------------------------------------------------
+
+SESSION_ATTRIBUTES_KEY = "attributes"
+SESSION_LLM_CALLS_KEY = "llm_calls"
+
+#: Attributes are dimensions to filter and group traces by (customer, task
+#: type, ...). They are indexed server-side, so the bag is kept small and flat.
+SESSION_ATTRIBUTES_MAX_KEYS = 20
+SESSION_ATTRIBUTE_KEY_MAX_LEN = 64
+SESSION_ATTRIBUTE_VALUE_MAX_LEN = 256
+
+_ATTRIBUTE_SCALARS = (str, int, float, bool)
+
+
+def validate_session_attributes(attributes: Any) -> dict[str, str | int | float | bool]:
+    """The validated form of a session attribute bag, or ``ValueError``.
+
+    Keys are stripped and lowercased (the server indexes them that way, so two
+    spellings of one dimension would otherwise never group together). Values
+    must be ``str``, ``int``, ``float`` or ``bool``; at most
+    ``SESSION_ATTRIBUTES_MAX_KEYS`` keys, each at most
+    ``SESSION_ATTRIBUTE_KEY_MAX_LEN`` characters, string values at most
+    ``SESSION_ATTRIBUTE_VALUE_MAX_LEN``. Rejected rather than trimmed: this is a
+    developer-facing API, and a silently shortened customer id is worse than an
+    error at the call site.
+    """
+    if attributes is None:
+        return {}
+    if not isinstance(attributes, dict):
+        raise TypeError("attributes must be a dict of scalar values")
+    if len(attributes) > SESSION_ATTRIBUTES_MAX_KEYS:
+        raise ValueError(
+            f"at most {SESSION_ATTRIBUTES_MAX_KEYS} session attributes are allowed "
+            f"(got {len(attributes)})"
+        )
+    out: dict[str, str | int | float | bool] = {}
+    for raw_key, value in attributes.items():
+        key = str(raw_key).strip().lower()
+        if not key:
+            raise ValueError("attribute keys must be non-empty strings")
+        if len(key) > SESSION_ATTRIBUTE_KEY_MAX_LEN:
+            raise ValueError(
+                f"attribute key {key[:20]!r}... exceeds {SESSION_ATTRIBUTE_KEY_MAX_LEN} characters"
+            )
+        if not isinstance(value, _ATTRIBUTE_SCALARS):
+            raise TypeError(
+                f"attribute {key!r} must be str, int, float or bool, "
+                f"not {type(value).__name__}"
+            )
+        if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+            raise ValueError(f"attribute {key!r} must be a finite number")
+        if isinstance(value, str) and len(value) > SESSION_ATTRIBUTE_VALUE_MAX_LEN:
+            raise ValueError(
+                f"attribute {key!r} exceeds {SESSION_ATTRIBUTE_VALUE_MAX_LEN} characters"
+            )
+        out[key] = value
+    return out
+
+
+def _normalize_llm_call(call: Any) -> dict[str, Any] | None:
+    """A JSON-safe LLM call record in the shape the trace pipeline reads
+    (``call_id``, ``model``, ``provider``, ``input_tokens``, ``output_tokens``,
+    ``cost_usd``, ``latency_ms``, ``started_at``), or ``None`` for an entry that
+    is not a usable call. Unknown keys are kept, so a richer client record
+    (cached tokens, finish reason, request id) travels intact."""
+    if not isinstance(call, dict):
+        return None
+    try:
+        input_tokens = int(call.get("input_tokens") or 0)
+        output_tokens = int(call.get("output_tokens") or 0)
+    except (TypeError, ValueError):
+        return None
+    model = call.get("model")
+    if not model and not input_tokens and not output_tokens:
+        return None
+    started_at = call.get("started_at")
+    if isinstance(started_at, datetime):
+        started_at = started_at.isoformat()
+    elif not isinstance(started_at, str) or not started_at:
+        started_at = datetime.now(UTC).isoformat()
+
+    def _num(value: Any) -> float | None:
+        if value is None:
+            return None
+        try:
+            out = float(value)
+        except (TypeError, ValueError):
+            return None
+        return out if math.isfinite(out) else None
+
+    normalized: dict[str, Any] = {
+        **call,
+        "call_id": str(call.get("call_id") or uuid.uuid4()),
+        "model": str(model or ""),
+        "provider": str(call.get("provider") or ""),
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cost_usd": _num(call.get("cost_usd")),
+        "latency_ms": _num(call.get("latency_ms")),
+        "started_at": started_at,
+    }
+    return normalized
+
+
+def _metadata_to_dict(meta: Any) -> dict[str, Any]:
+    """``session_metadata`` as a plain dict, extras included, whatever it is held as."""
+    if meta is None:
+        return {}
+    if hasattr(meta, "model_dump"):
+        return meta.model_dump(mode="json")
+    if isinstance(meta, dict):
+        return dict(meta)
+    return {}
 
 
 # ---------------------------------------------------------------------------
@@ -177,6 +297,10 @@ class AgentMemory:
         self._importance_evaluator = importance_evaluator
         self._branch = "main"
         self._session_metadata: SessionMetadata | None = None
+        # Buffered separately from ``_session_metadata`` — which callers (and the
+        # MCP server) reassign wholesale — and merged into it at commit time.
+        self._session_attributes: dict[str, str | int | float | bool] = {}
+        self._session_llm_calls: list[dict[str, Any]] = []
 
         self._lifecycle: LifecycleManager | None = None
         if ttl_sweep_interval is not None:
@@ -204,6 +328,16 @@ class AgentMemory:
     @session_metadata.setter
     def session_metadata(self, value: SessionMetadata | None) -> None:
         self._session_metadata = value
+
+    @property
+    def session_attributes(self) -> dict[str, str | int | float | bool]:
+        """The attribute bag the next ``commit_outcome`` will stamp on its trace."""
+        return dict(self._session_attributes)
+
+    @property
+    def session_llm_calls(self) -> list[dict[str, Any]]:
+        """The LLM calls recorded since the last ``commit_outcome``."""
+        return [dict(c) for c in self._session_llm_calls]
 
     @property
     def namespace(self) -> str:
@@ -1014,6 +1148,8 @@ class AgentMemory:
         task_input: str | None = None,
         response_text: str | None = None,
         tool_calls: list[dict[str, Any]] | None = None,
+        attributes: dict[str, Any] | None = None,
+        llm_calls: list[dict[str, Any]] | None = None,
     ) -> list[MemoryEntry]:
         """Record an outcome and back-propagate confidence changes.
 
@@ -1029,7 +1165,21 @@ class AgentMemory:
         to the session's own log, filled in by ``record_action``; pass a list to
         supply them directly, which is what the HTTP server does when relaying a
         remote client's actions.
+
+        *attributes* are merged over the bag built by ``set_session_attributes``
+        and stored in ``session_metadata["attributes"]`` — the dimensions the
+        trace can later be filtered and grouped by. *llm_calls* are appended to
+        the calls recorded with ``record_llm_call`` and stored in
+        ``session_metadata["llm_calls"]``; like *tool_calls*, the explicit form
+        exists for a server relaying a remote client's session. Both buffers are
+        cleared once the trace is built.
         """
+        # Validated first so a bad bag fails before anything is written.
+        commit_attributes = validate_session_attributes(attributes)
+        explicit_calls = [
+            c for c in (_normalize_llm_call(lc) for lc in (llm_calls or [])) if c is not None
+        ]
+
         if causal_entry_keys is None:
             causal_entry_keys = self._read_tracker.causal_keys
 
@@ -1143,6 +1293,8 @@ class AgentMemory:
             entries_updated=sum(1 for w in writes if not w.get("is_new")),
         )
 
+        session_metadata = self._session_metadata_for_trace(commit_attributes, explicit_calls)
+
         trace = DecisionTrace(
             agent_id=self.agent_id,
             session_id=self.session_id,
@@ -1159,7 +1311,7 @@ class AgentMemory:
             causal_entries=causal_trace_entries,
             external_contexts=ext_contexts,
             query_events=query_events,
-            session_metadata=self._session_metadata,
+            session_metadata=session_metadata,
             session_started_at=session_started,
             session_ended_at=now,
             session_duration_ms=session_duration,
@@ -1207,7 +1359,132 @@ class AgentMemory:
         # reinforces them again, and the trace's duration keeps growing from
         # process start rather than describing the work it covers.
         self._read_tracker.clear()
+        self._session_attributes = {}
+        self._session_llm_calls = []
         return updated
+
+    def _session_metadata_for_trace(
+        self,
+        commit_attributes: dict[str, Any],
+        explicit_calls: list[dict[str, Any]],
+    ) -> SessionMetadata | None:
+        """The metadata the trace carries: the session's own, with the attribute
+        bag and LLM calls merged in under ``attributes`` / ``llm_calls``.
+
+        Built from a dump of the current metadata so extras already on it — a
+        span tree a Pro recorder placed there, say — are kept, and so the trace
+        holds its own instance rather than the one the session keeps mutating.
+        ``None`` stays ``None`` when there is nothing to add.
+        """
+        data = _metadata_to_dict(self._session_metadata)
+        existing_attrs = data.get(SESSION_ATTRIBUTES_KEY)
+        attributes = {
+            **(existing_attrs if isinstance(existing_attrs, dict) else {}),
+            **self._session_attributes,
+            **commit_attributes,
+        }
+        existing_calls = data.get(SESSION_LLM_CALLS_KEY)
+        llm_calls = [
+            *(existing_calls if isinstance(existing_calls, list) else []),
+            *self._session_llm_calls,
+            *explicit_calls,
+        ]
+        if attributes:
+            data[SESSION_ATTRIBUTES_KEY] = attributes
+        else:
+            data.pop(SESSION_ATTRIBUTES_KEY, None)
+        if llm_calls:
+            data[SESSION_LLM_CALLS_KEY] = llm_calls
+        else:
+            data.pop(SESSION_LLM_CALLS_KEY, None)
+        if not data:
+            return None
+        try:
+            return SessionMetadata(**data)
+        except (TypeError, ValidationError):
+            logger.debug("session metadata could not be rebuilt; sending it as-is", exc_info=True)
+            return self._session_metadata
+
+    def set_session_attributes(
+        self, attributes: dict[str, Any]
+    ) -> dict[str, str | int | float | bool]:
+        """Merge *attributes* into the bag the next ``commit_outcome`` stamps on
+        its trace (``session_metadata["attributes"]``). Returns the bag as it
+        now stands.
+
+        Attributes are the dimensions a run is later filtered and grouped by —
+        ``customer``, ``task_type``, ``environment``. Scalars only (``str``,
+        ``int``, ``float``, ``bool``), at most 20 keys of up to 64 characters,
+        string values up to 256 characters; anything else raises. Keys are
+        lowercased. The bag is cleared when the trace is committed.
+
+        Example::
+
+            mem.set_session_attributes({"customer": "acme", "task_type": "deploy"})
+        """
+        validated = validate_session_attributes(attributes)
+        self._session_attributes.update(validated)
+        return dict(self._session_attributes)
+
+    def record_llm_call(
+        self,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        *,
+        cost_usd: float | None = None,
+        latency_ms: float | None = None,
+        provider: str | None = None,
+        call_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Record one LLM call for the trace the next ``commit_outcome`` builds.
+
+        Token counts and cost are only ever known if the agent reports them, so
+        this is what makes a trace's duration, token and cost figures real
+        rather than blank. Stored in ``session_metadata["llm_calls"]`` as::
+
+            {"call_id", "model", "provider", "input_tokens", "output_tokens",
+             "cost_usd", "latency_ms", "started_at"}
+
+        Returns the record as stored. Cleared when the trace is committed.
+
+        Example::
+
+            resp = client.chat.completions.create(...)
+            mem.record_llm_call(
+                resp.model, resp.usage.prompt_tokens, resp.usage.completion_tokens,
+                provider="openai", latency_ms=412.0,
+            )
+        """
+        if not isinstance(model, str) or not model:
+            raise ValueError("model must be a non-empty string")
+        try:
+            in_tokens = int(input_tokens)
+            out_tokens = int(output_tokens)
+        except (TypeError, ValueError) as exc:
+            raise TypeError("input_tokens and output_tokens must be integers") from exc
+        if in_tokens < 0 or out_tokens < 0:
+            raise ValueError("token counts must be non-negative")
+        for label, value in (("cost_usd", cost_usd), ("latency_ms", latency_ms)):
+            if value is not None and (
+                not isinstance(value, (int, float)) or isinstance(value, bool)
+                or not math.isfinite(float(value)) or value < 0
+            ):
+                raise ValueError(f"{label} must be a non-negative number or None")
+        record = _normalize_llm_call({
+            "call_id": call_id,
+            "model": model,
+            "provider": provider or "",
+            "input_tokens": in_tokens,
+            "output_tokens": out_tokens,
+            "cost_usd": cost_usd,
+            "latency_ms": latency_ms,
+            "started_at": datetime.now(UTC),
+        })
+        if record is None:  # pragma: no cover - a named model always normalises
+            raise ValueError("could not build an LLM call record")
+        self._session_llm_calls.append(record)
+        return dict(record)
 
     def _materialize_causal_edges(
         self,

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -13,10 +13,19 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {},
+  "peerDependencies": {
+    "openai": ">=4.0.0",
+    "@anthropic-ai/sdk": ">=0.20.0"
+  },
+  "peerDependenciesMeta": {
+    "openai": { "optional": true },
+    "@anthropic-ai/sdk": { "optional": true }
+  },
   "devDependencies": {
     "typescript": "^5.4",
     "vitest": "^3.1"

--- a/packages/sdk-typescript/src/__tests__/instrument.test.ts
+++ b/packages/sdk-typescript/src/__tests__/instrument.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgentMemory, instrumentAnthropic, instrumentOpenAI } from "../index.js";
+
+async function* stream<T>(chunks: T[], failAfter?: number): AsyncGenerator<T> {
+  let i = 0;
+  for (const c of chunks) {
+    if (failAfter !== undefined && i++ >= failAfter) throw new Error("stream broke");
+    yield c;
+  }
+}
+
+/** A stream that also carries a method, as the SDKs' `Stream` objects do. */
+function streamWithMethod<T>(chunks: T[]) {
+  const inner = stream(chunks);
+  return Object.assign(inner, { controller: { abort: vi.fn() } });
+}
+
+function chatResponse(model = "gpt-4o-mini", prompt = 100, completion = 20) {
+  return {
+    id: "chatcmpl-1",
+    model,
+    choices: [{ finish_reason: "stop", message: { content: "hi" } }],
+    usage: { prompt_tokens: prompt, completion_tokens: completion },
+  };
+}
+
+function fakeOpenAI(create: (...args: unknown[]) => unknown, responsesCreate?: (...a: unknown[]) => unknown) {
+  const client: Record<string, unknown> = { chat: { completions: { create } } };
+  if (responsesCreate) client.responses = { create: responsesCreate };
+  return client as {
+    chat: { completions: { create: (...args: unknown[]) => Promise<unknown> } };
+    responses?: { create: (...args: unknown[]) => Promise<unknown> };
+  };
+}
+
+describe("instrumentOpenAI", () => {
+  it("records a chat completion with model, tokens, latency and provider", async () => {
+    const mem = new AgentMemory("deploy-agent");
+    const create = vi.fn(async (params: unknown) => chatResponse());
+    const client = instrumentOpenAI(fakeOpenAI(create), mem);
+    expect(instrumentOpenAI(client, mem)).toBe(client); // idempotent
+
+    const out = (await client.chat.completions.create({
+      model: "gpt-4o-mini",
+      messages: [{ role: "user", content: "hi" }],
+    })) as ReturnType<typeof chatResponse>;
+    expect(out.choices[0].message.content).toBe("hi"); // untouched
+    expect(create).toHaveBeenCalledTimes(1);
+
+    const [call] = mem.sessionLlmCalls;
+    expect(call).toMatchObject({
+      model: "gpt-4o-mini", provider: "openai", input_tokens: 100, output_tokens: 20,
+    });
+    expect(call.latency_ms).toBeGreaterThanOrEqual(0);
+    expect(call.cost_usd).toBeNull(); // pricing is the server's job
+  });
+
+  it("uses the requested model when the response has none", async () => {
+    const mem = new AgentMemory("a");
+    const client = instrumentOpenAI(fakeOpenAI(async () => ({ usage: { prompt_tokens: 1, completion_tokens: 1 } })), mem);
+    await client.chat.completions.create({ model: "gpt-4o", messages: [] });
+    expect(mem.sessionLlmCalls[0].model).toBe("gpt-4o");
+  });
+
+  it("records a stream when it is exhausted, from the final usage chunk", async () => {
+    const mem = new AgentMemory("a");
+    const chunks = [
+      { id: "c", model: "gpt-4o-mini", choices: [{ delta: { content: "h" } }], usage: null },
+      { id: "c", model: "gpt-4o-mini", choices: [{ delta: { content: "i" }, finish_reason: "stop" }], usage: null },
+      { id: "c", model: "gpt-4o-mini", choices: [], usage: { prompt_tokens: 7, completion_tokens: 2 } },
+    ];
+    const s = streamWithMethod(chunks);
+    const client = instrumentOpenAI(fakeOpenAI(async () => s), mem);
+    const result = (await client.chat.completions.create({
+      model: "gpt-4o-mini", messages: [], stream: true,
+    })) as AsyncIterable<unknown> & { controller: { abort: () => void } };
+
+    expect(mem.sessionLlmCalls).toHaveLength(0); // not yet: the stream is still open
+    const seen: unknown[] = [];
+    for await (const chunk of result) seen.push(chunk);
+    expect(seen).toEqual(chunks);
+    expect(mem.sessionLlmCalls).toHaveLength(1);
+    expect(mem.sessionLlmCalls[0]).toMatchObject({ input_tokens: 7, output_tokens: 2, model: "gpt-4o-mini" });
+    result.controller.abort(); // other members are forwarded
+    expect(s.controller.abort).toHaveBeenCalled();
+  });
+
+  it("records a stream the consumer breaks out of, without tokens", async () => {
+    const mem = new AgentMemory("a");
+    const chunks = [{ model: "gpt-4o" }, { model: "gpt-4o" }, { model: "gpt-4o", usage: { prompt_tokens: 9, completion_tokens: 9 } }];
+    const client = instrumentOpenAI(fakeOpenAI(async () => stream(chunks)), mem);
+    const result = (await client.chat.completions.create({ model: "gpt-4o", stream: true })) as AsyncIterable<unknown>;
+    for await (const _ of result) break;
+    expect(mem.sessionLlmCalls).toHaveLength(1);
+    expect(mem.sessionLlmCalls[0]).toMatchObject({ model: "gpt-4o", input_tokens: 0, output_tokens: 0 });
+  });
+
+  it("records a failing stream as a failed call and rethrows", async () => {
+    const mem = new AgentMemory("a");
+    const client = instrumentOpenAI(fakeOpenAI(async () => stream([{ model: "gpt-4o" }, { model: "gpt-4o" }], 1)), mem);
+    const result = (await client.chat.completions.create({ model: "gpt-4o", stream: true })) as AsyncIterable<unknown>;
+    await expect((async () => { for await (const _ of result) { /* drain */ } })()).rejects.toThrow("stream broke");
+    expect(mem.sessionLlmCalls).toHaveLength(1);
+    expect(mem.sessionLlmCalls[0].error).toMatch(/stream broke/);
+  });
+
+  it("records a provider error and rethrows it unchanged", async () => {
+    const mem = new AgentMemory("a");
+    const boom = new Error("429 rate limited");
+    const client = instrumentOpenAI(fakeOpenAI(async () => { throw boom; }), mem);
+    await expect(client.chat.completions.create({ model: "gpt-4o", messages: [] })).rejects.toBe(boom);
+    const [call] = mem.sessionLlmCalls;
+    expect(call).toMatchObject({ model: "gpt-4o", input_tokens: 0, output_tokens: 0 });
+    expect(call.error).toContain("429");
+  });
+
+  it("instruments the Responses API, streaming included", async () => {
+    const mem = new AgentMemory("a");
+    const events = [
+      { type: "response.created", response: { id: "r", model: "gpt-4o" } },
+      { type: "response.output_text.delta", delta: "x" },
+      { type: "response.completed", response: { id: "r", model: "gpt-4o", usage: { input_tokens: 30, output_tokens: 10 } } },
+    ];
+    const responsesCreate = vi.fn(async (params: { stream?: boolean }) =>
+      params.stream ? stream(events) : { id: "r2", model: "gpt-4o-2024-08-06", usage: { input_tokens: 3, output_tokens: 4 } },
+    );
+    const client = instrumentOpenAI(fakeOpenAI(async () => chatResponse(), responsesCreate), mem);
+    await client.responses!.create({ model: "gpt-4o", input: "y" });
+    const s = (await client.responses!.create({ model: "gpt-4o", input: "x", stream: true })) as AsyncIterable<unknown>;
+    for await (const _ of s) { /* drain */ }
+    expect(mem.sessionLlmCalls.map((c) => [c.model, c.input_tokens, c.output_tokens])).toEqual([
+      ["gpt-4o-2024-08-06", 3, 4],
+      ["gpt-4o", 30, 10],
+    ]);
+  });
+
+  it("never breaks the call when the recorder throws", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const sink = { recordLlmCall: () => { throw new Error("recorder bug"); } };
+    const client = instrumentOpenAI(fakeOpenAI(async () => chatResponse()), sink);
+    const out = (await client.chat.completions.create({ model: "gpt-4o-mini", messages: [] })) as { id: string };
+    expect(out.id).toBe("chatcmpl-1");
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("tolerates a client without the resources", () => {
+    const mem = new AgentMemory("a");
+    const bare = {};
+    expect(instrumentOpenAI(bare, mem)).toBe(bare);
+  });
+
+  it("preserves `this` for SDK methods that rely on it", async () => {
+    const mem = new AgentMemory("a");
+    class Completions {
+      tag = "real";
+      async create(_params: unknown) {
+        return { model: `from-${this.tag}`, usage: { prompt_tokens: 1, completion_tokens: 1 } };
+      }
+    }
+    const client = { chat: { completions: new Completions() } };
+    instrumentOpenAI(client, mem);
+    await client.chat.completions.create({ model: "x" });
+    expect(mem.sessionLlmCalls[0].model).toBe("from-real");
+  });
+});
+
+describe("instrumentAnthropic", () => {
+  it("records messages.create, plain and streaming", async () => {
+    const mem = new AgentMemory("a");
+    const message = {
+      id: "msg_1", model: "claude-3-5-haiku-20241022", stop_reason: "end_turn",
+      usage: { input_tokens: 50, output_tokens: 25 }, content: [{ type: "text", text: "ok" }],
+    };
+    const events = [
+      { type: "message_start", message: { id: "msg_2", model: "claude-3-5-haiku-20241022", usage: { input_tokens: 8, output_tokens: 1 } } },
+      { type: "content_block_delta", delta: { type: "text_delta", text: "h" } },
+      { type: "message_delta", delta: { stop_reason: "max_tokens" }, usage: { output_tokens: 6 } },
+      { type: "message_stop" },
+    ];
+    const create = vi.fn(async (params: { stream?: boolean }) => (params.stream ? stream(events) : message));
+    const client = instrumentAnthropic({ messages: { create } }, mem);
+    expect(instrumentAnthropic(client, mem)).toBe(client);
+
+    const out = (await client.messages.create({ model: "claude-3-5-haiku-20241022", max_tokens: 100, messages: [] })) as typeof message;
+    expect(out.content[0].text).toBe("ok");
+    const s = (await client.messages.create({ model: "claude-3-5-haiku-20241022", max_tokens: 8, messages: [], stream: true })) as AsyncIterable<unknown>;
+    for await (const _ of s) { /* drain */ }
+
+    expect(mem.sessionLlmCalls.map((c) => [c.provider, c.model, c.input_tokens, c.output_tokens])).toEqual([
+      ["anthropic", "claude-3-5-haiku-20241022", 50, 25],
+      ["anthropic", "claude-3-5-haiku-20241022", 8, 6],
+    ]);
+  });
+});

--- a/packages/sdk-typescript/src/__tests__/session.test.ts
+++ b/packages/sdk-typescript/src/__tests__/session.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  AgentMemory,
+  HttpAdapter,
+  OutcomeType,
+  toDecisionTrace,
+  validateSessionAttributes,
+} from "../index.js";
+
+function mockFetch(responses: Array<{ status?: number; body: unknown }>) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fn = vi.fn(async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    const next = responses.shift() ?? { body: {} };
+    const status = next.status ?? 200;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => next.body,
+      text: async () => JSON.stringify(next.body),
+    } as unknown as Response;
+  });
+  vi.stubGlobal("fetch", fn);
+  return { calls, fn };
+}
+
+function body(call: { init?: RequestInit }): Record<string, unknown> {
+  return JSON.parse(String(call.init?.body)) as Record<string, unknown>;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("validateSessionAttributes", () => {
+  it("lowercases and trims keys and keeps scalars", () => {
+    expect(validateSessionAttributes({ " Customer ": "acme", N: 3, ok: true, f: 1.5 })).toEqual({
+      customer: "acme",
+      n: 3,
+      ok: true,
+      f: 1.5,
+    });
+    expect(validateSessionAttributes(undefined)).toEqual({});
+    expect(validateSessionAttributes(null)).toEqual({});
+  });
+
+  it("rejects rather than trims", () => {
+    expect(() => validateSessionAttributes([] as unknown)).toThrow(TypeError);
+    expect(() => validateSessionAttributes({ nested: { a: 1 } })).toThrow(TypeError);
+    expect(() => validateSessionAttributes({ nil: null })).toThrow(TypeError);
+    expect(() => validateSessionAttributes({ nan: Number.NaN })).toThrow(RangeError);
+    expect(() => validateSessionAttributes({ "": "x" })).toThrow(RangeError);
+    expect(() => validateSessionAttributes({ ["k".repeat(65)]: "x" })).toThrow(/64 characters/);
+    expect(() => validateSessionAttributes({ v: "x".repeat(257) })).toThrow(/256 characters/);
+    const many = Object.fromEntries(Array.from({ length: 21 }, (_, i) => [`k${i}`, i]));
+    expect(() => validateSessionAttributes(many)).toThrow(/at most 20/);
+  });
+});
+
+describe("AgentMemory session metadata", () => {
+  it("setSessionAttributes merges and validates", () => {
+    const mem = new AgentMemory("deploy-agent");
+    expect(mem.setSessionAttributes({ Customer: "acme" })).toEqual({ customer: "acme" });
+    expect(mem.setSessionAttributes({ task_type: "deploy" })).toEqual({
+      customer: "acme",
+      task_type: "deploy",
+    });
+    expect(() => mem.setSessionAttributes({ bad: [1] as unknown as string })).toThrow(TypeError);
+    // A rejected bag leaves the good one untouched, and the getter is a copy.
+    expect(mem.sessionAttributes).toEqual({ customer: "acme", task_type: "deploy" });
+    mem.sessionAttributes.customer = "mutated";
+    expect(mem.sessionAttributes.customer).toBe("acme");
+  });
+
+  it("recordLlmCall writes the wire record", () => {
+    const mem = new AgentMemory("deploy-agent");
+    const before = Date.now();
+    const rec = mem.recordLlmCall({
+      model: "gpt-4o-mini",
+      inputTokens: 100,
+      outputTokens: 20.9,
+      costUsd: 0.00003,
+      latencyMs: 412,
+      provider: "openai",
+    });
+    expect(rec).toMatchObject({
+      model: "gpt-4o-mini",
+      provider: "openai",
+      input_tokens: 100,
+      output_tokens: 20,
+      cost_usd: 0.00003,
+      latency_ms: 412,
+    });
+    expect(typeof rec.call_id).toBe("string");
+    expect(rec.call_id.length).toBeGreaterThan(8);
+    expect(Date.parse(rec.started_at)).toBeGreaterThanOrEqual(before - 1);
+    expect(Object.keys(rec).sort()).toEqual([
+      "call_id", "cost_usd", "input_tokens", "latency_ms", "model", "output_tokens",
+      "provider", "started_at",
+    ]);
+
+    const minimal = mem.recordLlmCall({ model: "claude-3-5-haiku", inputTokens: 1, outputTokens: 2 });
+    expect(minimal.cost_usd).toBeNull(); // unknown, not zero
+    expect(minimal.latency_ms).toBeNull();
+    expect(minimal.provider).toBe("");
+    expect(mem.sessionLlmCalls).toHaveLength(2);
+    expect(mem.sessionLlmCalls[0].call_id).toBe(rec.call_id);
+  });
+
+  it("recordLlmCall validates", () => {
+    const mem = new AgentMemory("deploy-agent");
+    expect(() => mem.recordLlmCall({ model: "", inputTokens: 1, outputTokens: 1 })).toThrow(TypeError);
+    expect(() =>
+      mem.recordLlmCall({ model: "m", inputTokens: -1, outputTokens: 1 }),
+    ).toThrow(RangeError);
+    expect(() =>
+      mem.recordLlmCall({ model: "m", inputTokens: "1" as unknown as number, outputTokens: 1 }),
+    ).toThrow(TypeError);
+    expect(() =>
+      mem.recordLlmCall({ model: "m", inputTokens: 1, outputTokens: 1, costUsd: -0.1 }),
+    ).toThrow(RangeError);
+    expect(() =>
+      mem.recordLlmCall({ model: "m", inputTokens: 1, outputTokens: 1, latencyMs: Number.NaN }),
+    ).toThrow(RangeError);
+    expect(mem.sessionLlmCalls).toEqual([]);
+  });
+
+  it("local commitOutcome accepts attributes and clears the session bag", () => {
+    const mem = new AgentMemory("deploy-agent");
+    mem.setSessionAttributes({ customer: "acme" });
+    mem.recordLlmCall({ model: "m", inputTokens: 1, outputTokens: 1 });
+    mem.commitOutcome("deploy-1", OutcomeType.SUCCESS, [], { attributes: { task_type: "deploy" } });
+    expect(mem.sessionAttributes).toEqual({});
+    expect(mem.sessionLlmCalls).toEqual([]);
+  });
+
+  it("commitOutcomeAsync sends attributes and llm_calls as session_metadata", async () => {
+    const { calls } = mockFetch([{ body: { ok: true } }, { body: { ok: true } }]);
+    const adapter = new HttpAdapter({ url: "http://amfs.test", apiKey: "k", agentId: "deploy-agent" });
+    const mem = new AgentMemory("deploy-agent", { adapter });
+
+    mem.setSessionAttributes({ customer: "acme" });
+    const call = mem.recordLlmCall({
+      model: "gpt-4o-mini", inputTokens: 10, outputTokens: 5, provider: "openai", latencyMs: 12,
+    });
+    await mem.commitOutcomeAsync("deploy-42", OutcomeType.SUCCESS, {
+      attributes: { Task_Type: "deploy" },
+    });
+
+    expect(calls[0].url).toBe("http://amfs.test/api/v1/outcomes");
+    const sent = body(calls[0]);
+    expect(sent.outcome_ref).toBe("deploy-42");
+    expect(sent.outcome_type).toBe("success");
+    expect(sent.session_metadata).toEqual({
+      attributes: { customer: "acme", task_type: "deploy" },
+      llm_calls: [call],
+    });
+
+    // Consumed by the commit: the next one describes a new run.
+    expect(mem.sessionAttributes).toEqual({});
+    expect(mem.sessionLlmCalls).toEqual([]);
+    await mem.commitOutcomeAsync("deploy-43", OutcomeType.FAILURE);
+    expect(body(calls[1])).not.toHaveProperty("session_metadata");
+  });
+
+  it("commitOutcomeAsync clears the bag even when the request fails", async () => {
+    mockFetch([{ status: 500, body: { detail: "boom" } }]);
+    const adapter = new HttpAdapter({ url: "http://amfs.test", apiKey: "k", agentId: "a" });
+    const mem = new AgentMemory("a", { adapter });
+    mem.setSessionAttributes({ customer: "acme" });
+    await expect(mem.commitOutcomeAsync("x", OutcomeType.SUCCESS)).rejects.toThrow();
+    expect(mem.sessionAttributes).toEqual({});
+  });
+
+  it("commitOutcomeAsync rejects a bad attribute bag before sending anything", async () => {
+    const { fn } = mockFetch([]);
+    const adapter = new HttpAdapter({ url: "http://amfs.test", apiKey: "k", agentId: "a" });
+    const mem = new AgentMemory("a", { adapter });
+    await expect(
+      mem.commitOutcomeAsync("x", OutcomeType.SUCCESS, { attributes: { nested: {} as never } }),
+    ).rejects.toThrow(TypeError);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+describe("toDecisionTrace session metadata", () => {
+  it("surfaces attributes and llm_calls from the wire", () => {
+    const trace = toDecisionTrace({
+      id: "t", agent_id: "a", session_id: "s", outcome_ref: "o", outcome_type: "success",
+      tool_calls: [], causal_entries: [], external_contexts: [], query_events: [], error_events: [],
+      created_at: "2026-09-05T00:00:00Z",
+      session_metadata: {
+        model: "gpt-4o",
+        attributes: { customer: "acme", n: 2, skip: { nested: true } },
+        llm_calls: [{ call_id: "c1", model: "gpt-4o", input_tokens: 1, output_tokens: 2 }],
+      },
+    });
+    expect(trace.sessionMetadata?.attributes).toEqual({ customer: "acme", n: 2 });
+    expect(trace.sessionMetadata?.llmCalls).toEqual([
+      { call_id: "c1", model: "gpt-4o", input_tokens: 1, output_tokens: 2 },
+    ]);
+  });
+
+  it("defaults them when an older server omits them", () => {
+    const trace = toDecisionTrace({
+      id: "t", agent_id: "a", session_id: "s", outcome_ref: "o", outcome_type: "success",
+      created_at: "2026-09-05T00:00:00Z", session_metadata: { model: "gpt-4o" },
+    });
+    expect(trace.sessionMetadata).toMatchObject({ model: "gpt-4o", attributes: {}, llmCalls: [] });
+  });
+});

--- a/packages/sdk-typescript/src/__tests__/session.test.ts
+++ b/packages/sdk-typescript/src/__tests__/session.test.ts
@@ -161,13 +161,63 @@ describe("AgentMemory session metadata", () => {
     expect(body(calls[1])).not.toHaveProperty("session_metadata");
   });
 
-  it("commitOutcomeAsync clears the bag even when the request fails", async () => {
-    mockFetch([{ status: 500, body: { detail: "boom" } }]);
+  it("commitOutcomeAsync keeps the bag when the server refuses the commit", async () => {
+    // A 422 for the bag, then a 5xx, then success: the attributes and LLM
+    // calls must survive both refusals and go out with the retry that lands.
+    const { calls } = mockFetch([
+      { status: 422, body: { detail: "session_metadata.attributes: bad" } },
+      { status: 500, body: { detail: "boom" } },
+      { body: { ok: true } },
+    ]);
     const adapter = new HttpAdapter({ url: "http://amfs.test", apiKey: "k", agentId: "a" });
     const mem = new AgentMemory("a", { adapter });
     mem.setSessionAttributes({ customer: "acme" });
+    const call = mem.recordLlmCall({ model: "m", inputTokens: 1, outputTokens: 1 });
+
     await expect(mem.commitOutcomeAsync("x", OutcomeType.SUCCESS)).rejects.toThrow();
+    expect(mem.sessionAttributes).toEqual({ customer: "acme" });
+    expect(mem.sessionLlmCalls).toEqual([call]);
+    await expect(mem.commitOutcomeAsync("x", OutcomeType.SUCCESS)).rejects.toThrow();
+    expect(mem.sessionAttributes).toEqual({ customer: "acme" });
+    expect(mem.sessionLlmCalls).toEqual([call]);
+
+    await mem.commitOutcomeAsync("x", OutcomeType.SUCCESS);
+    expect(body(calls[2]).session_metadata).toEqual({
+      attributes: { customer: "acme" },
+      llm_calls: [call],
+    });
     expect(mem.sessionAttributes).toEqual({});
+    expect(mem.sessionLlmCalls).toEqual([]);
+  });
+
+  it("setSessionAttributes caps the merged bag, not each call", () => {
+    const mem = new AgentMemory("a");
+    const first = Object.fromEntries(Array.from({ length: 15 }, (_, i) => [`a${i}`, i]));
+    mem.setSessionAttributes(first);
+    expect(() =>
+      mem.setSessionAttributes(Object.fromEntries(Array.from({ length: 15 }, (_, i) => [`b${i}`, i]))),
+    ).toThrow(RangeError);
+    expect(mem.sessionAttributes).toEqual(first);
+    // Keys already in the bag do not count twice.
+    expect(Object.keys(mem.setSessionAttributes({ a0: 99, a1: 98 }))).toHaveLength(15);
+    expect(
+      Object.keys(mem.setSessionAttributes(Object.fromEntries(Array.from({ length: 5 }, (_, i) => [`c${i}`, i])))),
+    ).toHaveLength(20);
+    expect(() => mem.setSessionAttributes({ one_too_many: true })).toThrow(/at most 20/);
+  });
+
+  it("commitOutcomeAsync rejects an over-cap merge before sending anything", async () => {
+    const { fn } = mockFetch([]);
+    const adapter = new HttpAdapter({ url: "http://amfs.test", apiKey: "k", agentId: "a" });
+    const mem = new AgentMemory("a", { adapter });
+    mem.setSessionAttributes(Object.fromEntries(Array.from({ length: 15 }, (_, i) => [`s${i}`, i])));
+    await expect(
+      mem.commitOutcomeAsync("x", OutcomeType.SUCCESS, {
+        attributes: Object.fromEntries(Array.from({ length: 15 }, (_, i) => [`c${i}`, i])),
+      }),
+    ).rejects.toThrow(RangeError);
+    expect(fn).not.toHaveBeenCalled();
+    expect(Object.keys(mem.sessionAttributes)).toHaveLength(15);
   });
 
   it("commitOutcomeAsync rejects a bad attribute bag before sending anything", async () => {

--- a/packages/sdk-typescript/src/__tests__/traces.test.ts
+++ b/packages/sdk-typescript/src/__tests__/traces.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentMemory, HttpAdapter, toDecisionTrace, toDecisionTracePage } from "../index.js";
+
+// Wire shape of a sealed trace, as GET /api/v1/traces/{id} returns it.
+const RAW_TRACE = {
+  id: "trace-1",
+  agent_id: "deploy-agent",
+  session_id: "sess-1",
+  outcome_ref: "deploy-v41",
+  outcome_type: "success",
+  decision_summary: "Rolled back checkout",
+  task_input: "checkout is returning 500s, roll back",
+  response_text: "Rolled checkout back to v41.",
+  tool_calls: [
+    {
+      tool_name: "deploy_rollback",
+      arguments: { service: "checkout", to_version: "v41", dry_run: false },
+      result_summary: "rolled back",
+      result_hash: "abc",
+      started_at: "2026-09-05T00:00:00Z",
+      duration_ms: 1200,
+      source: "deploy-cli",
+      success: true,
+    },
+  ],
+  session_metadata: {
+    model: "claude-4-opus",
+    client_name: "cursor",
+    platform: "darwin",
+    tools_available: ["amfs_write", "deploy_rollback"],
+    mcp_client_id: "c1",
+    mcp_session_id: null,
+  },
+  causal_entries: [
+    { entity_path: "shop/checkout", key: "runbook", version: 3, confidence: 0.9 },
+  ],
+  external_contexts: [{ label: "pagerduty", summary: "SEV-1 open", source: "PagerDuty" }],
+  query_events: [],
+  error_events: [],
+  state_diff: { entries_created: 1, entries_updated: 0 },
+  session_duration_ms: 4200,
+  created_at: "2026-09-05T00:01:00Z",
+};
+
+function mockFetch(responses: Array<{ status?: number; body: unknown }>) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fn = vi.fn(async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    const next = responses.shift() ?? { body: {} };
+    const status = next.status ?? 200;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => next.body,
+      text: async () => JSON.stringify(next.body),
+    } as unknown as Response;
+  });
+  vi.stubGlobal("fetch", fn);
+  return { calls, fn };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("toDecisionTrace", () => {
+  it("maps task_input, response_text, tool_calls and session_metadata", () => {
+    const trace = toDecisionTrace(RAW_TRACE);
+    expect(trace.id).toBe("trace-1");
+    expect(trace.agentId).toBe("deploy-agent");
+    expect(trace.taskInput).toBe("checkout is returning 500s, roll back");
+    expect(trace.responseText).toBe("Rolled checkout back to v41.");
+    expect(trace.toolCalls).toHaveLength(1);
+    expect(trace.toolCalls[0]).toEqual({
+      toolName: "deploy_rollback",
+      // caller-owned keys survive untouched
+      arguments: { service: "checkout", to_version: "v41", dry_run: false },
+      resultSummary: "rolled back",
+      resultHash: "abc",
+      startedAt: "2026-09-05T00:00:00Z",
+      durationMs: 1200,
+      source: "deploy-cli",
+      success: true,
+    });
+    expect(trace.sessionMetadata).toEqual({
+      model: "claude-4-opus",
+      clientName: "cursor",
+      platform: "darwin",
+      toolsAvailable: ["amfs_write", "deploy_rollback"],
+      mcpClientId: "c1",
+      mcpSessionId: null,
+    });
+    // The rest still goes through the generic converter.
+    expect(trace.causalEntries[0].entityPath).toBe("shop/checkout");
+    expect(trace.stateDiff).toEqual({ entriesCreated: 1, entriesUpdated: 0 });
+    expect(trace.createdAt).toBe("2026-09-05T00:01:00Z");
+  });
+
+  it("fills safe defaults for traces from servers that predate the fields", () => {
+    const { task_input, response_text, tool_calls, session_metadata, ...legacy } = RAW_TRACE;
+    void task_input;
+    void response_text;
+    void tool_calls;
+    void session_metadata;
+    const trace = toDecisionTrace(legacy);
+    expect(trace.taskInput).toBeNull();
+    expect(trace.responseText).toBeNull();
+    expect(trace.toolCalls).toEqual([]);
+    expect(trace.sessionMetadata).toBeNull();
+  });
+
+  it("tolerates partial tool calls", () => {
+    const trace = toDecisionTrace({ ...RAW_TRACE, tool_calls: [{ tool_name: "x", success: false }] });
+    expect(trace.toolCalls[0]).toMatchObject({
+      toolName: "x",
+      arguments: {},
+      durationMs: 0,
+      success: false,
+      source: null,
+    });
+  });
+});
+
+describe("toDecisionTracePage", () => {
+  it("reads the paged shape", () => {
+    const page = toDecisionTracePage({
+      traces: [RAW_TRACE],
+      next_cursor: "cur-2",
+      has_more: true,
+    });
+    expect(page.traces).toHaveLength(1);
+    expect(page.traces[0].agentId).toBe("deploy-agent");
+    expect(page.nextCursor).toBe("cur-2");
+    expect(page.hasMore).toBe(true);
+  });
+
+  it("accepts the legacy bare-array shape", () => {
+    const page = toDecisionTracePage([RAW_TRACE, RAW_TRACE]);
+    expect(page.traces).toHaveLength(2);
+    expect(page.nextCursor).toBeNull();
+    expect(page.hasMore).toBe(false);
+  });
+
+  it("applies since/until to createdAt client-side", () => {
+    const older = { ...RAW_TRACE, id: "old", created_at: "2026-08-01T00:00:00Z" };
+    const newer = { ...RAW_TRACE, id: "new", created_at: "2026-09-05T00:01:00Z" };
+    const body = { traces: [newer, older], next_cursor: null, has_more: false };
+
+    expect(toDecisionTracePage(body, { since: "2026-09-01T00:00:00Z" }).traces.map((t) => t.id))
+      .toEqual(["new"]);
+    expect(toDecisionTracePage(body, { until: new Date("2026-09-01T00:00:00Z") }).traces.map((t) => t.id))
+      .toEqual(["old"]);
+    // until is exclusive
+    expect(toDecisionTracePage(body, { until: "2026-09-05T00:01:00Z" }).traces.map((t) => t.id))
+      .toEqual(["old"]);
+  });
+});
+
+describe("HttpAdapter traces", () => {
+  it("listTracesPageAsync sends filters + cursor and returns page metadata", async () => {
+    const { calls } = mockFetch([
+      { body: { traces: [RAW_TRACE], next_cursor: "cur-2", has_more: true } },
+    ]);
+    const adapter = new HttpAdapter({ url: "https://api.test/", apiKey: "k" });
+    const page = await adapter.listTracesPageAsync({
+      agentId: "deploy-agent",
+      entityPath: "shop/checkout",
+      outcomeType: "success",
+      limit: 25,
+      cursor: "cur-1",
+      offset: 99, // ignored when a cursor is given
+    });
+    expect(page).toMatchObject({ nextCursor: "cur-2", hasMore: true });
+    expect(page.traces[0].id).toBe("trace-1");
+
+    const url = new URL(calls[0].url);
+    expect(url.pathname).toBe("/api/v1/traces");
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      entity_path: "shop/checkout",
+      agent_id: "deploy-agent",
+      outcome_type: "success",
+      limit: "25",
+      cursor: "cur-1",
+    });
+    expect((calls[0].init?.headers as Record<string, string>)["X-AMFS-API-Key"]).toBe("k");
+  });
+
+  it("uses offset only without a cursor", async () => {
+    const { calls } = mockFetch([{ body: { traces: [], next_cursor: null, has_more: false } }]);
+    const adapter = new HttpAdapter({ url: "https://api.test" });
+    await adapter.listTracesPageAsync({ offset: 10, limit: 5 });
+    expect(Object.fromEntries(new URL(calls[0].url).searchParams)).toEqual({
+      limit: "5",
+      offset: "10",
+    });
+  });
+
+  it("listTracesAsync keeps returning a flat array and follows a cursor when given one", async () => {
+    const { calls } = mockFetch([
+      { body: { traces: [RAW_TRACE], next_cursor: "cur-2", has_more: true } },
+      { body: { traces: [{ ...RAW_TRACE, id: "trace-2" }], next_cursor: null, has_more: false } },
+    ]);
+    const adapter = new HttpAdapter({ url: "https://api.test" });
+    const first = await adapter.listTracesAsync({ agentId: "deploy-agent" });
+    expect(Array.isArray(first)).toBe(true);
+    expect(first.map((t) => t.id)).toEqual(["trace-1"]);
+
+    const second = await adapter.listTracesAsync({ agentId: "deploy-agent", cursor: "cur-2" });
+    expect(second.map((t) => t.id)).toEqual(["trace-2"]);
+    expect(new URL(calls[1].url).searchParams.get("cursor")).toBe("cur-2");
+  });
+
+  it("walks every page via nextCursor / hasMore", async () => {
+    mockFetch([
+      { body: { traces: [{ ...RAW_TRACE, id: "a" }], next_cursor: "c1", has_more: true } },
+      { body: { traces: [{ ...RAW_TRACE, id: "b" }], next_cursor: "c2", has_more: true } },
+      { body: { traces: [{ ...RAW_TRACE, id: "c" }], next_cursor: null, has_more: false } },
+    ]);
+    const adapter = new HttpAdapter({ url: "https://api.test" });
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    for (;;) {
+      const page = await adapter.listTracesPageAsync({ limit: 1, cursor });
+      seen.push(...page.traces.map((t) => t.id));
+      if (!page.hasMore || !page.nextCursor) break;
+      cursor = page.nextCursor;
+    }
+    expect(seen).toEqual(["a", "b", "c"]);
+  });
+
+  it("getTraceAsync returns the mapped trace and null on 404", async () => {
+    mockFetch([{ body: RAW_TRACE }, { status: 404, body: { detail: "not found" } }]);
+    const adapter = new HttpAdapter({ url: "https://api.test" });
+    const trace = await adapter.getTraceAsync("trace-1");
+    expect(trace?.taskInput).toBe("checkout is returning 500s, roll back");
+    expect(trace?.toolCalls[0].arguments).toEqual({
+      service: "checkout",
+      to_version: "v41",
+      dry_run: false,
+    });
+    expect(trace?.sessionMetadata?.model).toBe("claude-4-opus");
+    expect(await adapter.getTraceAsync("missing")).toBeNull();
+  });
+});
+
+describe("AgentMemory trace facade", () => {
+  it("delegates listTracesAsync / listTracesPageAsync / getTraceAsync to the HTTP adapter", async () => {
+    mockFetch([
+      { body: { traces: [RAW_TRACE], next_cursor: "cur-2", has_more: true } },
+      { body: { traces: [RAW_TRACE], next_cursor: "cur-2", has_more: true } },
+      { body: RAW_TRACE },
+    ]);
+    const memory = new AgentMemory("deploy-agent", {
+      adapter: new HttpAdapter({ url: "https://api.test", apiKey: "k" }),
+    });
+    const flat = await memory.listTracesAsync({ since: "2026-09-01T00:00:00Z", limit: 10 });
+    expect(flat).toHaveLength(1);
+    const page = await memory.listTracesPageAsync({ cursor: "cur-1" });
+    expect(page.nextCursor).toBe("cur-2");
+    expect(page.hasMore).toBe(true);
+    const trace = await memory.getTraceAsync("trace-1");
+    expect(trace?.responseText).toBe("Rolled checkout back to v41.");
+  });
+
+  it("refuses without an HTTP adapter", async () => {
+    const memory = new AgentMemory("local");
+    await expect(memory.listTracesPageAsync()).rejects.toThrow(/requires a remote HTTP adapter/);
+  });
+});

--- a/packages/sdk-typescript/src/__tests__/traces.test.ts
+++ b/packages/sdk-typescript/src/__tests__/traces.test.ts
@@ -141,22 +141,33 @@ describe("toDecisionTracePage", () => {
     expect(page.hasMore).toBe(false);
   });
 
-  it("applies since/until to createdAt client-side", () => {
+  it("keeps every row the server returned — the window is the server's job", () => {
     const older = { ...RAW_TRACE, id: "old", created_at: "2026-08-01T00:00:00Z" };
     const newer = { ...RAW_TRACE, id: "new", created_at: "2026-09-05T00:01:00Z" };
     const body = { traces: [newer, older], next_cursor: null, has_more: false };
-
-    expect(toDecisionTracePage(body, { since: "2026-09-01T00:00:00Z" }).traces.map((t) => t.id))
-      .toEqual(["new"]);
-    expect(toDecisionTracePage(body, { until: new Date("2026-09-01T00:00:00Z") }).traces.map((t) => t.id))
-      .toEqual(["old"]);
-    // until is exclusive
-    expect(toDecisionTracePage(body, { until: "2026-09-05T00:01:00Z" }).traces.map((t) => t.id))
-      .toEqual(["old"]);
+    expect(toDecisionTracePage(body).traces.map((t) => t.id)).toEqual(["new", "old"]);
   });
 });
 
 describe("HttpAdapter traces", () => {
+  it("sends since/until as query parameters instead of filtering the page", async () => {
+    // A window that excludes the newest traces must reach the server: filtering
+    // the returned page would empty it and stop a cursor walk before the older
+    // matches were ever read.
+    const older = { ...RAW_TRACE, id: "old", created_at: "2026-08-01T00:00:00Z" };
+    const { calls } = mockFetch([{ body: { traces: [older], next_cursor: null, has_more: false } }]);
+    const adapter = new HttpAdapter({ url: "https://api.test" });
+    const page = await adapter.listTracesPageAsync({
+      since: "2026-07-01T00:00:00Z",
+      until: new Date("2026-09-01T00:00:00Z"),
+    });
+    expect(page.traces.map((t) => t.id)).toEqual(["old"]);
+    expect(Object.fromEntries(new URL(calls[0].url).searchParams)).toEqual({
+      since: "2026-07-01T00:00:00Z",
+      until: "2026-09-01T00:00:00.000Z",
+    });
+  });
+
   it("listTracesPageAsync sends filters + cursor and returns page metadata", async () => {
     const { calls } = mockFetch([
       { body: { traces: [RAW_TRACE], next_cursor: "cur-2", has_more: true } },

--- a/packages/sdk-typescript/src/__tests__/traces.test.ts
+++ b/packages/sdk-typescript/src/__tests__/traces.test.ts
@@ -89,6 +89,8 @@ describe("toDecisionTrace", () => {
       toolsAvailable: ["amfs_write", "deploy_rollback"],
       mcpClientId: "c1",
       mcpSessionId: null,
+      attributes: {},
+      llmCalls: [],
     });
     // The rest still goes through the generic converter.
     expect(trace.causalEntries[0].entityPath).toBe("shop/checkout");

--- a/packages/sdk-typescript/src/adapters/http.ts
+++ b/packages/sdk-typescript/src/adapters/http.ts
@@ -51,6 +51,12 @@ export class HttpAdapter implements AmfsAdapter {
     path: string,
     init?: RequestInit
   ): Promise<T> {
+    const raw = await this.fetchRaw(path, init);
+    return convertKeys(raw) as T;
+  }
+
+  /** Like `fetch` but returns the server's JSON untouched (snake_case keys). */
+  private async fetchRaw(path: string, init?: RequestInit): Promise<unknown> {
     const resp = await globalThis.fetch(`${this.baseUrl}${path}`, {
       ...init,
       headers: { ...this.headers, ...(init?.headers as Record<string, string>) },
@@ -59,8 +65,7 @@ export class HttpAdapter implements AmfsAdapter {
       const body = await resp.text().catch(() => "");
       throw new Error(`AMFS API ${resp.status}: ${body}`);
     }
-    const raw = await resp.json();
-    return convertKeys(raw) as T;
+    return resp.json();
   }
 
   read(
@@ -296,28 +301,42 @@ export class HttpAdapter implements AmfsAdapter {
     });
   }
 
-  async listTracesAsync(options?: {
-    entityPath?: string;
-    agentId?: string;
-    outcomeType?: string;
-    limit?: number;
-  }): Promise<DecisionTraceSummary[]> {
+  /**
+   * One page of decision traces, newest first, exactly as the server pages them.
+   *
+   * Mirrors GET /api/v1/traces: pass `cursor` (the previous page's `nextCursor`)
+   * to continue; `offset` is honoured only when no cursor is given. `since` and
+   * `until` are not server-side parameters — like the Python HttpAdapter, they
+   * are applied here to the page's `createdAt`, so a filtered page may hold fewer
+   * than `limit` rows while `hasMore` still reports the server's view.
+   */
+  async listTracesPageAsync(options?: ListTracesOptions): Promise<DecisionTracePage> {
     const params = new URLSearchParams();
     if (options?.entityPath) params.set("entity_path", options.entityPath);
     if (options?.agentId) params.set("agent_id", options.agentId);
     if (options?.outcomeType) params.set("outcome_type", options.outcomeType);
     if (options?.limit) params.set("limit", String(options.limit));
+    if (options?.cursor) params.set("cursor", options.cursor);
+    else if (options?.offset) params.set("offset", String(options.offset));
     const qs = params.toString();
-    const data = await this.fetch<{ traces: DecisionTraceSummary[] } | DecisionTraceSummary[]>(
-      `/api/v1/traces${qs ? `?${qs}` : ""}`
-    );
-    if (Array.isArray(data)) return data;
-    return data.traces ?? [];
+    const raw = await this.fetchRaw(`/api/v1/traces${qs ? `?${qs}` : ""}`);
+    return toDecisionTracePage(raw, options);
+  }
+
+  /**
+   * Decision traces as a flat array. Accepts the same paging options as
+   * {@link listTracesPageAsync}; use that method when you need `nextCursor` /
+   * `hasMore` to walk beyond one page.
+   */
+  async listTracesAsync(options?: ListTracesOptions): Promise<DecisionTraceSummary[]> {
+    const page = await this.listTracesPageAsync(options);
+    return page.traces;
   }
 
   async getTraceAsync(traceId: string): Promise<DecisionTrace | null> {
     try {
-      return await this.fetch<DecisionTrace>(`/api/v1/traces/${encodeURIComponent(traceId)}`);
+      const raw = await this.fetchRaw(`/api/v1/traces/${encodeURIComponent(traceId)}`);
+      return toDecisionTrace(raw);
     } catch {
       return null;
     }
@@ -449,6 +468,55 @@ export interface DecisionTraceSummary {
   createdAt: string;
 }
 
+/** Filters and paging for GET /api/v1/traces. */
+export interface ListTracesOptions {
+  entityPath?: string;
+  agentId?: string;
+  outcomeType?: string;
+  limit?: number;
+  /** Rows to skip; honoured only when no `cursor` is given. */
+  offset?: number;
+  /** Opaque keyset position — the `nextCursor` of the previous page. */
+  cursor?: string;
+  /** Only traces created at or after this instant (ISO-8601 string or Date). */
+  since?: string | Date;
+  /** Only traces created before this instant (ISO-8601 string or Date). */
+  until?: string | Date;
+}
+
+/** One page of GET /api/v1/traces. Follow `nextCursor` while `hasMore` is true. */
+export interface DecisionTracePage {
+  traces: DecisionTraceSummary[];
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
+/**
+ * An action the agent recorded during the session (`amfs_record_action`).
+ * `arguments` is passed through exactly as stored — its keys are the caller's,
+ * not the API's, so they are not converted to camelCase.
+ */
+export interface ToolCall {
+  toolName: string;
+  arguments: Record<string, unknown>;
+  resultSummary: string;
+  resultHash: string;
+  startedAt?: string;
+  durationMs: number;
+  source?: string | null;
+  success: boolean;
+}
+
+/** Which model, client and toolset produced the session's decisions. */
+export interface SessionMetadata {
+  model?: string | null;
+  clientName?: string | null;
+  platform?: string | null;
+  toolsAvailable: string[];
+  mcpClientId?: string | null;
+  mcpSessionId?: string | null;
+}
+
 export interface DecisionTrace {
   id: string;
   agentId: string;
@@ -456,6 +524,13 @@ export interface DecisionTrace {
   outcomeRef: string;
   outcomeType: string;
   decisionSummary?: string;
+  /** The request that started the work, as it arrived (may be redacted). */
+  taskInput?: string | null;
+  /** The agent's answer, when it was captured. */
+  responseText?: string | null;
+  /** Actions the agent recorded; empty for read/write-only sessions. */
+  toolCalls: ToolCall[];
+  sessionMetadata?: SessionMetadata | null;
   causalEntries: Array<{
     entityPath: string;
     key: string;
@@ -494,4 +569,104 @@ export interface DecisionTrace {
   sessionEndedAt?: string;
   sessionDurationMs?: number;
   createdAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Trace mappers (snake_case wire → camelCase SDK types)
+// ---------------------------------------------------------------------------
+
+type Raw = Record<string, unknown>;
+
+function asRecord(value: unknown): Raw {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Raw)
+    : {};
+}
+
+function toToolCall(raw: unknown): ToolCall {
+  const r = asRecord(raw);
+  return {
+    toolName: String(r.tool_name ?? ""),
+    // Caller-owned keys: never camelCased.
+    arguments: asRecord(r.arguments),
+    resultSummary: String(r.result_summary ?? ""),
+    resultHash: String(r.result_hash ?? ""),
+    startedAt: typeof r.started_at === "string" ? r.started_at : undefined,
+    durationMs: typeof r.duration_ms === "number" ? r.duration_ms : 0,
+    source: (r.source as string | null | undefined) ?? null,
+    success: r.success !== false,
+  };
+}
+
+function toSessionMetadata(raw: unknown): SessionMetadata | null {
+  if (raw === null || raw === undefined) return null;
+  const r = asRecord(raw);
+  return {
+    model: (r.model as string | null | undefined) ?? null,
+    clientName: (r.client_name as string | null | undefined) ?? null,
+    platform: (r.platform as string | null | undefined) ?? null,
+    toolsAvailable: Array.isArray(r.tools_available) ? r.tools_available.map(String) : [],
+    mcpClientId: (r.mcp_client_id as string | null | undefined) ?? null,
+    mcpSessionId: (r.mcp_session_id as string | null | undefined) ?? null,
+  };
+}
+
+/**
+ * Map a raw (snake_case) trace from the server to a `DecisionTrace`.
+ *
+ * The bulk of the object goes through the generic key converter, as before;
+ * the fields the converter would get wrong are set explicitly afterwards:
+ * `toolCalls[].arguments` must keep the caller's own keys, and
+ * `taskInput` / `responseText` / `sessionMetadata` must exist (null, not
+ * undefined) so consumers can distinguish "not captured" from "old server".
+ */
+export function toDecisionTrace(raw: unknown): DecisionTrace {
+  const r = asRecord(raw);
+  const converted = convertKeys(r) as Raw;
+  const toolCalls = Array.isArray(r.tool_calls) ? r.tool_calls.map(toToolCall) : [];
+  return {
+    ...(converted as unknown as DecisionTrace),
+    taskInput: (r.task_input as string | null | undefined) ?? null,
+    responseText: (r.response_text as string | null | undefined) ?? null,
+    toolCalls,
+    sessionMetadata: toSessionMetadata(r.session_metadata),
+  };
+}
+
+function toInstant(value: string | Date | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const ms = value instanceof Date ? value.getTime() : Date.parse(value);
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
+/** Map a raw GET /api/v1/traces body (new page shape or legacy array) to a page. */
+export function toDecisionTracePage(
+  raw: unknown,
+  options?: Pick<ListTracesOptions, "since" | "until">
+): DecisionTracePage {
+  const rows: unknown[] = Array.isArray(raw)
+    ? raw
+    : Array.isArray(asRecord(raw).traces)
+      ? (asRecord(raw).traces as unknown[])
+      : [];
+  const body = Array.isArray(raw) ? {} : asRecord(raw);
+  let traces = rows.map((t) => toDecisionTrace(t) as unknown as DecisionTraceSummary);
+
+  const since = toInstant(options?.since);
+  const until = toInstant(options?.until);
+  if (since !== undefined || until !== undefined) {
+    traces = traces.filter((t) => {
+      const created = Date.parse(t.createdAt);
+      if (Number.isNaN(created)) return true;
+      if (since !== undefined && created < since) return false;
+      if (until !== undefined && created >= until) return false;
+      return true;
+    });
+  }
+
+  return {
+    traces,
+    nextCursor: typeof body.next_cursor === "string" ? body.next_cursor : null,
+    hasMore: body.has_more === true,
+  };
 }

--- a/packages/sdk-typescript/src/adapters/http.ts
+++ b/packages/sdk-typescript/src/adapters/http.ts
@@ -305,10 +305,10 @@ export class HttpAdapter implements AmfsAdapter {
    * One page of decision traces, newest first, exactly as the server pages them.
    *
    * Mirrors GET /api/v1/traces: pass `cursor` (the previous page's `nextCursor`)
-   * to continue; `offset` is honoured only when no cursor is given. `since` and
-   * `until` are not server-side parameters — like the Python HttpAdapter, they
-   * are applied here to the page's `createdAt`, so a filtered page may hold fewer
-   * than `limit` rows while `hasMore` still reports the server's view.
+   * to continue; `offset` is honoured only when no cursor is given. `since`
+   * (inclusive) and `until` (exclusive) are sent to the server and bound the
+   * query itself, so a window that excludes the newest traces still returns
+   * the older matches rather than an empty first page.
    */
   async listTracesPageAsync(options?: ListTracesOptions): Promise<DecisionTracePage> {
     const params = new URLSearchParams();
@@ -318,9 +318,13 @@ export class HttpAdapter implements AmfsAdapter {
     if (options?.limit) params.set("limit", String(options.limit));
     if (options?.cursor) params.set("cursor", options.cursor);
     else if (options?.offset) params.set("offset", String(options.offset));
+    const since = toIsoString(options?.since);
+    const until = toIsoString(options?.until);
+    if (since) params.set("since", since);
+    if (until) params.set("until", until);
     const qs = params.toString();
     const raw = await this.fetchRaw(`/api/v1/traces${qs ? `?${qs}` : ""}`);
-    return toDecisionTracePage(raw, options);
+    return toDecisionTracePage(raw);
   }
 
   /**
@@ -633,36 +637,22 @@ export function toDecisionTrace(raw: unknown): DecisionTrace {
   };
 }
 
-function toInstant(value: string | Date | undefined): number | undefined {
+/** ISO-8601 for a query parameter; `undefined` when absent or unparseable. */
+function toIsoString(value: string | Date | undefined): string | undefined {
   if (value === undefined) return undefined;
-  const ms = value instanceof Date ? value.getTime() : Date.parse(value);
-  return Number.isNaN(ms) ? undefined : ms;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? undefined : value.toISOString();
+  return Number.isNaN(Date.parse(value)) ? undefined : value;
 }
 
 /** Map a raw GET /api/v1/traces body (new page shape or legacy array) to a page. */
-export function toDecisionTracePage(
-  raw: unknown,
-  options?: Pick<ListTracesOptions, "since" | "until">
-): DecisionTracePage {
+export function toDecisionTracePage(raw: unknown): DecisionTracePage {
   const rows: unknown[] = Array.isArray(raw)
     ? raw
     : Array.isArray(asRecord(raw).traces)
       ? (asRecord(raw).traces as unknown[])
       : [];
   const body = Array.isArray(raw) ? {} : asRecord(raw);
-  let traces = rows.map((t) => toDecisionTrace(t) as unknown as DecisionTraceSummary);
-
-  const since = toInstant(options?.since);
-  const until = toInstant(options?.until);
-  if (since !== undefined || until !== undefined) {
-    traces = traces.filter((t) => {
-      const created = Date.parse(t.createdAt);
-      if (Number.isNaN(created)) return true;
-      if (since !== undefined && created < since) return false;
-      if (until !== undefined && created >= until) return false;
-      return true;
-    });
-  }
+  const traces = rows.map((t) => toDecisionTrace(t) as unknown as DecisionTraceSummary);
 
   return {
     traces,

--- a/packages/sdk-typescript/src/adapters/http.ts
+++ b/packages/sdk-typescript/src/adapters/http.ts
@@ -234,6 +234,11 @@ export class HttpAdapter implements AmfsAdapter {
     causalEntryKeys?: string[];
     causalConfidence?: number;
     agentId?: string;
+    /**
+     * Already in wire shape (`attributes`, `llm_calls`, ...); the server lifts
+     * these onto the trace it seals for this outcome.
+     */
+    sessionMetadata?: Record<string, unknown>;
   }): Promise<unknown> {
     const agentId = record.agentId ?? this.agentId;
     return this.fetch("/api/v1/outcomes", {
@@ -245,6 +250,9 @@ export class HttpAdapter implements AmfsAdapter {
         ...(record.causalEntryKeys?.length ? { causal_entry_keys: record.causalEntryKeys } : {}),
         ...(record.causalConfidence != null ? { causal_confidence: record.causalConfidence } : {}),
         ...(agentId ? { agent_id: agentId } : {}),
+        ...(record.sessionMetadata && Object.keys(record.sessionMetadata).length
+          ? { session_metadata: record.sessionMetadata }
+          : {}),
       }),
     });
   }
@@ -519,6 +527,10 @@ export interface SessionMetadata {
   toolsAvailable: string[];
   mcpClientId?: string | null;
   mcpSessionId?: string | null;
+  /** The run's dimensions (`customer`, `task_type`, ...), when any were set. */
+  attributes: Record<string, string | number | boolean>;
+  /** LLM calls recorded for the run, in wire shape (snake_case keys). */
+  llmCalls: Array<Record<string, unknown>>;
 }
 
 export interface DecisionTrace {
@@ -612,7 +624,18 @@ function toSessionMetadata(raw: unknown): SessionMetadata | null {
     toolsAvailable: Array.isArray(r.tools_available) ? r.tools_available.map(String) : [],
     mcpClientId: (r.mcp_client_id as string | null | undefined) ?? null,
     mcpSessionId: (r.mcp_session_id as string | null | undefined) ?? null,
+    attributes: toAttributeBag(r.attributes),
+    // Caller-owned records: keys stay as the wire has them.
+    llmCalls: Array.isArray(r.llm_calls) ? r.llm_calls.map(asRecord) : [],
   };
+}
+
+function toAttributeBag(raw: unknown): Record<string, string | number | boolean> {
+  const out: Record<string, string | number | boolean> = {};
+  for (const [k, v] of Object.entries(asRecord(raw))) {
+    if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") out[k] = v;
+  }
+  return out;
 }
 
 /**

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -7,8 +7,16 @@ export type { AgentMemoryOptions, SearchOptions, MemoryStats } from "./memory.js
 export type { AmfsAdapter, WatchHandle } from "./adapter.js";
 export { createWatchHandle } from "./adapter.js";
 export { InMemoryAdapter } from "./adapters/filesystem.js";
-export { HttpAdapter } from "./adapters/http.js";
-export type { HttpAdapterOptions, DecisionTrace, DecisionTraceSummary } from "./adapters/http.js";
+export { HttpAdapter, toDecisionTrace, toDecisionTracePage } from "./adapters/http.js";
+export type {
+  HttpAdapterOptions,
+  DecisionTrace,
+  DecisionTraceSummary,
+  DecisionTracePage,
+  ListTracesOptions,
+  ToolCall,
+  SessionMetadata,
+} from "./adapters/http.js";
 export { CausalTagger, CoWEngine } from "./engine.js";
 export { ReadTracker } from "./tracker.js";
 export type { ExternalContext } from "./tracker.js";

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -17,6 +17,20 @@ export type {
   ToolCall,
   SessionMetadata,
 } from "./adapters/http.js";
+export {
+  validateSessionAttributes,
+  SESSION_ATTRIBUTES_MAX_KEYS,
+  SESSION_ATTRIBUTE_KEY_MAX_LEN,
+  SESSION_ATTRIBUTE_VALUE_MAX_LEN,
+} from "./session.js";
+export type {
+  AttributeValue,
+  SessionAttributes,
+  RecordLlmCallInput,
+  LlmCallRecord,
+} from "./session.js";
+export { instrumentOpenAI, instrumentAnthropic } from "./instrument/index.js";
+export type { LlmCallSink } from "./instrument/index.js";
 export { CausalTagger, CoWEngine } from "./engine.js";
 export { ReadTracker } from "./tracker.js";
 export type { ExternalContext } from "./tracker.js";

--- a/packages/sdk-typescript/src/instrument/anthropic.ts
+++ b/packages/sdk-typescript/src/instrument/anthropic.ts
@@ -1,0 +1,53 @@
+/**
+ * `instrumentAnthropic(client, memory)` — every `messages.create` on the
+ * `@anthropic-ai/sdk` client is recorded with `memory.recordLlmCall`.
+ *
+ * Streaming calls (`stream: true`) are recorded when the stream ends: input
+ * tokens come from `message_start`, output tokens from the final
+ * `message_delta`. The `messages.stream()` helper is not patched; iterate
+ * `create({ stream: true })` or call `memory.recordLlmCall` by hand.
+ * `@anthropic-ai/sdk` is an optional peer and is not imported here.
+ */
+
+import type { Extractor, LlmCallSink, Usage } from "./common.js";
+import { asInt, get, isInstrumented, markInstrumented, patchMethod, resolve } from "./common.js";
+
+const PROVIDER = "anthropic";
+
+function readUsage(u: unknown, usage: Usage, outputOnly = false): void {
+  if (!u) return;
+  if (!outputOnly) {
+    const inTok = asInt(get(u, "input_tokens"));
+    if (inTok !== undefined) usage.inputTokens = inTok;
+  }
+  const outTok = asInt(get(u, "output_tokens"));
+  if (outTok !== undefined) usage.outputTokens = outTok;
+}
+
+export const extractMessage: Extractor = (message, usage) => {
+  const model = get(message, "model");
+  if (typeof model === "string" && model) usage.model = model;
+  readUsage(get(message, "usage"), usage);
+};
+
+export const extractMessageEvent: Extractor = (event, usage) => {
+  const type = String(get(event, "type") ?? "");
+  if (type === "message_start") extractMessage(get(event, "message"), usage);
+  else if (type === "message_delta") readUsage(get(event, "usage"), usage, true);
+};
+
+/** Instrument an Anthropic client in place and return it. Idempotent. */
+export function instrumentAnthropic<C>(client: C, memory: LlmCallSink): C {
+  if (isInstrumented(client)) return client;
+  const messages = resolve(client, ["messages"]);
+  if (messages) {
+    patchMethod(messages, "create", {
+      provider: PROVIDER,
+      sink: memory,
+      extract: extractMessage,
+      onChunk: extractMessageEvent,
+    });
+  }
+  markInstrumented(client);
+  return client;
+}

--- a/packages/sdk-typescript/src/instrument/common.ts
+++ b/packages/sdk-typescript/src/instrument/common.ts
@@ -1,0 +1,206 @@
+/**
+ * Shared machinery for the provider instrumentations.
+ *
+ * Each `instrument*` function replaces a client method on the *instance* with a
+ * wrapper that times the call, reads token usage off the response (or, for a
+ * stream, accumulates it while the caller iterates and records when the stream
+ * ends) and hands the result to `memory.recordLlmCall`. The wrapped call is
+ * never altered: an instrumentation failure is logged and swallowed, an error
+ * from the provider is recorded as a failed call and re-thrown unchanged.
+ *
+ * Responses are read by duck typing, so neither `openai` nor `@anthropic-ai/sdk`
+ * is imported — they are optional peers — and tests drive the wrappers with
+ * plain objects.
+ */
+
+import type { RecordLlmCallInput } from "../session.js";
+
+/** The one method of `AgentMemory` the instrumentations need. */
+export interface LlmCallSink {
+  recordLlmCall(call: RecordLlmCallInput, startedAt?: Date): unknown;
+}
+
+export interface Usage {
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+export type Extractor = (response: unknown, usage: Usage) => void;
+
+const FLAG = "__amfsInstrumented";
+
+export function isInstrumented(target: unknown): boolean {
+  return Boolean((target as Record<string, unknown> | null)?.[FLAG]);
+}
+
+export function markInstrumented(target: unknown): void {
+  try {
+    Object.defineProperty(target, FLAG, { value: true, enumerable: false, configurable: true });
+  } catch {
+    // frozen or proxy — nothing to do
+  }
+}
+
+export function get(obj: unknown, key: string): unknown {
+  if (obj === null || obj === undefined) return undefined;
+  return (obj as Record<string, unknown>)[key];
+}
+
+export function asInt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.trunc(value);
+}
+
+export function resolve(target: unknown, path: string[]): unknown {
+  let obj = target;
+  for (const hop of path) {
+    obj = get(obj, hop);
+    if (obj === null || obj === undefined) return undefined;
+  }
+  return obj;
+}
+
+function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as Record<PropertyKey, unknown>)[Symbol.asyncIterator] === "function"
+  );
+}
+
+function warn(message: string, err: unknown): void {
+  try {
+    console.warn(`[amfs] ${message}`, err);
+  } catch {
+    // no console — stay silent
+  }
+}
+
+class Call {
+  readonly startedAt = new Date();
+  private readonly t0 = performance.now();
+  private done = false;
+
+  constructor(
+    private readonly sink: LlmCallSink,
+    private readonly provider: string,
+    private readonly requestedModel: string | undefined,
+  ) {}
+
+  record(usage: Usage, error?: unknown): void {
+    if (this.done) return;
+    this.done = true;
+    const latencyMs = performance.now() - this.t0;
+    try {
+      const model = usage.model || this.requestedModel || "";
+      if (!model) return; // nothing to attribute the call to
+      this.sink.recordLlmCall(
+        {
+          model,
+          provider: this.provider,
+          inputTokens: usage.inputTokens ?? 0,
+          outputTokens: usage.outputTokens ?? 0,
+          latencyMs,
+          ...(error !== undefined ? { error: String(error) } : {}),
+        },
+        this.startedAt,
+      );
+    } catch (err) {
+      warn(`${this.provider} instrumentation: could not record call`, err);
+    }
+  }
+}
+
+/**
+ * Wrap an async iterable so its chunks are observed and the call is recorded
+ * once the stream is exhausted, breaks, or is returned early. Every other
+ * property (e.g. `controller`, `finalMessage()`) is forwarded to the original.
+ */
+function proxyStream(inner: AsyncIterable<unknown>, call: Call, onChunk: Extractor): unknown {
+  const usage: Usage = {};
+  const iterate = async function* () {
+    try {
+      for await (const chunk of inner) {
+        try {
+          onChunk(chunk, usage);
+        } catch (err) {
+          warn("stream chunk extraction failed", err);
+        }
+        yield chunk;
+      }
+      call.record(usage);
+    } catch (err) {
+      call.record(usage, err);
+      throw err;
+    } finally {
+      call.record(usage); // early `return()` / `break` lands here
+    }
+  };
+  return new Proxy(inner as object, {
+    get(target, prop, receiver) {
+      if (prop === Symbol.asyncIterator) return () => iterate();
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+export interface PatchOptions {
+  provider: string;
+  sink: LlmCallSink;
+  /** Reads usage from a complete response. */
+  extract: Extractor;
+  /** Reads usage from one stream chunk, accumulating into the usage. */
+  onChunk: Extractor;
+}
+
+/**
+ * Replace `owner[method]` with an instrumented wrapper. Returns whether anything
+ * was patched (`false` when the method is missing or already wrapped).
+ *
+ * The provider SDKs return a promise-like (`APIPromise`) from `create`; the
+ * wrapper awaits it, so callers always get a plain `Promise`. `stream: true`
+ * calls resolve to an async iterable, which is proxied.
+ */
+export function patchMethod(owner: unknown, method: string, options: PatchOptions): boolean {
+  if (owner === null || typeof owner !== "object") return false;
+  const holder = owner as Record<string, unknown>;
+  const original = holder[method];
+  if (typeof original !== "function" || isInstrumented(original)) return false;
+
+  const wrapper = async function (this: unknown, ...args: unknown[]): Promise<unknown> {
+    const params = (args[0] ?? {}) as Record<string, unknown>;
+    const call = new Call(
+      options.sink,
+      options.provider,
+      typeof params.model === "string" ? params.model : undefined,
+    );
+    let result: unknown;
+    try {
+      result = await (original as (...a: unknown[]) => unknown).apply(this ?? owner, args);
+    } catch (err) {
+      call.record({}, err);
+      throw err;
+    }
+    try {
+      if (params.stream === true && isAsyncIterable(result)) {
+        return proxyStream(result, call, options.onChunk);
+      }
+      const usage: Usage = {};
+      options.extract(result, usage);
+      call.record(usage);
+    } catch (err) {
+      warn(`${options.provider} instrumentation failed; call unaffected`, err);
+    }
+    return result;
+  };
+  markInstrumented(wrapper);
+  try {
+    holder[method] = wrapper;
+  } catch (err) {
+    warn(`${options.provider} instrumentation: cannot patch ${method}`, err);
+    return false;
+  }
+  return true;
+}

--- a/packages/sdk-typescript/src/instrument/index.ts
+++ b/packages/sdk-typescript/src/instrument/index.ts
@@ -1,0 +1,3 @@
+export { instrumentOpenAI } from "./openai.js";
+export { instrumentAnthropic } from "./anthropic.js";
+export type { LlmCallSink } from "./common.js";

--- a/packages/sdk-typescript/src/instrument/openai.ts
+++ b/packages/sdk-typescript/src/instrument/openai.ts
@@ -1,0 +1,86 @@
+/**
+ * `instrumentOpenAI(client, memory)` — every `chat.completions.create` and
+ * `responses.create` on the `openai` package's client is recorded with
+ * `memory.recordLlmCall` (model, tokens, latency, provider).
+ *
+ * Streaming calls (`stream: true`) are recorded when the stream ends; the Chat
+ * Completions API only sends token counts on the final chunk when the request
+ * has `stream_options: { include_usage: true }` — without it the call is still
+ * recorded, with a model and latency but zero tokens. `openai` is an optional
+ * peer and is not imported here.
+ */
+
+import type { Extractor, LlmCallSink, Usage } from "./common.js";
+import { asInt, get, isInstrumented, markInstrumented, patchMethod, resolve } from "./common.js";
+
+const PROVIDER = "openai";
+
+export const extractChatCompletion: Extractor = (response, usage) => {
+  const model = get(response, "model");
+  if (typeof model === "string" && model) usage.model = model;
+  const u = get(response, "usage");
+  if (u) {
+    const inTok = asInt(get(u, "prompt_tokens"));
+    const outTok = asInt(get(u, "completion_tokens"));
+    if (inTok !== undefined) usage.inputTokens = inTok;
+    if (outTok !== undefined) usage.outputTokens = outTok;
+  }
+};
+
+export const extractResponse: Extractor = (response, usage) => {
+  const model = get(response, "model");
+  if (typeof model === "string" && model) usage.model = model;
+  const u = get(response, "usage");
+  if (u) {
+    const inTok = asInt(get(u, "input_tokens"));
+    const outTok = asInt(get(u, "output_tokens"));
+    if (inTok !== undefined) usage.inputTokens = inTok;
+    if (outTok !== undefined) usage.outputTokens = outTok;
+  }
+};
+
+/** Responses API stream: the terminal event carries the whole response. */
+export const extractResponseEvent: Extractor = (event, usage: Usage) => {
+  const type = String(get(event, "type") ?? "");
+  if (type === "response.completed" || type === "response.incomplete" || type === "response.failed") {
+    extractResponse(get(event, "response"), usage);
+  } else if (type === "response.created") {
+    const model = get(get(event, "response"), "model");
+    if (typeof model === "string" && model) usage.model = model;
+  }
+};
+
+/**
+ * Instrument an OpenAI (or AzureOpenAI) client in place and return it. Every
+ * call made through it is recorded on `memory` until the next
+ * `commitOutcomeAsync`, which ships the calls with the outcome. Idempotent.
+ *
+ * ```ts
+ * const openai = instrumentOpenAI(new OpenAI(), memory);
+ * const r = await openai.chat.completions.create({ model: "gpt-4o-mini", messages });
+ * await memory.commitOutcomeAsync("deploy-42", OutcomeType.SUCCESS);
+ * ```
+ */
+export function instrumentOpenAI<C>(client: C, memory: LlmCallSink): C {
+  if (isInstrumented(client)) return client;
+  const completions = resolve(client, ["chat", "completions"]);
+  if (completions) {
+    patchMethod(completions, "create", {
+      provider: PROVIDER,
+      sink: memory,
+      extract: extractChatCompletion,
+      onChunk: extractChatCompletion,
+    });
+  }
+  const responses = resolve(client, ["responses"]);
+  if (responses) {
+    patchMethod(responses, "create", {
+      provider: PROVIDER,
+      sink: memory,
+      extract: extractResponse,
+      onChunk: extractResponseEvent,
+    });
+  }
+  markInstrumented(client);
+  return client;
+}

--- a/packages/sdk-typescript/src/memory.ts
+++ b/packages/sdk-typescript/src/memory.ts
@@ -18,6 +18,7 @@ import { OutcomeType } from "./models.js";
 import { OutcomeBackPropagator } from "./outcome.js";
 import {
   buildSessionMetadata,
+  SESSION_ATTRIBUTES_MAX_KEYS,
   toLlmCallRecord,
   validateSessionAttributes,
 } from "./session.js";
@@ -434,9 +435,20 @@ export class AgentMemory {
    * boolean), at most 20 keys of up to 64 characters, string values up to 256
    * characters; anything else throws. Keys are lowercased. Cleared when the
    * outcome is committed.
+   *
+   * The key cap applies to the bag as merged, not to each call: a merge that
+   * would take it past 20 keys throws a `RangeError` and leaves the bag as it
+   * was.
    */
   setSessionAttributes(attributes: SessionAttributes): SessionAttributes {
-    Object.assign(this._sessionAttributes, validateSessionAttributes(attributes));
+    const merged = { ...this._sessionAttributes, ...validateSessionAttributes(attributes) };
+    const size = Object.keys(merged).length;
+    if (size > SESSION_ATTRIBUTES_MAX_KEYS) {
+      throw new RangeError(
+        `at most ${SESSION_ATTRIBUTES_MAX_KEYS} session attributes are allowed (the bag would hold ${size})`,
+      );
+    }
+    this._sessionAttributes = merged;
     return { ...this._sessionAttributes };
   }
 
@@ -689,8 +701,9 @@ export class AgentMemory {
    *
    * The session's attributes (from {@link setSessionAttributes} and
    * `options.attributes`) and recorded LLM calls travel as `session_metadata`
-   * and are cleared once the request has been sent, so each commit describes
-   * one run.
+   * and are cleared once the server has accepted them, so each commit
+   * describes one run. A refused commit — a 422 for a bad bag, a 5xx — leaves
+   * them in place: the run still happened, and a retry should carry them.
    */
   async commitOutcomeAsync(
     outcomeRef: string,
@@ -705,19 +718,17 @@ export class AgentMemory {
     const keys = options?.causalEntryKeys ?? this.readTracker.causalKeys;
     if (options?.attributes) this.setSessionAttributes(options.attributes);
     const sessionMetadata = buildSessionMetadata(this._sessionAttributes, this._sessionLlmCalls);
-    try {
-      return await this.requireHttp("commitOutcomeAsync").commitOutcomeAsync({
-        outcomeRef,
-        outcomeType: String(outcomeType),
-        entityPath: options?.entityPath,
-        causalEntryKeys: keys,
-        causalConfidence: options?.causalConfidence,
-        agentId: this.agentId,
-        sessionMetadata,
-      });
-    } finally {
-      this.resetSessionMetadata();
-    }
+    const result = await this.requireHttp("commitOutcomeAsync").commitOutcomeAsync({
+      outcomeRef,
+      outcomeType: String(outcomeType),
+      entityPath: options?.entityPath,
+      causalEntryKeys: keys,
+      causalConfidence: options?.causalConfidence,
+      agentId: this.agentId,
+      sessionMetadata,
+    });
+    this.resetSessionMetadata();
+    return result;
   }
 
   /** Version history of a key from the remote server. */

--- a/packages/sdk-typescript/src/memory.ts
+++ b/packages/sdk-typescript/src/memory.ts
@@ -3,7 +3,13 @@
  */
 
 import type { AmfsAdapter, WatchHandle } from "./adapter.js";
-import type { DecisionTrace, DecisionTraceSummary, HttpAdapter } from "./adapters/http.js";
+import type {
+  DecisionTrace,
+  DecisionTracePage,
+  DecisionTraceSummary,
+  HttpAdapter,
+  ListTracesOptions,
+} from "./adapters/http.js";
 import { InMemoryAdapter } from "./adapters/filesystem.js";
 import { defaultConfig } from "./config.js";
 import { CausalTagger, CoWEngine } from "./engine.js";
@@ -662,14 +668,23 @@ export class AgentMemory {
     return this.requireHttp("graphNeighborsAsync").graphNeighborsAsync(options);
   }
 
-  /** Browse persisted decision traces from past sessions. */
-  async listTracesAsync(options?: {
-    entityPath?: string;
-    agentId?: string;
-    outcomeType?: string;
-    limit?: number;
-  }): Promise<DecisionTraceSummary[]> {
+  /**
+   * Browse persisted decision traces from past sessions, newest first.
+   *
+   * Returns one page as a flat array. Pass `cursor` (from
+   * {@link listTracesPageAsync}) to continue, or `since` / `until` to bound by
+   * creation time.
+   */
+  async listTracesAsync(options?: ListTracesOptions): Promise<DecisionTraceSummary[]> {
     return this.requireHttp("listTracesAsync").listTracesAsync(options);
+  }
+
+  /**
+   * One page of decision traces with paging metadata:
+   * `{ traces, nextCursor, hasMore }`. Follow `nextCursor` while `hasMore`.
+   */
+  async listTracesPageAsync(options?: ListTracesOptions): Promise<DecisionTracePage> {
+    return this.requireHttp("listTracesPageAsync").listTracesPageAsync(options);
   }
 
   /** Retrieve a full decision trace by ID, or null if not found. */

--- a/packages/sdk-typescript/src/memory.ts
+++ b/packages/sdk-typescript/src/memory.ts
@@ -16,6 +16,12 @@ import { CausalTagger, CoWEngine } from "./engine.js";
 import type { AMFSConfig, Commit, MemoryEntry, RecallConfig, ScopeInfo, ScoredEntry } from "./models.js";
 import { OutcomeType } from "./models.js";
 import { OutcomeBackPropagator } from "./outcome.js";
+import {
+  buildSessionMetadata,
+  toLlmCallRecord,
+  validateSessionAttributes,
+} from "./session.js";
+import type { LlmCallRecord, RecordLlmCallInput, SessionAttributes } from "./session.js";
 import { ReadTracker } from "./tracker.js";
 
 export interface AgentMemoryOptions {
@@ -57,6 +63,9 @@ export class AgentMemory {
 
   private engine: CoWEngine;
   private propagator: OutcomeBackPropagator;
+  /** Cleared when an outcome is committed; see {@link setSessionAttributes}. */
+  private _sessionAttributes: SessionAttributes = {};
+  private _sessionLlmCalls: LlmCallRecord[] = [];
 
   constructor(agentId: string, options?: AgentMemoryOptions) {
     const config = options?.config ?? defaultConfig();
@@ -394,7 +403,7 @@ export class AgentMemory {
     outcomeRef: string,
     outcomeType: OutcomeType,
     causalEntryKeys?: string[],
-    options?: { causalConfidence?: number }
+    options?: { causalConfidence?: number; attributes?: SessionAttributes }
   ): MemoryEntry[] {
     const keys = causalEntryKeys ?? this.readTracker.causalKeys;
     const record = OutcomeBackPropagator.makeRecord(
@@ -404,7 +413,62 @@ export class AgentMemory {
       this.agentId,
       { causalConfidence: options?.causalConfidence }
     );
+    // Local adapters propagate confidence but build no trace, so the session
+    // bag has nowhere to go here; it is still validated and consumed so the
+    // next run starts clean, as on the HTTP path.
+    if (options?.attributes) this.setSessionAttributes(options.attributes);
+    this.resetSessionMetadata();
     return this.propagator.propagate(record);
+  }
+
+  // ------------------------------------------------------------------
+  // Session metadata — attributes and LLM calls for the next trace
+  // ------------------------------------------------------------------
+
+  /**
+   * Merge `attributes` into the bag the next committed outcome stamps on its
+   * trace (`session_metadata.attributes`); returns the bag as it now stands.
+   *
+   * Attributes are the dimensions a run is later filtered and grouped by —
+   * `customer`, `task_type`, `environment`. Scalars only (string, number,
+   * boolean), at most 20 keys of up to 64 characters, string values up to 256
+   * characters; anything else throws. Keys are lowercased. Cleared when the
+   * outcome is committed.
+   */
+  setSessionAttributes(attributes: SessionAttributes): SessionAttributes {
+    Object.assign(this._sessionAttributes, validateSessionAttributes(attributes));
+    return { ...this._sessionAttributes };
+  }
+
+  /** The attribute bag waiting for the next commit. */
+  get sessionAttributes(): SessionAttributes {
+    return { ...this._sessionAttributes };
+  }
+
+  /**
+   * Record one LLM call for the trace the next committed outcome builds.
+   *
+   * Token counts and cost are only ever known if the agent reports them, so
+   * this is what makes a trace's token and cost figures real rather than
+   * blank. `instrumentOpenAI` / `instrumentAnthropic` call this for you.
+   * Stored in `session_metadata.llm_calls` as
+   * `{call_id, model, provider, input_tokens, output_tokens, cost_usd, latency_ms, started_at}`.
+   * Returns the record as stored. Cleared when the outcome is committed.
+   */
+  recordLlmCall(call: RecordLlmCallInput, startedAt?: Date): LlmCallRecord {
+    const record = toLlmCallRecord(call, startedAt);
+    this._sessionLlmCalls.push(record);
+    return { ...record };
+  }
+
+  /** The LLM calls waiting for the next commit. */
+  get sessionLlmCalls(): LlmCallRecord[] {
+    return this._sessionLlmCalls.map((c) => ({ ...c }));
+  }
+
+  private resetSessionMetadata(): void {
+    this._sessionAttributes = {};
+    this._sessionLlmCalls = [];
   }
 
   // ------------------------------------------------------------------
@@ -620,21 +684,40 @@ export class AgentMemory {
     return this.requireHttp("briefingAsync").briefingAsync(options);
   }
 
-  /** Commit an outcome remotely, snapshotting the session's causal chain. */
+  /**
+   * Commit an outcome remotely, snapshotting the session's causal chain.
+   *
+   * The session's attributes (from {@link setSessionAttributes} and
+   * `options.attributes`) and recorded LLM calls travel as `session_metadata`
+   * and are cleared once the request has been sent, so each commit describes
+   * one run.
+   */
   async commitOutcomeAsync(
     outcomeRef: string,
     outcomeType: OutcomeType,
-    options?: { entityPath?: string; causalEntryKeys?: string[]; causalConfidence?: number }
+    options?: {
+      entityPath?: string;
+      causalEntryKeys?: string[];
+      causalConfidence?: number;
+      attributes?: SessionAttributes;
+    }
   ): Promise<unknown> {
     const keys = options?.causalEntryKeys ?? this.readTracker.causalKeys;
-    return this.requireHttp("commitOutcomeAsync").commitOutcomeAsync({
-      outcomeRef,
-      outcomeType: String(outcomeType),
-      entityPath: options?.entityPath,
-      causalEntryKeys: keys,
-      causalConfidence: options?.causalConfidence,
-      agentId: this.agentId,
-    });
+    if (options?.attributes) this.setSessionAttributes(options.attributes);
+    const sessionMetadata = buildSessionMetadata(this._sessionAttributes, this._sessionLlmCalls);
+    try {
+      return await this.requireHttp("commitOutcomeAsync").commitOutcomeAsync({
+        outcomeRef,
+        outcomeType: String(outcomeType),
+        entityPath: options?.entityPath,
+        causalEntryKeys: keys,
+        causalConfidence: options?.causalConfidence,
+        agentId: this.agentId,
+        sessionMetadata,
+      });
+    } finally {
+      this.resetSessionMetadata();
+    }
   }
 
   /** Version history of a key from the remote server. */

--- a/packages/sdk-typescript/src/session.ts
+++ b/packages/sdk-typescript/src/session.ts
@@ -1,0 +1,154 @@
+/**
+ * Session metadata the SDK collects for a trace: the attribute bag a run is
+ * filtered and grouped by, and the LLM calls that give it real token and cost
+ * figures. Both travel in `session_metadata` when the outcome is committed —
+ * `attributes` and `llm_calls`, the same shape the Python SDK and MCP server
+ * write, so the server treats every producer alike.
+ */
+
+export type AttributeValue = string | number | boolean;
+export type SessionAttributes = Record<string, AttributeValue>;
+
+/** Attributes are indexed server-side, so the bag is kept small and flat. */
+export const SESSION_ATTRIBUTES_MAX_KEYS = 20;
+export const SESSION_ATTRIBUTE_KEY_MAX_LEN = 64;
+export const SESSION_ATTRIBUTE_VALUE_MAX_LEN = 256;
+
+/**
+ * The validated form of an attribute bag, or a thrown `TypeError` / `RangeError`.
+ *
+ * Keys are trimmed and lowercased (the server indexes them that way, so two
+ * spellings of one dimension would otherwise never group together). Values
+ * must be string, finite number or boolean; at most 20 keys of up to 64
+ * characters, string values up to 256 characters. Rejected rather than
+ * trimmed: a silently shortened customer id is worse than an error at the
+ * call site.
+ */
+export function validateSessionAttributes(attributes: unknown): SessionAttributes {
+  if (attributes === null || attributes === undefined) return {};
+  if (typeof attributes !== "object" || Array.isArray(attributes)) {
+    throw new TypeError("attributes must be an object of scalar values");
+  }
+  const entries = Object.entries(attributes as Record<string, unknown>);
+  if (entries.length > SESSION_ATTRIBUTES_MAX_KEYS) {
+    throw new RangeError(
+      `at most ${SESSION_ATTRIBUTES_MAX_KEYS} session attributes are allowed (got ${entries.length})`,
+    );
+  }
+  const out: SessionAttributes = {};
+  for (const [rawKey, value] of entries) {
+    const key = String(rawKey).trim().toLowerCase();
+    if (!key) throw new RangeError("attribute keys must be non-empty strings");
+    if (key.length > SESSION_ATTRIBUTE_KEY_MAX_LEN) {
+      throw new RangeError(
+        `attribute key '${key.slice(0, 20)}...' exceeds ${SESSION_ATTRIBUTE_KEY_MAX_LEN} characters`,
+      );
+    }
+    if (typeof value === "string") {
+      if (value.length > SESSION_ATTRIBUTE_VALUE_MAX_LEN) {
+        throw new RangeError(
+          `attribute '${key}' exceeds ${SESSION_ATTRIBUTE_VALUE_MAX_LEN} characters`,
+        );
+      }
+      out[key] = value;
+    } else if (typeof value === "number") {
+      if (!Number.isFinite(value)) throw new RangeError(`attribute '${key}' must be a finite number`);
+      out[key] = value;
+    } else if (typeof value === "boolean") {
+      out[key] = value;
+    } else {
+      throw new TypeError(
+        `attribute '${key}' must be a string, number or boolean, not ${value === null ? "null" : typeof value}`,
+      );
+    }
+  }
+  return out;
+}
+
+/** What {@link AgentMemory.recordLlmCall} takes. */
+export interface RecordLlmCallInput {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  /** USD; omit when unknown — a blank cost is honest, a zero one is not. */
+  costUsd?: number | null;
+  latencyMs?: number | null;
+  provider?: string | null;
+  callId?: string | null;
+  /** Set when the call failed; the record still counts the attempt. */
+  error?: string | null;
+}
+
+/**
+ * One LLM call as stored in `session_metadata.llm_calls` (wire shape, snake_case).
+ * Mirrors the record the Python SDK's `record_llm_call` writes.
+ */
+export interface LlmCallRecord {
+  call_id: string;
+  model: string;
+  provider: string;
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number | null;
+  latency_ms: number | null;
+  started_at: string;
+  [extra: string]: unknown;
+}
+
+function nonNegativeInt(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new TypeError(`${label} must be a number`);
+  }
+  const n = Math.trunc(value);
+  if (n < 0) throw new RangeError(`${label} must be non-negative`);
+  return n;
+}
+
+function optionalNonNegative(value: unknown, label: string): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new RangeError(`${label} must be a non-negative number or null`);
+  }
+  return value;
+}
+
+function newCallId(): string {
+  const c = globalThis.crypto as { randomUUID?: () => string } | undefined;
+  if (c?.randomUUID) return c.randomUUID();
+  // Fallback for runtimes without WebCrypto: time + random, unique enough per session.
+  return `${Date.now().toString(16)}-${Math.random().toString(16).slice(2, 14)}`;
+}
+
+/** Validate and normalise a call into the wire record. Throws on bad input. */
+export function toLlmCallRecord(input: RecordLlmCallInput, startedAt?: Date): LlmCallRecord {
+  if (typeof input?.model !== "string" || !input.model) {
+    throw new TypeError("model must be a non-empty string");
+  }
+  const record: LlmCallRecord = {
+    call_id: input.callId || newCallId(),
+    model: input.model,
+    provider: input.provider ?? "",
+    input_tokens: nonNegativeInt(input.inputTokens, "inputTokens"),
+    output_tokens: nonNegativeInt(input.outputTokens, "outputTokens"),
+    cost_usd: optionalNonNegative(input.costUsd, "costUsd"),
+    latency_ms: optionalNonNegative(input.latencyMs, "latencyMs"),
+    started_at: (startedAt ?? new Date()).toISOString(),
+  };
+  if (input.error) record.error = String(input.error);
+  return record;
+}
+
+/**
+ * The `session_metadata` object sent with an outcome: the two collections when
+ * they have content, nothing otherwise (so a server that predates them sees
+ * the request it always saw).
+ */
+export function buildSessionMetadata(
+  attributes: SessionAttributes,
+  llmCalls: LlmCallRecord[],
+): Record<string, unknown> | undefined {
+  const out: Record<string, unknown> = {};
+  if (Object.keys(attributes).length) out.attributes = { ...attributes };
+  if (llmCalls.length) out.llm_calls = llmCalls.map((c) => ({ ...c }));
+  return Object.keys(out).length ? out : undefined;
+}

--- a/tests/integration/test_postgres_adapter.py
+++ b/tests/integration/test_postgres_adapter.py
@@ -10,7 +10,7 @@ import os
 
 import pytest
 
-from tests.integration.adapter_contract import AdapterContractTests
+from tests.integration.adapter_contract import AdapterContractTests, _make_entry
 
 PG_DSN = os.environ.get("AMFS_TEST_PG_DSN")
 
@@ -30,6 +30,11 @@ def adapter():
     conn = psycopg.connect(PG_DSN, autocommit=True)
     conn.execute("DROP TABLE IF EXISTS amfs_outcomes CASCADE")
     conn.execute("DROP TABLE IF EXISTS amfs_memory_entries CASCADE")
+    # Traces and events too, so the pagination and partitioning tests below
+    # start from an empty, freshly bootstrapped (partitioned) trace table.
+    conn.execute("DROP TABLE IF EXISTS amfs_decision_traces CASCADE")
+    conn.execute("DROP TABLE IF EXISTS amfs_decision_traces_legacy CASCADE")
+    conn.execute("DROP TABLE IF EXISTS amfs_events CASCADE")
     conn.close()
 
     a = PostgresAdapter(dsn=PG_DSN, namespace="test", auto_schema=True)
@@ -197,3 +202,464 @@ def test_a_trace_without_session_metadata_still_saves(adapter) -> None:
     assert fetched.session_metadata is None or (
         fetched.session_metadata.model is None
     )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Keyset pagination, SQL counts, and the causal_entries containment filter
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _saved_traces(adapter, n: int, *, agent_id: str = "page-agent", entity_path: str = "svc/api"):
+    """Persist *n* traces a minute apart, oldest first; returns them newest first."""
+    from datetime import UTC, datetime, timedelta
+
+    from amfs_core.models import DecisionTrace, TraceEntry
+
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    out = []
+    for i in range(n):
+        out.append(
+            adapter.save_trace(
+                DecisionTrace(
+                    agent_id=agent_id,
+                    session_id="s",
+                    outcome_ref=f"PAGE-{i}",
+                    outcome_type="success" if i % 2 == 0 else "failure",
+                    causal_entries=[
+                        TraceEntry(entity_path=entity_path, key=f"k{i}", version=1, confidence=1.0)
+                    ],
+                    created_at=base + timedelta(minutes=i),
+                )
+            )
+        )
+    return list(reversed(out))
+
+
+def test_list_traces_pages_by_cursor_without_gaps_or_repeats(adapter) -> None:
+    from amfs_core.pagination import page_from_overfetch
+
+    expected = [t.outcome_ref for t in _saved_traces(adapter, 11)]
+
+    seen, cursor, pages = [], None, 0
+    while True:
+        rows = adapter.list_traces(agent_id="page-agent", limit=4 + 1, cursor=cursor)
+        page = page_from_overfetch(
+            rows, limit=4, timestamp=lambda t: t.created_at, tiebreak=lambda t: t.id
+        )
+        pages += 1
+        seen.extend(t.outcome_ref for t in page.items)
+        if not page.has_more:
+            assert page.next_cursor is None
+            break
+        cursor = page.next_cursor
+    assert pages == 3
+    assert seen == expected
+
+    # offset is still honoured when no cursor is given
+    rows = adapter.list_traces(agent_id="page-agent", limit=3, offset=4)
+    assert [t.outcome_ref for t in rows] == expected[4:7]
+
+
+def test_list_traces_since_until_and_count(adapter) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    _saved_traces(adapter, 10)
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    since, until = base + timedelta(minutes=2), base + timedelta(minutes=6)
+
+    rows = adapter.list_traces(agent_id="page-agent", since=since, until=until, limit=100)
+    assert [t.outcome_ref for t in rows] == ["PAGE-5", "PAGE-4", "PAGE-3", "PAGE-2"]
+
+    assert adapter.count_traces(agent_id="page-agent") == 10
+    assert adapter.count_traces(agent_id="page-agent", since=since, until=until) == 4
+    assert adapter.count_traces(agent_id="page-agent", outcome_type="success") == 5
+    assert adapter.count_traces(agent_id="nobody") == 0
+
+
+def test_entity_path_filter_uses_containment_and_matches_the_old_scan(adapter, pg_conn) -> None:
+    """The ``@>`` rewrite must return exactly what ``jsonb_array_elements`` did."""
+    _saved_traces(adapter, 6, entity_path="svc/api")
+    _saved_traces(adapter, 3, agent_id="other-agent", entity_path="svc/other")
+
+    new = adapter.list_traces(entity_path="svc/api", limit=100)
+    assert len(new) == 6
+    assert all(any(c.entity_path == "svc/api" for c in t.causal_entries) for t in new)
+
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id FROM amfs_decision_traces
+            WHERE namespace = %s AND EXISTS (
+                SELECT 1 FROM jsonb_array_elements(causal_entries) ce
+                WHERE ce->>'entity_path' = %s
+            )
+            ORDER BY created_at DESC, id DESC
+            """,
+            (adapter._namespace, "svc/api"),
+        )
+        old_ids = [r[0] for r in cur.fetchall()]
+        cur.execute(
+            "SELECT 1 FROM pg_indexes WHERE indexname = 'idx_traces_causal_entries_gin'"
+        )
+        assert cur.fetchone() is not None, "GIN index on causal_entries was not created"
+    assert [t.id for t in new] == [str(i) for i in old_ids]
+
+    assert adapter.count_traces(entity_path="svc/api") == 6
+    assert adapter.list_traces(entity_path="svc/nope", limit=100) == []
+
+
+def test_trace_read_counts_aggregates_in_sql(adapter) -> None:
+    from amfs_core.abc import AdapterABC
+
+    _saved_traces(adapter, 5)
+    counts = adapter.trace_read_counts("page-agent")
+    assert counts == {"svc/api": {f"k{i}": 1 for i in range(5)}}
+    # identical to the base-class scan it replaces
+    assert counts == AdapterABC.trace_read_counts(adapter, "page-agent")
+    assert adapter.trace_read_counts("nobody") == {}
+
+
+def test_count_outcomes_matches_rows_not_a_capped_list(adapter, monkeypatch) -> None:
+    from amfs_core.models import OutcomeRecord, OutcomeType
+
+    adapter.write(_make_entry(key="counted"))
+    for i in range(7):
+        adapter.commit_outcome(
+            OutcomeRecord(
+                outcome_ref=f"CNT-{i}",
+                outcome_type=OutcomeType.SUCCESS,
+                committed_at=_make_entry().provenance.written_at,
+                causal_entry_keys=["checkout-service/counted"],
+                agent_id="review-agent",
+            )
+        )
+    # A scan ceiling smaller than the row count must not affect a SQL count.
+    monkeypatch.setenv("AMFS_MAX_SCAN_ROWS", "3")
+    assert adapter.count_outcomes() == 7
+    assert len(adapter.list_outcomes(limit=3)) == 3
+    assert [o.outcome_ref for o in adapter.list_outcomes(outcome_ref="CNT-4")] == ["CNT-4"]
+
+
+def test_list_entries_for_agent_pages_and_filters_in_sql(adapter) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from amfs_core.abc import AdapterABC
+    from amfs_core.models import MemoryEntry, Provenance
+    from amfs_core.pagination import entry_tiebreak, page_from_overfetch
+
+    base = datetime(2026, 2, 1, tzinfo=UTC)
+
+    def write(i, agent="act-agent", entity="svc/api"):
+        adapter.write(
+            MemoryEntry(
+                entity_path=entity,
+                key=f"k{i:02d}",
+                value={"i": i},
+                provenance=Provenance(
+                    agent_id=agent, session_id="s", written_at=base + timedelta(minutes=i)
+                ),
+            )
+        )
+
+    for i in range(9):
+        write(i)
+    write(50, agent="someone-else")
+    write(60, entity="_system/hidden")
+
+    seen, cursor = [], None
+    while True:
+        rows = adapter.list_entries_for_agent("act-agent", limit=4 + 1, cursor=cursor)
+        page = page_from_overfetch(
+            rows, limit=4, timestamp=lambda e: e.provenance.written_at, tiebreak=entry_tiebreak
+        )
+        seen.extend(e.key for e in page.items)
+        if not page.has_more:
+            break
+        cursor = page.next_cursor
+    assert seen == [f"k{i:02d}" for i in reversed(range(9))]
+
+    window = adapter.list_entries_for_agent(
+        "act-agent", since=base + timedelta(minutes=2), until=base + timedelta(minutes=5), limit=50
+    )
+    assert [e.key for e in window] == ["k04", "k03", "k02"]
+
+    # same answer as the in-memory base implementation
+    base_rows = AdapterABC.list_entries_for_agent(adapter, "act-agent", limit=6)
+    sql_rows = adapter.list_entries_for_agent("act-agent", limit=6)
+    assert [(e.entity_path, e.key) for e in sql_rows] == [
+        (e.entity_path, e.key) for e in base_rows
+    ]
+
+
+def test_list_events_pages_by_cursor(adapter) -> None:
+    from amfs_core.models import Event, EventType
+    from amfs_core.pagination import page_from_overfetch
+
+    for i in range(7):
+        adapter.log_event(
+            Event(
+                agent_id="evt-agent", namespace=adapter._namespace,
+                event_type=EventType.READ, summary=f"r{i}",
+            )
+        )
+    seen, cursor = [], None
+    while True:
+        rows = adapter.list_events("evt-agent", adapter._namespace, limit=3 + 1, cursor=cursor)
+        page = page_from_overfetch(
+            rows, limit=3, timestamp=lambda e: e.created_at, tiebreak=lambda e: e.id
+        )
+        seen.extend(e.summary for e in page.items)
+        if not page.has_more:
+            break
+        cursor = page.next_cursor
+    assert sorted(seen) == [f"r{i}" for i in range(7)]
+    assert len(seen) == 7
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Partitioning and retention
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def pg_conn():
+    import psycopg
+
+    conn = psycopg.connect(PG_DSN, autocommit=True)
+    yield conn
+    conn.close()
+
+
+def _relkind(conn, name: str) -> str | None:
+    with conn.cursor() as cur:
+        cur.execute("SELECT relkind FROM pg_class WHERE relname = %s", (name,))
+        row = cur.fetchone()
+    return row[0] if row else None
+
+
+def _partitions(conn) -> list[str]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT c.relname FROM pg_inherits i
+            JOIN pg_class c ON c.oid = i.inhrelid
+            WHERE i.inhparent = 'amfs_decision_traces'::regclass ORDER BY 1
+            """
+        )
+        return [r[0] for r in cur.fetchall()]
+
+
+def test_fresh_install_creates_a_partitioned_trace_table(adapter, pg_conn) -> None:
+    from datetime import UTC, datetime
+
+    from amfs_postgres.trace_partitions import partition_name
+
+    assert _relkind(pg_conn, "amfs_decision_traces") == "p"
+    parts = _partitions(pg_conn)
+    assert "amfs_decision_traces_default" in parts
+    now = datetime.now(UTC)
+    assert partition_name(now.year, now.month) in parts  # ensure_trace_partitions ran at init
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT a.attname FROM pg_index x
+            JOIN pg_attribute a ON a.attrelid = x.indrelid AND a.attnum = ANY (x.indkey)
+            WHERE x.indrelid = 'amfs_decision_traces'::regclass AND x.indisprimary
+            ORDER BY a.attname
+            """
+        )
+        assert [r[0] for r in cur.fetchall()] == ["created_at", "id"]
+
+
+def test_get_trace_by_id_works_on_the_partitioned_table(adapter) -> None:
+    traces = _saved_traces(adapter, 3)
+    for t in traces:
+        got = adapter.get_trace(t.id)
+        assert got is not None and got.outcome_ref == t.outcome_ref
+    assert adapter.get_trace("00000000-0000-0000-0000-000000000000") is None
+
+
+def test_flat_table_is_migrated_in_place_with_rows_and_policies_kept(adapter, pg_conn) -> None:
+    """The upgrade path: a database from before partitioning, with traces in it."""
+    from amfs_postgres.adapter import PostgresAdapter
+
+    saved = _saved_traces(adapter, 5)
+    adapter.close()
+
+    with pg_conn.cursor() as cur:
+        # Rebuild the pre-partitioning shape: a flat table with PRIMARY KEY (id),
+        # holding the same rows, an RLS policy and an extra index.
+        cur.execute("CREATE TABLE flat_traces (LIKE amfs_decision_traces INCLUDING DEFAULTS)")
+        cur.execute("INSERT INTO flat_traces SELECT * FROM amfs_decision_traces")
+        cur.execute("DROP TABLE amfs_decision_traces CASCADE")
+        cur.execute("ALTER TABLE flat_traces RENAME TO amfs_decision_traces")
+        cur.execute("ALTER TABLE amfs_decision_traces ADD PRIMARY KEY (id)")
+        cur.execute("CREATE INDEX idx_traces_test_extra ON amfs_decision_traces (outcome_ref)")
+        cur.execute(
+            "CREATE POLICY traces_test_policy ON amfs_decision_traces "
+            "USING (namespace = current_setting('amfs.test_ns', true))"
+        )
+        cur.execute("ALTER TABLE amfs_decision_traces ENABLE ROW LEVEL SECURITY")
+        # A stored fingerprint would let the fast path skip the migration.
+        cur.execute("DELETE FROM amfs_schema_state")
+    assert _relkind(pg_conn, "amfs_decision_traces") == "r"
+
+    migrated = PostgresAdapter(dsn=PG_DSN, namespace="test", auto_schema=True)
+    try:
+        assert _relkind(pg_conn, "amfs_decision_traces") == "p"
+        assert _relkind(pg_conn, "amfs_decision_traces_legacy") is None
+        parts = _partitions(pg_conn)
+        assert "amfs_decision_traces_default" in parts
+        assert "amfs_decision_traces_y2026m01" in parts  # the month the rows live in
+
+        # every row survived, is reachable by id, and lives in its month
+        assert migrated.count_traces(agent_id="page-agent") == 5
+        for t in saved:
+            assert migrated.get_trace(t.id) is not None
+        with pg_conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM amfs_decision_traces_default")
+            assert cur.fetchone()[0] == 0
+            cur.execute("SELECT count(*) FROM amfs_decision_traces_y2026m01")
+            assert cur.fetchone()[0] == 5
+            cur.execute("SELECT 1 FROM pg_indexes WHERE indexname = 'idx_traces_test_extra'")
+            assert cur.fetchone() is not None
+            cur.execute(
+                "SELECT 1 FROM pg_policies WHERE tablename = 'amfs_decision_traces' "
+                "AND policyname = 'traces_test_policy'"
+            )
+            assert cur.fetchone() is not None
+            cur.execute(
+                "SELECT relrowsecurity FROM pg_class WHERE relname = 'amfs_decision_traces'"
+            )
+            assert cur.fetchone()[0] is True
+            # the new primary key includes the partition key
+            cur.execute(
+                """
+                SELECT count(*) FROM pg_index x
+                JOIN pg_attribute a ON a.attrelid = x.indrelid AND a.attnum = ANY (x.indkey)
+                WHERE x.indrelid = 'amfs_decision_traces'::regclass AND x.indisprimary
+                """
+            )
+            assert cur.fetchone()[0] == 2
+
+        # a second start is a no-op, not a second migration
+        again = PostgresAdapter(dsn=PG_DSN, namespace="test", auto_schema=True)
+        again.close()
+        assert migrated.count_traces(agent_id="page-agent") == 5
+    finally:
+        migrated.close()
+
+
+def test_ensure_trace_partitions_creates_months_ahead_and_drains_default(adapter, pg_conn) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from amfs_core.models import DecisionTrace
+    from amfs_postgres.trace_partitions import partition_name
+
+    now = datetime.now(UTC)
+    created = adapter.ensure_trace_partitions(months_ahead=4)
+    parts = _partitions(pg_conn)
+    m = now.replace(day=1)
+    for _ in range(5):
+        assert partition_name(m.year, m.month) in parts
+        m = (m.replace(day=28) + timedelta(days=4)).replace(day=1)
+    # the two extra months are new; this month and the next two existed from init
+    assert len(created) == 2
+
+    # A backdated trace lands in DEFAULT; the next upkeep gives its month a
+    # partition and moves the row out.
+    old = adapter.save_trace(
+        DecisionTrace(
+            agent_id="old-agent",
+            session_id="s",
+            outcome_ref="OLD-1",
+            outcome_type="success",
+            created_at=datetime(2019, 6, 15, tzinfo=UTC),
+        )
+    )
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM amfs_decision_traces_default")
+        assert cur.fetchone()[0] == 1
+    assert adapter.ensure_trace_partitions() == ["amfs_decision_traces_y2019m06"]
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM amfs_decision_traces_default")
+        assert cur.fetchone()[0] == 0
+        cur.execute("SELECT count(*) FROM amfs_decision_traces_y2019m06")
+        assert cur.fetchone()[0] == 1
+    assert adapter.get_trace(old.id) is not None
+    assert adapter.ensure_trace_partitions() == []
+
+
+def test_apply_trace_retention_strips_payloads_and_drops_old_partitions(adapter, pg_conn) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from amfs_core.models import DecisionTrace, ToolCall
+
+    now = datetime.now(UTC)
+
+    def save(ref, age_days):
+        return adapter.save_trace(
+            DecisionTrace(
+                agent_id="ret-agent",
+                session_id="s",
+                outcome_ref=ref,
+                outcome_type="success",
+                task_input="prompt " + ref,
+                response_text="answer " + ref,
+                tool_calls=[ToolCall(tool_name="Shell", arguments={"cmd": "ls"})],
+                created_at=now - timedelta(days=age_days),
+            )
+        )
+
+    fresh = save("FRESH", 1)
+    cold = save("COLD", 45)
+    ancient = save("ANCIENT", 400)
+    adapter.ensure_trace_partitions()  # gives the backdated rows their months
+
+    # Payload stripping only: nothing dropped, metadata kept.
+    result = adapter.apply_trace_retention(hot_days=30)
+    assert result["dropped_partitions"] == []
+    assert result["stripped_rows"] == 2
+
+    f = adapter.get_trace(fresh.id)
+    assert f.task_input == "prompt FRESH" and len(f.tool_calls) == 1
+    for t in (adapter.get_trace(cold.id), adapter.get_trace(ancient.id)):
+        assert t is not None
+        assert t.task_input is None and t.response_text is None
+        assert t.tool_calls == []
+        assert t.outcome_ref in ("COLD", "ANCIENT")  # metadata stays
+
+    # Running again strips nothing new.
+    assert adapter.apply_trace_retention(hot_days=30)["stripped_rows"] == 0
+
+    # Dropping: only partitions wholly older than the cutoff go.
+    ancient_month = (now - timedelta(days=400)).strftime("amfs_decision_traces_y%Ym%m")
+    result = adapter.apply_trace_retention(hot_days=30, drop_after_days=365)
+    assert ancient_month in result["dropped_partitions"]
+    assert adapter.get_trace(ancient.id) is None
+    assert adapter.get_trace(cold.id) is not None
+    assert adapter.get_trace(fresh.id) is not None
+    assert ancient_month not in _partitions(pg_conn)
+
+
+def test_retention_cli_dry_run_reports_without_changing_anything(adapter, pg_conn) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from amfs_core.models import DecisionTrace
+    from amfs_postgres import retention
+
+    adapter.save_trace(
+        DecisionTrace(
+            agent_id="cli-agent",
+            session_id="s",
+            outcome_ref="CLI-1",
+            outcome_type="success",
+            task_input="keep me",
+            created_at=datetime.now(UTC) - timedelta(days=90),
+        )
+    )
+    adapter.ensure_trace_partitions()
+    code = retention.main(["--dsn", PG_DSN, "--namespace", "test", "--hot-days", "30", "--dry-run"])
+    assert code == 0
+    rows = adapter.list_traces(agent_id="cli-agent", limit=10)
+    assert rows[0].task_input == "keep me"

--- a/tests/test_event_account_scoping.py
+++ b/tests/test_event_account_scoping.py
@@ -95,6 +95,13 @@ class TestTheTimelineStaysScoped:
         """These return whole event rows rather than counts, so the same
         omission would disclose another account's agent names and summaries."""
         body = _method(SYNC, method)
+        if "_event_conditions(" in body:
+            # The WHERE clause is built by a helper shared with the async adapter;
+            # the filter has to be in there, and the method has to pass the account.
+            assert "account_id=self._get_current_account_id()" in body, (
+                f"{method} does not pass the current account to _event_conditions"
+            )
+            body += _method(SYNC, "_event_conditions")
         assert "account_id = %s" in body, (
             f"{method} reads amfs_events without an account filter"
         )

--- a/tests/unit/test_keyset_pagination.py
+++ b/tests/unit/test_keyset_pagination.py
@@ -1,0 +1,606 @@
+"""Keyset pagination: the cursor codec, ``has_more`` semantics, the paginated
+routes, and the counts that used to be capped at 10,000 rows.
+
+These run without Postgres. The SQL side of the same contract is exercised in
+tests/integration/test_postgres_adapter.py when ``AMFS_TEST_PG_DSN`` is set.
+"""
+
+from __future__ import annotations
+
+import types
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from amfs_core.abc import AdapterABC
+from amfs_core.models import (
+    DecisionTrace,
+    Event,
+    EventType,
+    MemoryEntry,
+    OutcomeRecord,
+    Provenance,
+    TraceEntry,
+)
+from amfs_core.pagination import (
+    DEFAULT_MAX_SCAN_ROWS,
+    MAX_PAGE_SIZE,
+    InvalidCursorError,
+    clamp_limit,
+    decode_cursor,
+    encode_cursor,
+    entry_tiebreak,
+    max_scan_rows,
+    page_from_overfetch,
+    paginate_desc,
+)
+
+T0 = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _entry(
+    i: int,
+    *,
+    agent: str = "agent-a",
+    entity_path: str = "svc/api",
+    key: str | None = None,
+    written_at: datetime | None = None,
+) -> MemoryEntry:
+    return MemoryEntry(
+        entity_path=entity_path,
+        key=key or f"k{i:03d}",
+        value={"i": i},
+        provenance=Provenance(
+            agent_id=agent,
+            session_id="s",
+            written_at=written_at or (T0 + timedelta(minutes=i)),
+        ),
+    )
+
+
+def _trace(i: int, *, agent: str = "agent-a", outcome_ref: str | None = None) -> DecisionTrace:
+    return DecisionTrace(
+        id=str(uuid.UUID(int=i)),
+        agent_id=agent,
+        session_id="s",
+        outcome_ref=outcome_ref if outcome_ref is not None else f"OUT-{i}",
+        outcome_type="success",
+        causal_entries=[TraceEntry(entity_path="svc/api", key="k", version=1, confidence=1.0)],
+        created_at=T0 + timedelta(minutes=i),
+    )
+
+
+def _event(i: int, *, agent: str = "agent-a") -> Event:
+    return Event(
+        id=str(uuid.UUID(int=10_000 + i)),
+        agent_id=agent,
+        event_type=EventType.READ,
+        summary=f"read {i}",
+        created_at=T0 + timedelta(minutes=i, seconds=30),
+    )
+
+
+# ── cursor codec ──────────────────────────────────────────────────────
+
+
+class TestCursorCodec:
+    def test_round_trip_with_string_tiebreak(self):
+        ts = datetime(2026, 3, 4, 5, 6, 7, 123456, tzinfo=UTC)
+        cur = encode_cursor(ts, "abc-123")
+        assert isinstance(cur, str) and "=" not in cur  # url-safe, unpadded
+        assert decode_cursor(cur) == (ts, "abc-123")
+
+    def test_round_trip_with_composite_tiebreak(self):
+        ts = datetime(2026, 3, 4, tzinfo=UTC)
+        tb = ["svc/api", "k001", 3]
+        assert decode_cursor(encode_cursor(ts, tb)) == (ts, tb)
+
+    def test_naive_timestamp_is_read_back_as_utc(self):
+        cur = encode_cursor(datetime(2026, 3, 4, 12, 0, 0), "x")
+        ts, _ = decode_cursor(cur)
+        assert ts.tzinfo is not None
+        assert ts == datetime(2026, 3, 4, 12, 0, 0, tzinfo=UTC)
+
+    def test_non_utc_timestamp_keeps_its_instant(self):
+        from datetime import timezone
+
+        plus9 = timezone(timedelta(hours=9))
+        ts = datetime(2026, 3, 4, 21, 0, 0, tzinfo=plus9)
+        decoded, _ = decode_cursor(encode_cursor(ts, "x"))
+        assert decoded == ts
+
+    @pytest.mark.parametrize("bad", ["", "not base64!", "AAAA", "e30", "WzEsMl0"])
+    def test_malformed_cursors_raise(self, bad):
+        with pytest.raises(InvalidCursorError):
+            decode_cursor(bad)
+
+    def test_entry_tiebreak_is_json_shaped(self):
+        e = _entry(1)
+        assert entry_tiebreak(e) == ["svc/api", "k001", 1]
+
+
+class TestLimits:
+    def test_clamp_limit(self):
+        assert clamp_limit(None) == 100
+        assert clamp_limit(0) == 1
+        assert clamp_limit(-5) == 1
+        assert clamp_limit(50) == 50
+        assert clamp_limit(MAX_PAGE_SIZE + 1) == MAX_PAGE_SIZE
+
+    def test_max_scan_rows_reads_env(self, monkeypatch):
+        monkeypatch.delenv("AMFS_MAX_SCAN_ROWS", raising=False)
+        assert max_scan_rows() == DEFAULT_MAX_SCAN_ROWS
+        monkeypatch.setenv("AMFS_MAX_SCAN_ROWS", "250")
+        assert max_scan_rows() == 250
+        monkeypatch.setenv("AMFS_MAX_SCAN_ROWS", "garbage")
+        assert max_scan_rows() == DEFAULT_MAX_SCAN_ROWS
+        monkeypatch.setenv("AMFS_MAX_SCAN_ROWS", "0")
+        assert max_scan_rows() == DEFAULT_MAX_SCAN_ROWS
+
+
+# ── in-memory pagination primitives ───────────────────────────────────
+
+
+class TestPaginateDesc:
+    def _walk(self, items, limit, **kw):
+        seen, cursor, pages = [], None, 0
+        while True:
+            page = paginate_desc(
+                items,
+                timestamp=lambda e: e.provenance.written_at,
+                tiebreak=entry_tiebreak,
+                limit=limit,
+                cursor=cursor,
+                **kw,
+            )
+            pages += 1
+            seen.extend(page.items)
+            if not page.has_more:
+                assert page.next_cursor is None
+                return seen, pages
+            assert page.next_cursor is not None
+            cursor = page.next_cursor
+
+    def test_pages_cover_everything_once_newest_first(self):
+        items = [_entry(i) for i in range(23)]
+        seen, pages = self._walk(items, 5)
+        assert pages == 5
+        assert [e.key for e in seen] == [f"k{i:03d}" for i in reversed(range(23))]
+
+    def test_exact_multiple_has_no_phantom_page(self):
+        items = [_entry(i) for i in range(10)]
+        page = paginate_desc(
+            items,
+            timestamp=lambda e: e.provenance.written_at,
+            tiebreak=entry_tiebreak,
+            limit=10,
+        )
+        assert len(page.items) == 10
+        assert page.has_more is False
+        assert page.next_cursor is None
+
+    def test_ties_on_timestamp_are_broken_deterministically(self):
+        same = T0 + timedelta(hours=1)
+        items = [_entry(i, written_at=same) for i in range(7)]
+        seen, _ = self._walk(items, 3)
+        assert len(seen) == 7
+        assert len({e.key for e in seen}) == 7
+
+    def test_offset_is_honoured_without_a_cursor(self):
+        items = [_entry(i) for i in range(10)]
+        page = paginate_desc(
+            items,
+            timestamp=lambda e: e.provenance.written_at,
+            tiebreak=entry_tiebreak,
+            limit=3,
+            offset=4,
+        )
+        assert [e.key for e in page.items] == ["k005", "k004", "k003"]
+        assert page.has_more is True
+
+    def test_page_from_overfetch(self):
+        rows = [_trace(i) for i in range(6)]
+        page = page_from_overfetch(
+            rows, limit=5, timestamp=lambda t: t.created_at, tiebreak=lambda t: t.id
+        )
+        assert len(page.items) == 5 and page.has_more
+        assert decode_cursor(page.next_cursor) == (rows[4].created_at, rows[4].id)
+        page = page_from_overfetch(
+            rows[:5], limit=5, timestamp=lambda t: t.created_at, tiebreak=lambda t: t.id
+        )
+        assert len(page.items) == 5 and not page.has_more and page.next_cursor is None
+
+
+# ── filesystem adapter: has_more and agent filtering ─────────────────
+
+
+@pytest.fixture
+def fs_adapter(tmp_path):
+    from amfs_filesystem.adapter import FilesystemAdapter
+
+    return FilesystemAdapter(root=tmp_path, namespace="test")
+
+
+class TestFilesystemListEntriesForAgent:
+    # The filesystem layout keys entities by directory name, so these use flat
+    # entity paths and an explicit hidden prefix rather than ``_system/``.
+    HIDDEN = ("hidden-",)
+
+    def _seed(self, adapter):
+        for i in range(12):
+            adapter.write(_entry(i, entity_path="svc-api"))
+        for i in range(3):
+            adapter.write(_entry(100 + i, agent="agent-b", entity_path="svc-other"))
+        adapter.write(_entry(200, entity_path="hidden-internal"))
+        adapter.write(_entry(300, entity_path="hidden-internal", key="k300"))
+
+    def test_has_more_semantics_across_pages(self, fs_adapter):
+        self._seed(fs_adapter)
+        seen: list[str] = []
+        cursor = None
+        pages = 0
+        while True:
+            rows = fs_adapter.list_entries_for_agent(
+                "agent-a", limit=5 + 1, cursor=cursor, exclude_prefixes=self.HIDDEN
+            )
+            page = page_from_overfetch(
+                rows, limit=5, timestamp=lambda e: e.provenance.written_at, tiebreak=entry_tiebreak
+            )
+            pages += 1
+            seen.extend(e.key for e in page.items)
+            if not page.has_more:
+                break
+            cursor = page.next_cursor
+        # 12 of agent-a's entries; the hidden ones are excluded.
+        assert pages == 3
+        assert seen == [f"k{i:03d}" for i in reversed(range(12))]
+
+    def test_exact_page_boundary_reports_no_more(self, fs_adapter):
+        for i in range(5):
+            fs_adapter.write(_entry(i, entity_path="svc-api"))
+        rows = fs_adapter.list_entries_for_agent("agent-a", limit=6)
+        page = page_from_overfetch(
+            rows, limit=5, timestamp=lambda e: e.provenance.written_at, tiebreak=entry_tiebreak
+        )
+        assert len(page.items) == 5 and page.has_more is False
+
+    def test_filters_by_agent_time_window_and_prefix(self, fs_adapter):
+        self._seed(fs_adapter)
+        rows = fs_adapter.list_entries_for_agent(
+            "agent-a",
+            since=T0 + timedelta(minutes=3),
+            until=T0 + timedelta(minutes=8),
+            limit=100,
+            exclude_prefixes=self.HIDDEN,
+        )
+        assert [e.key for e in rows] == ["k007", "k006", "k005", "k004", "k003"]
+        assert all(e.provenance.agent_id == "agent-a" for e in rows)
+
+        rows = fs_adapter.list_entries_for_agent("agent-a", limit=100, exclude_prefixes=self.HIDDEN)
+        assert not any(e.entity_path.startswith("hidden-") for e in rows)
+        assert len(rows) == 12
+
+        rows = fs_adapter.list_entries_for_agent("agent-b", limit=100)
+        assert [e.key for e in rows] == ["k102", "k101", "k100"]
+
+        rows = fs_adapter.list_entries_for_agent("agent-a", limit=100, exclude_prefixes=())
+        assert "k300" in {e.key for e in rows}
+
+    def test_only_current_versions_are_listed(self, fs_adapter):
+        fs_adapter.write(_entry(1, key="dup", entity_path="svc-api"))
+        fs_adapter.write(
+            _entry(2, key="dup", entity_path="svc-api", written_at=T0 + timedelta(hours=1))
+        )
+        rows = fs_adapter.list_entries_for_agent("agent-a", limit=10)
+        assert [(e.key, e.version) for e in rows] == [("dup", 2)]
+
+    def test_matches_the_abc_default_ordering(self, fs_adapter):
+        """The streaming override must page identically to the base class."""
+        self._seed(fs_adapter)
+        base = AdapterABC.list_entries_for_agent(
+            fs_adapter, "agent-a", limit=7, exclude_prefixes=self.HIDDEN
+        )
+        fast = fs_adapter.list_entries_for_agent("agent-a", limit=7, exclude_prefixes=self.HIDDEN)
+        assert [(e.entity_path, e.key, e.version) for e in base] == [
+            (e.entity_path, e.key, e.version) for e in fast
+        ]
+
+
+# ── a small in-memory adapter for the route and count tests ──────────
+
+
+class _FakeAdapter(AdapterABC):
+    """Enough of the adapter contract for the paginated routes.
+
+    Lists are held in memory; ``list_traces``/``list_events`` page with the same
+    primitive the base class uses, so the routes see the sync contract exactly
+    as a filesystem-backed server would.
+    """
+
+    def __init__(self, *, traces=(), events=(), entries=(), outcome_total=0):
+        self.traces = list(traces)
+        self.events = list(events)
+        self.entries = list(entries)
+        self.outcome_total = outcome_total
+        self.calls: list[tuple[str, dict]] = []
+
+    # unused parts of the contract
+    def read(self, *a, **k):
+        return None
+
+    def write(self, entry):
+        return entry
+
+    def watch(self, *a, **k):
+        raise NotImplementedError
+
+    def commit_outcome(self, record):
+        return []
+
+    def write_batch(self, entries):
+        return entries
+
+    def list(self, entity_path=None, **k):
+        return list(self.entries)
+
+    def search(self, *a, **k):
+        return []
+
+    def stats(self):
+        raise NotImplementedError
+
+    def record_outcome(self, *a, **k):
+        return []
+
+    def list_outcomes(self, *, entity_path=None, since=None, limit=1000, outcome_ref=None):
+        self.calls.append(("list_outcomes", {"limit": limit}))
+        return [
+            OutcomeRecord(
+                outcome_ref=f"O-{i}", outcome_type="success", committed_at=T0, agent_id="agent-a",
+            )
+            for i in range(min(limit, self.outcome_total))
+        ]
+
+    def count_outcomes(self, *, entity_path=None, since=None):
+        self.calls.append(("count_outcomes", {}))
+        return self.outcome_total
+
+    def list_traces(
+        self, *, entity_path=None, agent_id=None, outcome_type=None,
+        limit=100, offset=0, cursor=None, since=None, until=None,
+    ):
+        self.calls.append(("list_traces", {"limit": limit, "offset": offset, "cursor": cursor}))
+        rows = [
+            t for t in self.traces
+            if (agent_id is None or t.agent_id == agent_id)
+            and (outcome_type is None or t.outcome_type == outcome_type)
+            and (entity_path is None or any(c.entity_path == entity_path for c in t.causal_entries))
+            and (since is None or t.created_at >= since)
+            and (until is None or t.created_at < until)
+        ]
+        return paginate_desc(
+            rows, timestamp=lambda t: t.created_at, tiebreak=lambda t: t.id,
+            limit=limit, cursor=cursor, offset=offset,
+        ).items
+
+    def list_events(
+        self, agent_id, namespace="default", *, branch=None, event_type=None,
+        since=None, limit=100, offset=0, cursor=None, until=None,
+    ):
+        self.calls.append(("list_events", {"limit": limit, "offset": offset, "cursor": cursor}))
+        rows = [
+            e for e in self.events
+            if e.agent_id == agent_id
+            and (event_type is None or e.event_type.value == event_type)
+            and (since is None or e.created_at >= since)
+            and (until is None or e.created_at < until)
+        ]
+        return paginate_desc(
+            rows, timestamp=lambda e: e.created_at, tiebreak=lambda e: e.id,
+            limit=limit, cursor=cursor, offset=offset,
+        ).items
+
+
+# ── the routes ────────────────────────────────────────────────────────
+
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+import amfs_http.server as server  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+def _client(monkeypatch, adapter):
+    stats = types.SimpleNamespace(
+        total_entries=3, total_agents=1, agents={"agent-a": 3}, entities={"svc/api": 3},
+    )
+    mem = types.SimpleNamespace(
+        namespace="test-ns",
+        _adapter=adapter,
+        list=lambda entity_path=None, branch="main": list(adapter.entries),
+        stats=lambda: stats,
+    )
+    monkeypatch.setattr(server, "_get_memory", lambda: mem)
+    monkeypatch.setattr(server, "_async_adapter", None)
+    monkeypatch.setattr(server, "_get_visibility_filter", lambda request: None)
+    monkeypatch.setattr(server, "_active_visibility_filter", lambda request: None)
+    monkeypatch.setattr(server, "_visible_agent_ids", lambda request: None)
+    monkeypatch.setattr(server, "_get_db_pool", lambda: None)
+    return TestClient(server.app)
+
+
+class TestTracesRoute:
+    def test_pages_with_cursor_and_reports_has_more(self, monkeypatch):
+        adapter = _FakeAdapter(traces=[_trace(i) for i in range(7)])
+        client = _client(monkeypatch, adapter)
+
+        r = client.get("/api/v1/traces", params={"limit": 3})
+        body = r.json()
+        assert r.status_code == 200
+        assert [t["outcome_ref"] for t in body["traces"]] == ["OUT-6", "OUT-5", "OUT-4"]
+        assert body["has_more"] is True and body["next_cursor"]
+        # overfetch by one so has_more is exact
+        assert adapter.calls[-1] == ("list_traces", {"limit": 4, "offset": 0, "cursor": None})
+
+        r = client.get("/api/v1/traces", params={"limit": 3, "cursor": body["next_cursor"]})
+        body = r.json()
+        assert [t["outcome_ref"] for t in body["traces"]] == ["OUT-3", "OUT-2", "OUT-1"]
+        assert body["has_more"] is True
+
+        r = client.get("/api/v1/traces", params={"limit": 3, "cursor": body["next_cursor"]})
+        body = r.json()
+        assert [t["outcome_ref"] for t in body["traces"]] == ["OUT-0"]
+        assert body["has_more"] is False and body["next_cursor"] is None
+
+    def test_offset_still_works_without_a_cursor(self, monkeypatch):
+        adapter = _FakeAdapter(traces=[_trace(i) for i in range(7)])
+        client = _client(monkeypatch, adapter)
+        body = client.get("/api/v1/traces", params={"limit": 2, "offset": 2}).json()
+        assert [t["outcome_ref"] for t in body["traces"]] == ["OUT-4", "OUT-3"]
+        assert body["has_more"] is True
+
+    def test_bad_cursor_is_a_400(self, monkeypatch):
+        client = _client(monkeypatch, _FakeAdapter())
+        r = client.get("/api/v1/traces", params={"cursor": "definitely-not-a-cursor"})
+        assert r.status_code == 400
+        assert "cursor" in r.json()["detail"].lower()
+
+    def test_limit_is_clamped(self, monkeypatch):
+        adapter = _FakeAdapter(traces=[_trace(i) for i in range(3)])
+        client = _client(monkeypatch, adapter)
+        assert client.get("/api/v1/traces", params={"limit": 50_000}).status_code == 200
+        assert adapter.calls[-1][1]["limit"] == MAX_PAGE_SIZE + 1
+
+
+class TestTimelineRoute:
+    def test_pages_with_cursor(self, monkeypatch):
+        adapter = _FakeAdapter(events=[_event(i) for i in range(5)])
+        client = _client(monkeypatch, adapter)
+        body = client.get("/api/v1/agents/agent-a/timeline", params={"limit": 2}).json()
+        assert [e["summary"] for e in body["events"]] == ["read 4", "read 3"]
+        assert body["count"] == 2 and body["has_more"] is True
+        body = client.get(
+            "/api/v1/agents/agent-a/timeline",
+            params={"limit": 2, "cursor": body["next_cursor"]},
+        ).json()
+        assert [e["summary"] for e in body["events"]] == ["read 2", "read 1"]
+        body = client.get(
+            "/api/v1/agents/agent-a/timeline",
+            params={"limit": 2, "cursor": body["next_cursor"]},
+        ).json()
+        assert [e["summary"] for e in body["events"]] == ["read 0"]
+        assert body["has_more"] is False and body["next_cursor"] is None
+
+    def test_since_until_window(self, monkeypatch):
+        adapter = _FakeAdapter(events=[_event(i) for i in range(5)])
+        client = _client(monkeypatch, adapter)
+        body = client.get(
+            "/api/v1/agents/agent-a/timeline",
+            params={
+                "since": (T0 + timedelta(minutes=1)).isoformat(),
+                "until": (T0 + timedelta(minutes=3)).isoformat(),
+            },
+        ).json()
+        assert [e["summary"] for e in body["events"]] == ["read 2", "read 1"]
+
+    def test_bad_timestamp_is_a_400(self, monkeypatch):
+        client = _client(monkeypatch, _FakeAdapter())
+        r = client.get("/api/v1/agents/agent-a/timeline", params={"since": "yesterday"})
+        assert r.status_code == 400
+
+
+class TestActivityRoute:
+    def _adapter(self):
+        entries = [_entry(i) for i in range(6)]  # agent-a writes at T0+0..5 min
+        entries += [_entry(50 + i, agent="agent-b") for i in range(3)]  # not agent-a
+        entries += [_entry(90, entity_path="_system/x")]  # hidden prefix
+        traces = [_trace(i) for i in range(4)]  # outcomes at T0+0..3 min
+        traces.append(_trace(20, outcome_ref=""))  # no outcome_ref: never shown
+        traces.append(_trace(30, agent="agent-b"))  # not agent-a
+        events = [_event(i) for i in range(3)]  # T0+0..2 min +30s
+        events.append(_event(40, agent="agent-b"))
+        return _FakeAdapter(traces=traces, events=events, entries=entries)
+
+    def test_filters_to_the_agent_and_merges_newest_first(self, monkeypatch):
+        client = _client(monkeypatch, self._adapter())
+        body = client.get("/api/v1/agents/agent-a/activity", params={"limit": 100}).json()
+        assert body["agentId"] == "agent-a"
+        assert body["has_more"] is False and body["next_cursor"] is None
+        kinds = [(t["type"], t["timestamp"]) for t in body["timeline"]]
+        # 6 writes + 4 outcomes + 3 read events; agent-b and _system/ excluded,
+        # the trace without an outcome_ref dropped.
+        assert len(kinds) == 13
+        stamps = [k[1] for k in kinds]
+        assert stamps == sorted(stamps, reverse=True)
+        assert {k[0] for k in kinds} == {"write", "outcome", "read"}
+        assert all(t.get("outcomeRef", "x") for t in body["timeline"])
+        assert not any(t.get("entityPath", "").startswith("_system/") for t in body["timeline"])
+
+    def test_pages_cover_the_merged_feed_exactly_once(self, monkeypatch):
+        client = _client(monkeypatch, self._adapter())
+        full = client.get("/api/v1/agents/agent-a/activity", params={"limit": 100}).json()
+        expected = [(t["type"], t["timestamp"]) for t in full["timeline"]]
+
+        seen: list[tuple[str, str]] = []
+        cursor = None
+        for _ in range(20):
+            params = {"limit": 4}
+            if cursor:
+                params["cursor"] = cursor
+            body = client.get("/api/v1/agents/agent-a/activity", params=params).json()
+            seen.extend((t["type"], t["timestamp"]) for t in body["timeline"])
+            if not body["has_more"]:
+                assert body["next_cursor"] is None
+                break
+            cursor = body["next_cursor"]
+        assert seen == expected
+
+    def test_since_until_bound_every_source(self, monkeypatch):
+        client = _client(monkeypatch, self._adapter())
+        body = client.get(
+            "/api/v1/agents/agent-a/activity",
+            params={
+                "since": (T0 + timedelta(minutes=1)).isoformat(),
+                "until": (T0 + timedelta(minutes=3)).isoformat(),
+            },
+        ).json()
+        stamps = [datetime.fromisoformat(t["timestamp"]) for t in body["timeline"]]
+        lo, hi = T0 + timedelta(minutes=1), T0 + timedelta(minutes=3)
+        assert stamps and all(lo <= s < hi for s in stamps)
+        assert {t["type"] for t in body["timeline"]} == {"write", "outcome", "read"}
+
+    def test_reads_bounded_pages_not_the_whole_namespace(self, monkeypatch):
+        adapter = self._adapter()
+        client = _client(monkeypatch, adapter)
+        client.get("/api/v1/agents/agent-a/activity", params={"limit": 2})
+        limits = {
+            name: kw["limit"]
+            for name, kw in adapter.calls
+            if name in ("list_traces", "list_events")
+        }
+        assert limits == {"list_traces": 3, "list_events": 3}
+
+    def test_foreign_cursor_is_a_400(self, monkeypatch):
+        client = _client(monkeypatch, self._adapter())
+        cur = encode_cursor(T0, "a-plain-trace-cursor")
+        r = client.get("/api/v1/agents/agent-a/activity", params={"cursor": cur})
+        assert r.status_code == 400
+
+
+class TestAdminUsageCount:
+    def test_decision_trace_quota_counts_past_ten_thousand(self, monkeypatch):
+        adapter = _FakeAdapter(outcome_total=25_000)
+        client = _client(monkeypatch, adapter)
+        r = client.get("/api/v1/admin/usage")
+        assert r.status_code == 200
+        quotas = {q["label"]: q["current"] for q in r.json()["quotas"]}
+        assert quotas["Decision traces"] == 25_000
+        assert ("count_outcomes", {}) in adapter.calls
+        assert not any(name == "list_outcomes" for name, _ in adapter.calls)
+
+    def test_base_class_count_is_bounded_by_the_scan_ceiling(self, monkeypatch):
+        """Adapters without a SQL count fall back to a capped scan, so the
+        ceiling is what limits them, and it is configurable."""
+        adapter = _FakeAdapter(outcome_total=25_000)
+        monkeypatch.setenv("AMFS_MAX_SCAN_ROWS", "500")
+        assert AdapterABC.count_outcomes(adapter) == 500
+        assert adapter.calls[-1] == ("list_outcomes", {"limit": 500})

--- a/tests/unit/test_keyset_pagination.py
+++ b/tests/unit/test_keyset_pagination.py
@@ -470,6 +470,25 @@ class TestTracesRoute:
         assert client.get("/api/v1/traces", params={"limit": 50_000}).status_code == 200
         assert adapter.calls[-1][1]["limit"] == MAX_PAGE_SIZE + 1
 
+    def test_since_until_bound_the_query_not_the_page(self, monkeypatch):
+        # A window that excludes the newest traces must still return the older
+        # matches on the first page. Filtering the page after the fact would
+        # return [] here and stop any cursor walk before reaching OUT-1/OUT-2.
+        adapter = _FakeAdapter(traces=[_trace(i) for i in range(7)])
+        client = _client(monkeypatch, adapter)
+        r = client.get(
+            "/api/v1/traces",
+            params={
+                "limit": 2,
+                "since": (T0 + timedelta(minutes=1)).isoformat(),
+                "until": (T0 + timedelta(minutes=3)).isoformat(),  # exclusive
+            },
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert [t["outcome_ref"] for t in body["traces"]] == ["OUT-2", "OUT-1"]
+        assert body["has_more"] is False
+
 
 class TestTimelineRoute:
     def test_pages_with_cursor(self, monkeypatch):

--- a/tests/unit/test_keyset_pagination.py
+++ b/tests/unit/test_keyset_pagination.py
@@ -489,6 +489,25 @@ class TestTracesRoute:
         assert [t["outcome_ref"] for t in body["traces"]] == ["OUT-2", "OUT-1"]
         assert body["has_more"] is False
 
+    def test_naive_since_until_are_taken_as_utc(self, monkeypatch):
+        # Stored timestamps are aware; a naive query value must not reach the
+        # adapter's comparison naive (TypeError) or be read in the session
+        # timezone. Same window as above, written without an offset.
+        adapter = _FakeAdapter(traces=[_trace(i) for i in range(7)])
+        client = _client(monkeypatch, adapter)
+        r = client.get(
+            "/api/v1/traces",
+            params={"since": "2026-01-01T00:01:00", "until": "2026-01-01T00:03:00"},
+        )
+        assert r.status_code == 200
+        assert [t["outcome_ref"] for t in r.json()["traces"]] == ["OUT-2", "OUT-1"]
+
+    def test_bad_timestamp_is_a_400(self, monkeypatch):
+        client = _client(monkeypatch, _FakeAdapter())
+        r = client.get("/api/v1/traces", params={"since": "yesterday"})
+        assert r.status_code == 400
+        assert "timestamp" in r.json()["detail"].lower()
+
 
 class TestTimelineRoute:
     def test_pages_with_cursor(self, monkeypatch):

--- a/tests/unit/test_seal_attribution.py
+++ b/tests/unit/test_seal_attribution.py
@@ -73,11 +73,24 @@ def sealed(monkeypatch) -> list[Any]:
     records: list[Any] = []
 
     monkeypatch.setattr(http_server, "_HAS_PRO_TRACES", True, raising=False)
-    for name in ("ImmutableDecisionTrace", "TraceEntry", "TraceExternalContext",
-                 "ProToolCall"):
-        monkeypatch.setattr(
-            http_server, name, lambda **kw: SimpleNamespace(**kw), raising=False
-        )
+
+    # The OSS -> immutable mapping is the Pro package's; the server hands it the
+    # trace plus the identity it resolved. The stub keeps both so the assertions
+    # below read what the server passed, not what the trace happened to carry.
+    def _map(oss_trace, **kw):
+        fields = {
+            k: getattr(oss_trace, k, None)
+            for k in ("outcome_ref", "outcome_type", "task_input", "agent_id")
+        }
+        fields.update(kw)
+        return SimpleNamespace(**fields)
+
+    monkeypatch.setattr(
+        http_server, "_pro_immutable_from_oss_trace", _map, raising=False
+    )
+    monkeypatch.setattr(
+        http_server, "_pro_finalize_spans", lambda imm: imm, raising=False
+    )
     monkeypatch.setattr(
         http_server, "seal", lambda imm, *a, **kw: imm, raising=False
     )

--- a/tests/unit/test_session_metadata_extras.py
+++ b/tests/unit/test_session_metadata_extras.py
@@ -1,0 +1,327 @@
+"""Session attributes and LLM calls: the two things a trace cannot know unless
+the SDK is told.
+
+A run's cost and token counts exist only if the agent's LLM calls are recorded;
+its dimensions (customer, task type) only if the developer passes them. Both
+travel in ``DecisionTrace.session_metadata`` under ``attributes`` / ``llm_calls``,
+which the server lifts into the sealed trace. These tests pin that contract for
+the Python SDK: what ``set_session_attributes`` / ``record_llm_call`` /
+``commit_outcome(attributes=..., llm_calls=...)`` accept, the exact shape they
+write, that the shape survives the HTTP adapter's ``model_dump``, and that the
+buffers reset once a trace is built.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from amfs import AgentMemory
+from amfs.memory import (
+    SESSION_ATTRIBUTES_KEY,
+    SESSION_LLM_CALLS_KEY,
+    validate_session_attributes,
+)
+from amfs_core.models import DecisionTrace, OutcomeType, SessionMetadata
+from amfs_filesystem.adapter import FilesystemAdapter
+
+
+@pytest.fixture
+def mem(tmp_path) -> AgentMemory:
+    return AgentMemory(agent_id="deploy-agent", adapter=FilesystemAdapter(tmp_path / "amfs"))
+
+
+# ---------------------------------------------------------------------------
+# SessionMetadata keeps extras
+# ---------------------------------------------------------------------------
+
+
+def test_session_metadata_keeps_and_serialises_extra_keys() -> None:
+    meta = SessionMetadata(model="gpt-4o", attributes={"customer": "acme"}, spans=[{"a": 1}])
+    dumped = meta.model_dump(mode="json")
+    assert dumped["attributes"] == {"customer": "acme"}
+    assert dumped["spans"] == [{"a": 1}]
+
+    # Through the trace too — this is the HTTP adapter's wire form.
+    trace = DecisionTrace(agent_id="a", session_id="s", session_metadata=meta)
+    wire = trace.model_dump(mode="json")["session_metadata"]
+    assert wire["attributes"] == {"customer": "acme"}
+    assert wire["spans"] == [{"a": 1}]
+
+    # And back from a dict, which is how the server reads a posted body.
+    again = DecisionTrace.model_validate(
+        {"agent_id": "a", "session_id": "s", "session_metadata": wire}
+    )
+    assert again.session_metadata is not None
+    assert again.session_metadata.model_dump()["attributes"] == {"customer": "acme"}
+
+
+# ---------------------------------------------------------------------------
+# validate_session_attributes
+# ---------------------------------------------------------------------------
+
+
+def test_validate_attributes_accepts_scalars_and_lowercases_keys() -> None:
+    out = validate_session_attributes({" Customer ": "acme", "retries": 3, "ok": True, "p": 0.5})
+    assert out == {"customer": "acme", "retries": 3, "ok": True, "p": 0.5}
+
+
+@pytest.mark.parametrize(
+    "bad, exc",
+    [
+        ({"customer": ["acme"]}, TypeError),
+        ({"customer": {"id": 1}}, TypeError),
+        ({"customer": None}, TypeError),
+        ({"": "x"}, ValueError),
+        ({"k" * 65: "x"}, ValueError),
+        ({"customer": "x" * 257}, ValueError),
+        ({f"k{i}": i for i in range(21)}, ValueError),
+        ({"nan": float("nan")}, ValueError),
+        ("not-a-dict", TypeError),
+    ],
+)
+def test_validate_attributes_rejects_bad_input(bad, exc) -> None:
+    with pytest.raises(exc):
+        validate_session_attributes(bad)
+
+
+def test_validate_attributes_none_is_empty() -> None:
+    assert validate_session_attributes(None) == {}
+
+
+# ---------------------------------------------------------------------------
+# set_session_attributes / record_llm_call
+# ---------------------------------------------------------------------------
+
+
+def test_set_session_attributes_merges_and_returns_bag(mem) -> None:
+    assert mem.set_session_attributes({"customer": "acme"}) == {"customer": "acme"}
+    bag = mem.set_session_attributes({"task_type": "deploy", "customer": "globex"})
+    assert bag == {"customer": "globex", "task_type": "deploy"}
+    assert mem.session_attributes == bag
+
+
+def test_set_session_attributes_raises_and_leaves_bag_untouched(mem) -> None:
+    mem.set_session_attributes({"customer": "acme"})
+    with pytest.raises(TypeError):
+        mem.set_session_attributes({"bad": object()})
+    assert mem.session_attributes == {"customer": "acme"}
+
+
+def test_record_llm_call_writes_the_llm_call_shape(mem) -> None:
+    rec = mem.record_llm_call(
+        "gpt-4o", 120, 30, cost_usd=0.0006, latency_ms=412.5, provider="openai", call_id="c1",
+    )
+    assert rec == {
+        "call_id": "c1",
+        "model": "gpt-4o",
+        "provider": "openai",
+        "input_tokens": 120,
+        "output_tokens": 30,
+        "cost_usd": 0.0006,
+        "latency_ms": 412.5,
+        "started_at": rec["started_at"],
+    }
+    assert isinstance(rec["started_at"], str) and rec["started_at"].endswith("+00:00")
+    assert mem.session_llm_calls == [rec]
+
+
+def test_record_llm_call_defaults(mem) -> None:
+    rec = mem.record_llm_call("claude-3.5-sonnet", 10, 5)
+    assert rec["provider"] == ""
+    assert rec["cost_usd"] is None
+    assert rec["latency_ms"] is None
+    assert rec["call_id"]  # generated
+
+
+@pytest.mark.parametrize(
+    "kwargs, exc",
+    [
+        (dict(model="", input_tokens=1, output_tokens=1), ValueError),
+        (dict(model="m", input_tokens="x", output_tokens=1), TypeError),
+        (dict(model="m", input_tokens=-1, output_tokens=1), ValueError),
+        (dict(model="m", input_tokens=1, output_tokens=1, cost_usd=-0.1), ValueError),
+        (dict(model="m", input_tokens=1, output_tokens=1, latency_ms="fast"), ValueError),
+    ],
+)
+def test_record_llm_call_validates(mem, kwargs, exc) -> None:
+    with pytest.raises(exc):
+        mem.record_llm_call(**kwargs)
+    assert mem.session_llm_calls == []
+
+
+# ---------------------------------------------------------------------------
+# commit_outcome merges everything into session_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_commit_outcome_merges_attributes_and_llm_calls_into_session_metadata(mem) -> None:
+    mem.session_metadata = SessionMetadata(model="claude-4-opus")
+    mem.set_session_attributes({"customer": "acme", "task_type": "deploy"})
+    mem.record_llm_call("gpt-4o", 100, 20, cost_usd=0.001, provider="openai")
+
+    mem.commit_outcome(
+        "deploy-42",
+        OutcomeType.SUCCESS,
+        attributes={"task_type": "rollback", "region": "eu"},
+        llm_calls=[{"model": "gpt-4o-mini", "input_tokens": 5, "output_tokens": 2}],
+    )
+
+    trace = mem._last_trace
+    meta = trace.session_metadata
+    assert isinstance(meta, SessionMetadata)
+    assert meta.model == "claude-4-opus"  # base fields kept
+    dumped = meta.model_dump(mode="json")
+    # commit_outcome(attributes=) wins over set_session_attributes.
+    assert dumped[SESSION_ATTRIBUTES_KEY] == {
+        "customer": "acme", "task_type": "rollback", "region": "eu",
+    }
+    calls = dumped[SESSION_LLM_CALLS_KEY]
+    assert [c["model"] for c in calls] == ["gpt-4o", "gpt-4o-mini"]
+    # The explicit call was normalised into the same shape as the recorded one.
+    assert set(calls[1]) >= {
+        "call_id", "model", "provider", "input_tokens", "output_tokens",
+        "cost_usd", "latency_ms", "started_at",
+    }
+    assert calls[1]["provider"] == ""
+
+    # Session timing is on the trace regardless of adapter.
+    assert trace.session_started_at is not None
+    assert trace.session_ended_at is not None
+    assert trace.session_duration_ms is not None and trace.session_duration_ms >= 0
+
+    # Buffers reset for the next window.
+    assert mem.session_attributes == {}
+    assert mem.session_llm_calls == []
+    # ... but the session's own metadata instance was not mutated.
+    assert "attributes" not in mem.session_metadata.model_dump()
+
+
+def test_commit_outcome_with_nothing_extra_leaves_metadata_none(mem) -> None:
+    mem.commit_outcome("t-1", OutcomeType.SUCCESS)
+    assert mem._last_trace.session_metadata is None
+
+
+def test_commit_outcome_preserves_extras_already_on_the_metadata(mem) -> None:
+    """A Pro recorder puts its span tree on the metadata as an extra key; the
+    merge must carry it, and merge into — not replace — an attribute bag it set."""
+    meta = SessionMetadata()
+    meta.spans = [{"span_id": "s1", "name": "root", "kind": "session"}]
+    meta.attributes = {"agent_kind": "deploy"}
+    mem.session_metadata = meta
+    mem.set_session_attributes({"customer": "acme"})
+
+    mem.commit_outcome("t-2", OutcomeType.SUCCESS)
+
+    dumped = mem._last_trace.session_metadata.model_dump(mode="json")
+    assert dumped["spans"] == [{"span_id": "s1", "name": "root", "kind": "session"}]
+    assert dumped["attributes"] == {"agent_kind": "deploy", "customer": "acme"}
+
+
+def test_commit_outcome_rejects_bad_attributes_before_writing(mem) -> None:
+    with pytest.raises(TypeError):
+        mem.commit_outcome("t-3", OutcomeType.SUCCESS, attributes={"x": object()})
+    assert getattr(mem, "_last_trace", None) is None
+
+
+def test_commit_outcome_skips_unusable_explicit_llm_calls(mem) -> None:
+    mem.commit_outcome(
+        "t-4", OutcomeType.SUCCESS,
+        llm_calls=["nope", {"foo": "bar"}, {"model": "m", "input_tokens": "x"}],
+    )
+    assert mem._last_trace.session_metadata is None
+
+
+def test_the_shape_survives_the_http_adapters_wire_form(mem) -> None:
+    """``HttpAdapter.save_trace`` posts ``trace.model_dump(mode="json")``; the
+    extras must be in it — a subclass instance would have lost them here."""
+    mem.set_session_attributes({"customer": "acme"})
+    mem.record_llm_call("gpt-4o", 1, 1, provider="openai")
+    mem.commit_outcome("t-5", OutcomeType.SUCCESS)
+
+    wire = mem._last_trace.model_dump(mode="json")
+    assert wire["session_metadata"]["attributes"] == {"customer": "acme"}
+    assert wire["session_metadata"]["llm_calls"][0]["model"] == "gpt-4o"
+    assert wire["session_started_at"] and wire["session_ended_at"]
+    assert wire["session_duration_ms"] is not None
+
+
+# ---------------------------------------------------------------------------
+# The HTTP server relays a remote client's session_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_outcomes_endpoint_passes_client_session_metadata_to_commit_outcome() -> None:
+    """The TypeScript SDK commits through ``POST /api/v1/outcomes``; the trace is
+    built server-side from the shared handle, so the client's attributes and
+    LLM calls only reach it if the endpoint hands them to ``commit_outcome``."""
+    from amfs_http import server as http_server
+    from amfs_http.models import OutcomeRequest
+
+    seen: dict[str, object] = {}
+
+    def _commit(outcome_ref, otype, **kwargs):
+        seen.update(kwargs, outcome_ref=outcome_ref)
+        return []
+
+    mem = SimpleNamespace(
+        commit_outcome=_commit,
+        _tagger=SimpleNamespace(agent_id="server"),
+        _adapter=SimpleNamespace(ensure_agent=lambda *a, **k: None),
+        namespace="default",
+        _last_trace=None,
+    )
+    originals = (
+        http_server._get_memory, http_server._link_agent_owner_once,
+        http_server._audit_log, http_server._auto_seal_trace,
+    )
+    http_server._get_memory = lambda: mem  # type: ignore[assignment]
+    http_server._link_agent_owner_once = lambda *a, **k: None  # type: ignore[assignment]
+    http_server._audit_log = lambda *a, **k: None  # type: ignore[assignment]
+    http_server._auto_seal_trace = lambda *a, **k: None  # type: ignore[assignment]
+    try:
+        req = OutcomeRequest(
+            outcome_ref="ts-1",
+            outcome_type="success",
+            agent_id="ts-agent",
+            session_metadata={
+                "attributes": {"Customer": "acme"},
+                "llm_calls": [{"model": "gpt-4o", "input_tokens": 3, "output_tokens": 1}],
+            },
+        )
+        request = SimpleNamespace(client=None)
+        asyncio.run(http_server.commit_outcome(req, request, None))
+    finally:
+        (
+            http_server._get_memory, http_server._link_agent_owner_once,
+            http_server._audit_log, http_server._auto_seal_trace,
+        ) = originals  # type: ignore[assignment]
+
+    assert seen["attributes"] == {"customer": "acme"}
+    assert seen["llm_calls"] == [{"model": "gpt-4o", "input_tokens": 3, "output_tokens": 1}]
+
+
+def test_outcomes_endpoint_rejects_bad_client_attributes_with_422() -> None:
+    from amfs_http import server as http_server
+    from amfs_http.models import OutcomeRequest
+    from fastapi import HTTPException
+
+    mem = SimpleNamespace(
+        commit_outcome=lambda *a, **k: pytest.fail("must not commit"),
+        _tagger=SimpleNamespace(agent_id="server"),
+        _adapter=SimpleNamespace(ensure_agent=lambda *a, **k: None),
+        namespace="default",
+    )
+    original = http_server._get_memory
+    http_server._get_memory = lambda: mem  # type: ignore[assignment]
+    try:
+        req = OutcomeRequest(
+            outcome_ref="ts-2", outcome_type="success",
+            session_metadata={"attributes": {"customer": ["acme"]}},
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(http_server.commit_outcome(req, SimpleNamespace(client=None), None))
+    finally:
+        http_server._get_memory = original  # type: ignore[assignment]
+    assert exc_info.value.status_code == 422

--- a/tests/unit/test_session_metadata_extras.py
+++ b/tests/unit/test_session_metadata_extras.py
@@ -14,6 +14,7 @@ buffers reset once a trace is built.
 from __future__ import annotations
 
 import asyncio
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -107,6 +108,20 @@ def test_set_session_attributes_raises_and_leaves_bag_untouched(mem) -> None:
     with pytest.raises(TypeError):
         mem.set_session_attributes({"bad": object()})
     assert mem.session_attributes == {"customer": "acme"}
+
+
+def test_set_session_attributes_caps_the_merged_bag_not_each_call(mem) -> None:
+    """Two batches of 15 are each under the cap; the bag they build is not."""
+    first = {f"a{i}": i for i in range(15)}
+    mem.set_session_attributes(first)
+    with pytest.raises(ValueError, match="at most 20"):
+        mem.set_session_attributes({f"b{i}": i for i in range(15)})
+    assert mem.session_attributes == first
+    # Re-setting keys already in the bag does not count towards the cap.
+    assert len(mem.set_session_attributes({"a0": 99, "a1": 98})) == 15
+    assert len(mem.set_session_attributes({f"c{i}": i for i in range(5)})) == 20
+    with pytest.raises(ValueError, match="at most 20"):
+        mem.set_session_attributes({"one_too_many": True})
 
 
 def test_record_llm_call_writes_the_llm_call_shape(mem) -> None:
@@ -225,6 +240,29 @@ def test_commit_outcome_rejects_bad_attributes_before_writing(mem) -> None:
     assert getattr(mem, "_last_trace", None) is None
 
 
+def test_commit_outcome_caps_the_bag_merged_from_all_three_sources(mem) -> None:
+    """Identity metadata, ``set_session_attributes`` and ``attributes=`` are each
+    within the cap; their union is not, and nothing may be written for it."""
+    meta = SessionMetadata()
+    meta.attributes = {f"m{i}": i for i in range(8)}
+    mem.session_metadata = meta
+    mem.set_session_attributes({f"s{i}": i for i in range(8)})
+    with pytest.raises(ValueError, match="at most 20"):
+        mem.commit_outcome(
+            "t-3b", OutcomeType.SUCCESS, attributes={f"c{i}": i for i in range(8)}
+        )
+    assert getattr(mem, "_last_trace", None) is None
+    assert mem._adapter.list_outcomes() == []
+    # The session bag survives a refused commit so the caller can trim and retry.
+    assert len(mem.session_attributes) == 8
+    # Overlapping keys collapse in the merge, so this one fits: 8 + 8 + 4 new.
+    mem.commit_outcome(
+        "t-3c", OutcomeType.SUCCESS,
+        attributes={**{f"s{i}": i for i in range(4)}, **{f"c{i}": i for i in range(4)}},
+    )
+    assert len(mem._last_trace.session_metadata.model_dump()["attributes"]) == 20
+
+
 def test_commit_outcome_skips_unusable_explicit_llm_calls(mem) -> None:
     mem.commit_outcome(
         "t-4", OutcomeType.SUCCESS,
@@ -245,6 +283,75 @@ def test_the_shape_survives_the_http_adapters_wire_form(mem) -> None:
     assert wire["session_metadata"]["llm_calls"][0]["model"] == "gpt-4o"
     assert wire["session_started_at"] and wire["session_ended_at"]
     assert wire["session_duration_ms"] is not None
+
+
+def _http_memory():
+    """An ``AgentMemory`` over an ``HttpAdapter`` whose transport records every
+    request body and answers with an empty 200."""
+    import httpx
+    from amfs_adapter_http.adapter import HttpAdapter
+
+    calls: list[dict[str, object]] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content) if request.content else None
+        calls.append({"method": request.method, "path": request.url.path, "body": body})
+        return httpx.Response(200, json={})
+
+    adapter = HttpAdapter.__new__(HttpAdapter)
+    adapter._base = "http://test"
+    adapter._api_key = "k"
+    adapter._client = httpx.Client(
+        base_url="http://test", headers={"X-AMFS-API-Key": "k"},
+        transport=httpx.MockTransport(_handler),
+    )
+    return AgentMemory(agent_id="deploy-agent", adapter=adapter), calls
+
+
+def test_http_commit_outcome_carries_session_metadata_on_the_outcome_request() -> None:
+    """The server seals its trace from ``POST /api/v1/outcomes`` and reads the
+    bag from that body. A bag that only travelled on the later ``/traces`` post
+    sealed a trace with no attributes and no token or cost figures."""
+    mem, calls = _http_memory()
+    mem.session_metadata = SessionMetadata(model="claude-4-opus")
+    mem.set_session_attributes({"customer": "acme"})
+    mem.record_llm_call("gpt-4o", 100, 20, cost_usd=0.001, provider="openai", call_id="c1")
+
+    mem.commit_outcome(
+        "deploy-42", OutcomeType.SUCCESS,
+        attributes={"task_type": "deploy"},
+        llm_calls=[{"model": "gpt-4o-mini", "input_tokens": 5, "output_tokens": 2}],
+    )
+
+    outcome_posts = [c for c in calls if c["path"] == "/api/v1/outcomes"]
+    assert len(outcome_posts) == 1
+    meta = outcome_posts[0]["body"]["session_metadata"]
+    assert meta["model"] == "claude-4-opus"
+    assert meta[SESSION_ATTRIBUTES_KEY] == {"customer": "acme", "task_type": "deploy"}
+    assert [c["model"] for c in meta[SESSION_LLM_CALLS_KEY]] == ["gpt-4o", "gpt-4o-mini"]
+    assert meta[SESSION_LLM_CALLS_KEY][0]["call_id"] == "c1"
+    assert meta[SESSION_LLM_CALLS_KEY][0]["cost_usd"] == 0.001
+    # The outcome went out before the trace, and the trace carries the same bag.
+    trace_posts = [c for c in calls if c["path"] == "/api/v1/traces"]
+    assert calls.index(outcome_posts[0]) < calls.index(trace_posts[0])
+    assert trace_posts[0]["body"]["session_metadata"][SESSION_ATTRIBUTES_KEY] == meta[
+        SESSION_ATTRIBUTES_KEY
+    ]
+
+
+def test_http_commit_outcome_omits_session_metadata_when_there_is_none() -> None:
+    mem, calls = _http_memory()
+    mem.commit_outcome("t-6", OutcomeType.SUCCESS)
+    (post,) = [c for c in calls if c["path"] == "/api/v1/outcomes"]
+    assert "session_metadata" not in post["body"]
+
+
+def test_http_commit_outcome_sends_nothing_when_the_merged_bag_is_over_the_cap() -> None:
+    mem, calls = _http_memory()
+    mem.set_session_attributes({f"s{i}": i for i in range(15)})
+    with pytest.raises(ValueError, match="at most 20"):
+        mem.commit_outcome("t-7", OutcomeType.SUCCESS, attributes={f"c{i}": i for i in range(15)})
+    assert [c for c in calls if c["method"] == "POST"] == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_trace_capture.py
+++ b/tests/unit/test_trace_capture.py
@@ -543,5 +543,8 @@ def test_the_postgres_read_queries_select_the_capture_columns() -> None:
 
     for fn in (pg.PostgresAdapter.get_trace, pg.PostgresAdapter.list_traces):
         source = inspect.getsource(fn)
+        if "_TRACE_COLUMNS" in source:
+            # The SELECT list lives in a shared class constant; check that instead.
+            source += pg.PostgresAdapter._TRACE_COLUMNS
         assert "task_input" in source, f"{fn.__name__} does not select task_input"
         assert "response_text" in source, f"{fn.__name__} does not select response_text"


### PR DESCRIPTION
Paired with **raia-live/amfs-internal#721**, which goes **first**. This one second, deliberately — reasoning in that PR.

## Recorded as a merge, not a squash

This is the one thing about this PR that needs reading before merging.

The previous promotion, #379, was squashed. That re-applied all of `dev`'s content as a single commit sharing no ancestry with the `dev` commits it came from, so git subsequently read `main` as having independently changed every one of those files. Merging `main` back into `dev` today conflicted on **8 files** — `server.py`, `memory.py`, `models.py` and others — and every one of those conflicts was false.

So the sync-main-into-dev step this promotion was thought to need does not exist. `85a9ba5`, `main`'s only commit not in `dev`, has tree `6059f03a`, which is **byte-identical** to `b869864` already in `dev`'s history (#378, `sync/main-into-dev-2026-09-10`). `main` held a `dev` state and nothing more.

The commit here therefore takes `dev`'s tree wholesale and records both parents:

```
promotion tree: 7983282a749b4a63671639382da30e55337e755f
dev tree:       7983282a749b4a63671639382da30e55337e755f
parents:        85a9ba5 (main), 1104851 (dev)
git diff HEAD origin/dev  ->  empty
```

**Please merge this with a merge commit.** Squashing it would discard the `dev` parent and hand the same false-conflict problem to whoever promotes next. #370 was a real merge and caused none of this.

## What reaches PyPI and self-hosted users

The hosted product builds these packages from this git tree, so production gets them either way. Everything else installs from PyPI, and this promotion is what publishes:

| package | new version |
| --- | --- |
| `amfs-core` | 0.3.19 |
| `amfs` | 0.5.11 |
| `amfs-adapter-http` | 0.1.13 |
| `amfs-http-server` | 0.3.18 |
| `amfs-mcp-server` | 0.7.19 |
| `amfs-adapter-postgres` | 0.2.5 |

Four of those had been sitting at already-published versions with changed source (#390), so PyPI has been serving old code under current version numbers. `auto-publish.yml` fires on the `pyproject.toml` changes in this promotion.

## Notable contents

- #386 — the cross-account leak via `GET /api/v1/explain` and `POST /api/v1/outcomes`
- #389, #390 — the memory-gap report at `commit_outcome`, and its surfacing on the OSS stdio server
- the trigger column-list fix, which had cost 1,040 of 2,027 outcome-reinforced entries their embedding
- seal-once-per-outcome, read-tracker request scoping, system-row exclusions
- CI now runs on `dev` branches, and a `version-bump` job blocks the drift described above

## Testing

1149 unit tests pass on this exact commit. The single failure, `TestAgentIdDetection::test_explicit_env_var`, is environmental and pre-existing — the local Cursor-derived agent ID beats the env var on the machine this ran on, and it fails identically on the base commit. CI has been green on it throughout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches tenancy (account-scoped propagation, partition RLS), shared-server session isolation, and outcome/trace persistence paths that affect production metrics and sealed traces.
> 
> **Overview**
> **Promotion-scale release** that tightens CI, fixes several production data/tenancy bugs, and ships the **memory-gap report** plus **single-trace-per-outcome** behavior across SDK, HTTP server, and MCP.
> 
> **CI** now runs Python/TypeScript tests on **`dev`** as well as `main`, sets workflow-wide **`contents: read`**, and adds a PR **`version-bump`** job so changed package `src` cannot merge without a `pyproject.toml` version bump (aligned with `auto-publish.yml`). Package versions are bumped (`amfs-core` 0.3.19, `amfs` 0.5.11, adapters/http-server/mcp/postgres, etc.).
> 
> **Outcome & traces:** `OutcomeRecord.trace_follows` tells the server not to auto-seal or persist a server-assembled trace when the SDK will post its own; HTTP uses `read_tracker_scope` middleware so shared `ReadTracker` state is per-request. **`POST /api/v1/outcomes`** adds an optional **`memory_gap`** block (retrieve-aligned matching without `recall_count` bumps); HTTP adapter stores it for **`AgentMemory`** / MCP **`amfs_commit_outcome`**.
> 
> **Postgres:** Migration **007** rewrites `amfs_propagate_outcome` to **copy the full row** (fixes silent resets of `recall_count`, `shared`, `tier`, `embedding`, etc.), scopes lookups with **`account_id IS NOT DISTINCT FROM`**, and keeps **`schema.sql` / adapter / migration** definitions in sync. **`sync_partition_rls`** copies parent RLS policies onto trace partitions (without `FORCE`, so maintenance still works). Stats/SQL aggregates exclude **benchmark/system** rows via shared **`amfs_core.exclusions`** rules (scoped path queries still include opted-in paths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdc683bdb6b5baffe746ca1cf452f2d1d4b72a37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->